### PR TITLE
Improve typing of actor properties in Item and ItemSheet

### DIFF
--- a/types/applications/forms/item.d.ts
+++ b/types/applications/forms/item.d.ts
@@ -35,7 +35,7 @@ declare class ItemSheet<T = object, O extends Item = Item, F = object> extends B
    * The Actor instance which owns this item. This may be null if the item is
    * unowned.
    */
-  get actor(): Actor;
+  get actor(): Actor<O, Actor.Data<any, Actor.OwnedItem<O>>> | null;
 
   /**
    * Activate listeners which provide interactivity for item sheet events

--- a/types/framework/entities/item.d.ts
+++ b/types/framework/entities/item.d.ts
@@ -84,7 +84,7 @@ declare class Item<D extends Item.Data = Item.Data<any>> extends Entity<D> {
   /**
    * A convenience reference to the Actor entity which owns this item, if any
    */
-  get actor(): Actor | null;
+  get actor(): Actor<this, Actor.Data<any, Actor.OwnedItem<this>>> | null;
 
   /**
    * A convenience reference to the image path (data.img) used to represent this Item


### PR DESCRIPTION
This slightly improves the types of the `actor` properties in `Item` and  `ItemSheet`. In particular, this also solves the issue with the actor property of `Item` circularly referencing itself somehow. The underlying issue was that the property was typed as `Actor` earlier, which was being mistaken as the namespace `Actor`. Fixes #217.