### PR TITLE
Remove issue assignee and replace type check action

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,7 +3,7 @@ name: Feature request
 about: Suggest an idea for this project beyond plain Foundry types
 title: ''
 labels: enhancement
-assignees: kmoschcau
+assignees:
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/wrong_type.md
+++ b/.github/ISSUE_TEMPLATE/wrong_type.md
@@ -3,7 +3,7 @@ name: Wrong Type
 about: Create a report to help us improve
 title: ''
 labels: bug
-assignees: kmoschcau
+assignees:
 
 ---
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,8 +15,8 @@ jobs:
           node-version: '14'
       - name: npm install
         run: npm install
-      - name: run typescript error reporter
-        uses: andoshin11/typescript-error-reporter-action@v1.0.2
+      - name: compile typescript
+        run: tsc
   lint:
     name: lint code base
     runs-on: ubuntu-latest


### PR DESCRIPTION
This removes kmoschcau as the default assignee from the issue templates
and replaces the broken type check action with just a plain tsc run.