### PR TITLE
Fix type definition of duplicate

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,7 @@ module.exports = {
   extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'plugin:prettier/recommended'],
   parser: '@typescript-eslint/parser',
   parserOptions: {
-    project: './tsconfig.eslint.json',
+    project: './tsconfig.json',
     sourceType: 'module'
   },
   plugins: ['@typescript-eslint', 'eslint-plugin-tsdoc'],

--- a/test-d/utils.test-d.ts
+++ b/test-d/utils.test-d.ts
@@ -1,0 +1,175 @@
+import '../index';
+import { expectType } from 'tsd';
+
+expectType<string>(duplicate(''));
+
+expectType<number | null>(duplicate(0));
+
+expectType<number>(duplicate<number, 'lenient'>(0));
+
+/* by explicitly specifying `'lenient'`, we tell the compiler to use number. It will accept it, even if at runtime there
+   are numbers which are converted to `null` */
+expectType<number>(duplicate<number, 'lenient'>(NaN));
+
+expectType<boolean>(duplicate(((): boolean => false)()));
+
+expectType<null>(duplicate(null));
+
+expectType<never>(duplicate(undefined));
+
+expectType<never>(duplicate(() => 0));
+
+expectType<never>(duplicate(Symbol('')));
+
+expectType<false>(duplicate(false));
+
+expectType<string | boolean>(duplicate(((): string | boolean => '')()));
+
+expectType<string | number | null>(duplicate(((): string | number => '')()));
+
+expectType<string | number>(duplicate<string | number, 'lenient'>(((): string | number => '')()));
+
+expectType<string | null>(duplicate(((): string | null => '')()));
+
+expectType<string>(duplicate(((): string | undefined => '')()));
+
+expectType<string>(duplicate(((): string | Function => '')()));
+
+expectType<string>(duplicate(((): string | symbol => '')()));
+
+expectType<Array<string>>(duplicate(['']));
+
+expectType<Array<number | null>>(duplicate([0]));
+
+expectType<Array<number>>(
+  duplicate<Array<number>, 'lenient'>([0])
+);
+
+expectType<Array<boolean>>(duplicate([false, true]));
+
+expectType<Array<null>>(duplicate([null]));
+
+expectType<Array<null>>(duplicate([undefined]));
+
+expectType<Array<null>>(duplicate([() => 0]));
+
+expectType<Array<null>>(duplicate([Symbol('')]));
+
+expectType<Array<false>>(duplicate([false]));
+
+expectType<Array<string | boolean>>(duplicate(['', false, true]));
+
+expectType<Array<string | number | null>>(duplicate(['', 0]));
+
+expectType<Array<string | number>>(
+  duplicate<Array<string | number>, 'lenient'>(['', 0])
+);
+
+expectType<Array<string | null>>(duplicate(['', null]));
+
+expectType<Array<string | null>>(duplicate(['', undefined]));
+
+expectType<Array<string | null>>(duplicate(['', () => 0]));
+
+expectType<Array<string | null>>(duplicate(['', Symbol('')]));
+
+expectType<Array<'a' | 'b'>>(duplicate([((): 'a' | 'b' => 'a')()]));
+
+expectType<Array<Array<boolean>>>(duplicate([[false, true]]));
+
+expectType<Array<{ a: string }>>(duplicate([{ a: '' }]));
+
+expectType<{ a: string }>(duplicate({ a: '' }));
+
+expectType<{ a: number | null }>(duplicate({ a: 0 }));
+
+expectType<{ a: number }>(
+  duplicate<{ a: number }, 'lenient'>({ a: 0 })
+);
+
+expectType<{ a: boolean }>(duplicate({ a: ((): boolean => false)() }));
+
+expectType<{ a: null }>(duplicate({ a: null }));
+
+expectType<{}>(duplicate({ a: undefined }));
+
+expectType<{}>(duplicate({ a: () => 0 }));
+
+expectType<{}>(duplicate({ a: Symbol('') }));
+
+expectType<{ a: string | boolean }>(duplicate({ a: ((): string | boolean => '')() }));
+
+expectType<{ a: string | number | null }>(duplicate({ a: ((): string | number => '')() }));
+
+expectType<{ a: string | number }>(
+  duplicate<{ a: string | number }, 'lenient'>({ a: ((): string | number => '')() })
+);
+
+expectType<{ a: string | null }>(duplicate({ a: ((): string | null => '')() }));
+
+expectType<{ a?: string }>(duplicate({ a: ((): string | undefined => '')() }));
+
+expectType<{ a?: string }>(duplicate({ a: ((): string | Function => '')() }));
+
+expectType<{ a?: string }>(duplicate({ a: ((): string | symbol => '')() }));
+
+expectType<{ a: Array<string> }>(duplicate({ a: [''] }));
+
+expectType<{ a: { b: string } }>(duplicate({ a: { b: '' } }));
+
+expectType<{ a: false }>(duplicate({ a: false }));
+
+expectType<{ a: 'a' | 'b' }>(duplicate({ a: ((): 'a' | 'b' => 'a')() }));
+
+expectType<string>(duplicate({ a: 0, b: '', c: false, toJSON: (): string => '' }));
+
+expectType<{ foo: string; bar: boolean }>(
+  duplicate({ a: 0, b: '', c: false, toJSON: () => ({ foo: '', bar: ((): boolean => false)() }) })
+);
+
+expectType<{ foo: string; bar: boolean }>(
+  duplicate({ a: 0, b: '', c: false, toJSON: () => ({ foo: '', bar: ((): boolean => false)(), toJSON: () => '' }) })
+);
+
+expectType<{ foo: string; bar: false }>(
+  duplicate({ a: 0, b: '', c: false, toJSON: () => ({ foo: '', bar: { baz: '', toJSON: () => false } }) })
+);
+
+const complexObject = {
+  a: '',
+  b: 0,
+  toJSON: () => [
+    false,
+    undefined,
+    {
+      c: undefined,
+      d: ((): boolean | symbol => false)(),
+      e: [true],
+      f: { g: 0, h: ((): number | undefined => 0)() }
+    }
+  ]
+};
+
+expectType<
+  Array<
+    | boolean
+    | null
+    | {
+        d?: boolean;
+        e: Array<boolean>;
+        f: { g: number | null; h?: number | null };
+      }
+  >
+>(duplicate(complexObject));
+
+expectType<
+  Array<
+    | boolean
+    | null
+    | {
+        d?: boolean;
+        e: Array<boolean>;
+        f: { g: number; h?: number };
+      }
+  >
+>(duplicate<typeof complexObject, 'lenient'>(complexObject));

--- a/test-d/utils.test-d.ts
+++ b/test-d/utils.test-d.ts
@@ -173,3 +173,15 @@ expectType<
       }
   >
 >(duplicate<typeof complexObject, 'lenient'>(complexObject));
+
+type SomeItemData = Item.Data<{}>;
+class SomeItem extends Item<SomeItemData> {}
+const someItem = new SomeItem();
+const someItemData = duplicate<SomeItem, 'lenient'>(someItem);
+SomeItem.create<SomeItem>(someItemData);
+
+type SomeActorData = Actor.Data<{}, SomeItemData>;
+class SomeActor extends Actor<SomeActorData, SomeItem> {}
+const someActor = new SomeActor();
+const someActorData = duplicate<SomeActor, 'lenient'>(someActor);
+SomeActor.create<SomeActor>(someActorData);

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,4 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "include": ["index.d.ts", "test-d"]
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,5 +6,5 @@
     "strict": true,
     "target": "ES2017"
   },
-  "include": ["index.d.ts"]
+  "include": ["index.d.ts", "test-d"]
 }

--- a/types/typesUtils.d.ts
+++ b/types/typesUtils.d.ts
@@ -5,3 +5,50 @@
 declare type DeepPartial<T> = {
   [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P];
 };
+
+/**
+ * Omit properties of `T` which are of type `U`.
+ *
+ * @typeParam T - Object type from which properties will be omitted.
+ * @typeParam U - Properties of this type will be omitted.
+ * @internal
+ */
+type OmitOfType<T extends object, U> = { [k in keyof T as T[k] extends U ? never : k]: T[k] };
+
+/**
+ * If T extends `U`, the resulting type is `R`, otherwise it is `T`.
+ *
+ * @typeParam T - Original type.
+ * @typeParam U - Only convert types of this type.
+ * @typeParam R - Adjust to this type.
+ * @internal
+ */
+type TypeToType<T, U, R> = T extends U ? R : T;
+
+/**
+ * Map the types of properties of `T` to `R` if they are of type `U`.
+ *
+ * @typeParam T - Object type that will have its properties' types adjusted.
+ * @typeParam U - Adjust the types of properties of this type.
+ * @typeParam R - Type that properties' types will be adjusted to.
+ * @internal
+ */
+type MapTypeToType<T, U, R> = { [k in keyof T]: TypeToType<T[k], U, R> };
+
+/**
+ * Omit properties of `T` which are assignable from `U`.
+ *
+ * @typeParam T - Object type that will have its properties omitted.
+ * @typeParam U - Properties with types that are assignable from this type will be omitted.
+ * @internal
+ */
+type OmitAssignableFromType<T extends object, U> = { [k in keyof T as U extends T[k] ? never : k]: T[k] };
+
+/**
+ * Omit properties of `T` which are not assignable from `U`.
+ *
+ * @typeParam T - Object type that will have its properties omitted.
+ * @typeParam U - Properties with types that are not assignable from this type will be omitted.
+ * @internal
+ */
+type OmitNotAssignableFromType<T extends object, U> = { [k in keyof T as U extends T[k] ? k : never]: T[k] };

--- a/types/utils.d.ts
+++ b/types/utils.d.ts
@@ -62,8 +62,82 @@ declare function getParentClasses(cls: new (...args: any[]) => any): Array<new (
 /**
  * A cheap data duplication trick, surprisingly relatively performant
  * @param original - Some sort of data
+ * @typeParam T - Type of the original data.
+ * @typeParam S - A flag to indicate whether or not to handle conversion of `NaN`, `Infinity`, and `-Infinity` to `null`
+ *                strictly. If set to `'strict'`, `number` will be converted to `number | null`, if set to `'lenient'`,
+ *                `number` will simply stay `number`.
+ *                (default: `'strict'`)
  */
-declare function duplicate<T>(original: T): T;
+declare function duplicate<T, S extends 'strict' | 'lenient' = 'strict'>(original: T): Duplicated<T, S>;
+
+/**
+ * Internal Helper for {@link Duplicated}. A union type of all primitive types that do not have a JSON representation.
+ *
+ * @internal
+ */
+type NonStringifiable = undefined | Function | symbol;
+
+/**
+ * Internal helper for {@link InnerDuplicated}. Maps the properties of `T` to their duplicated types.
+ *
+ * @typeParam T - The object type that should have its properties mapped.
+ * @typeParam S - A flag to indicate whether or not to handle conversion of `NaN`, `Infinity`, and `-Infinity` to `null`
+ *                strictly. If set to `'strict'`, `number` will be converted to `number | null`, if set to `'lenient'`,
+ *                `number` will simply stay `number`.
+ *                (default: `'strict'`)
+ * @internal
+ */
+type MapToInnerDuplicated<T extends object, S extends 'strict' | 'lenient' = 'strict'> = {
+  [k in keyof T]: InnerDuplicated<T[k], S>;
+};
+
+/**
+ * Internal helper type for {@link Duplicated}. It is the main part of the implementation, which does the recursion.
+ *
+ * @typeParam T - Type currently being converted.
+ * @typeParam S - A flag to indicate whether or not to handle conversion of `NaN`, `Infinity`, and `-Infinity` to `null`
+ *                strictly. If set to `'strict'`, `number` will be converted to `number | null`, if set to `'lenient'`,
+ *                `number` will simply stay `number`.
+ *                (default: `'strict'`)
+ * @internal
+ */
+type InnerDuplicated<T, S extends 'strict' | 'lenient' = 'strict'> = T extends { toJSON(): infer U }
+  ? U extends Array<unknown>
+    ? InnerDuplicated<U, S>
+    : U extends object
+    ? InnerDuplicated<Omit<U, 'toJSON'>, S>
+    : InnerDuplicated<U, S>
+  : T extends NonStringifiable
+  ? undefined
+  : T extends number
+  ? S extends 'strict'
+    ? number | null
+    : number
+  : T extends Array<unknown>
+  ? MapToInnerDuplicated<MapTypeToType<T, NonStringifiable, null>, S>
+  : T extends object
+  ? MapToInnerDuplicated<
+      OmitAssignableFromType<MapTypeToType<T, NonStringifiable, undefined>, undefined> &
+        Partial<
+          OmitOfType<OmitNotAssignableFromType<MapTypeToType<T, NonStringifiable, undefined>, undefined>, undefined>
+        >,
+      S
+    >
+  : T;
+
+/**
+ * The resulting type when using {@link duplicate} on some data of type `T`.
+ *
+ * @typeParam T - Original type.
+ * @typeParam S - A flag to indicate whether or not to handle conversion of `NaN`, `Infinity`, and `-Infinity` to `null`
+ *                strictly. If set to `'strict'`, `number` will be converted to `number | null`, if set to `'lenient'`,
+ *                `number` will simply stay `number`.
+ *                (default: `'strict'`)
+ * @internal
+ */
+type Duplicated<T, S extends 'strict' | 'lenient' = 'strict'> = T extends NonStringifiable
+  ? never
+  : InnerDuplicated<T, S>;
 
 /* -------------------------------------------- */
 

--- a/types/utils.d.ts
+++ b/types/utils.d.ts
@@ -101,29 +101,27 @@ type MapToInnerDuplicated<T extends object, S extends 'strict' | 'lenient' = 'st
  *                (default: `'strict'`)
  * @internal
  */
+// prettier-ignore
 type InnerDuplicated<T, S extends 'strict' | 'lenient' = 'strict'> = T extends { toJSON(): infer U }
   ? U extends Array<unknown>
     ? InnerDuplicated<U, S>
     : U extends object
-    ? InnerDuplicated<Omit<U, 'toJSON'>, S>
-    : InnerDuplicated<U, S>
+      ? InnerDuplicated<Omit<U, 'toJSON'>, S>
+      : InnerDuplicated<U, S>
   : T extends NonStringifiable
-  ? undefined
-  : T extends number
-  ? S extends 'strict'
-    ? number | null
-    : number
-  : T extends Array<unknown>
-  ? MapToInnerDuplicated<MapTypeToType<T, NonStringifiable, null>, S>
-  : T extends object
-  ? MapToInnerDuplicated<
-      OmitAssignableFromType<MapTypeToType<T, NonStringifiable, undefined>, undefined> &
-        Partial<
-          OmitOfType<OmitNotAssignableFromType<MapTypeToType<T, NonStringifiable, undefined>, undefined>, undefined>
-        >,
-      S
-    >
-  : T;
+    ? undefined
+    : T extends number
+      ? S extends 'strict'
+        ? number | null
+        : number
+      : T extends Array<unknown>
+        ? MapToInnerDuplicated<MapTypeToType<T, NonStringifiable, null>, S>
+        : T extends object
+          ? MapToInnerDuplicated<
+            OmitAssignableFromType<MapTypeToType<T, NonStringifiable, undefined>, undefined> &
+              Partial<OmitOfType<OmitNotAssignableFromType<MapTypeToType<T, NonStringifiable, undefined>, undefined>, undefined>>,
+            S>
+          : T;
 
 /**
  * The resulting type when using {@link duplicate} on some data of type `T`.


### PR DESCRIPTION
This fixes the type definition of `duplicate`.

For convenience, you can provide `lenient` as generic parameter so that it does not convert `number` to `number | null`, which it does by default because `duplicate` turns `NaN`, `Infinity`, and `-Infinity` into `null`. So in theory, using `number | null` is actually the correct thing. However, often one knows that the fields contain actual numbers. Unfortunately, the type system cannot represent this, so in order to improve usability, this option to be lenient in this regard is available.

This introduces quite a lot of internal utility types. It might make sense to put them in other locations or in namespaces. Please feel free to give feedback regarding this topic.

This also adds the `test-d` directory to the `incldue` of `tsconfig.json` because that way, the same settings are used for both the type definitions and the tests (which improves editor integration, which was the main reason). If there are any objections to this, we can think of alternative solutions.

Fixes #242