### PR TITLE
Improve type definitions of ActiveEffect

### DIFF
--- a/test-d/framework/entities/activeEffect.test-d.ts
+++ b/test-d/framework/entities/activeEffect.test-d.ts
@@ -1,0 +1,18 @@
+import '../../../index';
+import { expectType } from 'tsd';
+
+type SomeItemData = Item.Data<{}>;
+class SomeItem extends Item<SomeItemData> {}
+const someItem = new SomeItem();
+
+type SomeActorData = Actor.Data<{}, SomeItemData>;
+class SomeActor extends Actor<SomeActorData, SomeItem> {}
+const someActor = new SomeActor();
+
+const actorEffect = ActiveEffect.create<SomeActor>({}, someActor);
+expectType<SomeActor>(actorEffect.parent);
+expectType<SomeActor | undefined>(actorEffect.parent.effects.find(() => true)?.parent);
+
+const itemEffect = ActiveEffect.create<SomeItem>({}, someItem);
+expectType<SomeItem>(itemEffect.parent);
+expectType<SomeItem | undefined>(itemEffect.parent.effects.find(() => true)?.parent);

--- a/types/framework/entities/activeEffect.d.ts
+++ b/types/framework/entities/activeEffect.d.ts
@@ -279,3 +279,7 @@ declare namespace ActiveEffect {
     transfer?: boolean;
   }
 }
+
+type ActiveEffectChange = ActiveEffect.Change;
+type ActiveEffectDuration = ActiveEffect.Duration;
+type ActiveEffectData = ActiveEffect.Data;

--- a/types/framework/entities/activeEffect.d.ts
+++ b/types/framework/entities/activeEffect.d.ts
@@ -1,14 +1,16 @@
 /**
  * An Active Effect instance within a parent Actor or Item.
- * @see {@link Actor#effects}
- * @see {@link Item#effects}
+ * @see {@link Actor.effects}
+ * @see {@link Item.effects}
+ *
+ * @typeParam P - Type of the parent of the `ActiveEffect`.
  */
-declare class ActiveEffect extends EmbeddedEntity<ActiveEffect.Data> {
+declare class ActiveEffect<P extends Actor | Item = Actor | Item> extends EmbeddedEntity<ActiveEffect.Data, P> {
   /**
    * @param data   - Data for the Active Effect
    * @param parent - The parent Entity which owns the effect
    */
-  constructor(data: ActiveEffect.Data, parent: Actor | Item);
+  constructor(data: DeepPartial<ActiveEffect.Data>, parent: P);
 
   /**
    * A cached reference to the source name to avoid recurring database lookups
@@ -131,7 +133,7 @@ declare class ActiveEffect extends EmbeddedEntity<ActiveEffect.Data> {
    * @param options - Configuration options which modify the request.
    * @returns The updated ActiveEffect data.
    */
-  update(data: Partial<ActiveEffect.Data>, options?: Entity.UpdateOptions): Promise<ActiveEffect.Data>;
+  update(data: DeepPartial<ActiveEffect.Data>, options?: Entity.UpdateOptions): Promise<ActiveEffect.Data>;
 
   /* -------------------------------------------- */
 
@@ -152,15 +154,19 @@ declare class ActiveEffect extends EmbeddedEntity<ActiveEffect.Data> {
    * @param args - Initialization arguments passed to the ActiveEffect constructor.
    * @returns The constructed ActiveEffect instance.
    */
-  static create(...args: [ActiveEffect.Data, Actor | Item]): ActiveEffect;
+  static create<P extends Actor | Item = Actor | Item>(...args: [DeepPartial<ActiveEffect.Data>, P]): ActiveEffect<P>;
 
   /* -------------------------------------------- */
 
   /**
    * A helper function to handle obtaining dropped ActiveEffect data from a dropped data transfer event.
+   *
+   * Warning: This is currently buggy and will create an `ActiveEffect` with `parent` set to `undefined`.
+   *
    * @param data - The data object extracted from a DataTransfer event
    * @returns The ActiveEffect instance which contains the dropped effect data or null, if other data was dropped.
    */
+  static fromDropData<T extends { data: DeepPartial<ActiveEffect.Data> }>(data: T): Promise<ActiveEffect>;
   static fromDropData(data: Record<string, unknown>): Promise<ActiveEffect | null>;
 }
 

--- a/types/framework/entities/actor.d.ts
+++ b/types/framework/entities/actor.d.ts
@@ -127,7 +127,7 @@ declare class Actor<
   /**
    * ActiveEffects are prepared by the Actor.prepareEmbeddedEntities() method
    */
-  effects: Collection<ActiveEffect>;
+  effects: Collection<ActiveEffect<this>>;
 
   /**
    * A set that tracks which keys in the data model were modified by active effects
@@ -167,7 +167,7 @@ declare class Actor<
    * An array of ActiveEffect instances which are present on the Actor which have a limited duration.
    * @returns
    */
-  get temporaryEffects(): ActiveEffect[];
+  get temporaryEffects(): ActiveEffect<this>[];
 
   /* -------------------------------------------- */
   /*  Data Preparation                            */
@@ -205,7 +205,7 @@ declare class Actor<
    * @param effects - The raw array of active effect objects
    * @returns The prepared active effects collection
    */
-  protected _prepareActiveEffects(effects: ActiveEffect.Data[]): Collection<ActiveEffect>;
+  protected _prepareActiveEffects(effects: ActiveEffect.Data[]): Collection<ActiveEffect<this>>;
 
   /**
    * Apply any transformations to the Actor data which are caused by ActiveEffects.
@@ -392,14 +392,11 @@ declare class Actor<
    * @param options  - Item update options
    * @returns A Promise resolving to the updated Owned Item data
    */
-  updateOwnedItem(
-    itemData: DeepPartial<Actor.OwnedItemData<D>>,
-    options?: any
-  ): Promise<ActiveEffect | Actor.OwnedItemData<D>>;
+  updateOwnedItem(itemData: DeepPartial<Actor.OwnedItemData<D>>, options?: any): Promise<Actor.OwnedItemData<D>>;
   updateOwnedItem(
     itemData: DeepPartial<Actor.OwnedItemData<D>>[],
     options?: any
-  ): Promise<Array<ActiveEffect | Actor.OwnedItemData<D>>>;
+  ): Promise<Array<Actor.OwnedItemData<D>>>;
 
   /* -------------------------------------------- */
 
@@ -411,8 +408,8 @@ declare class Actor<
    * @param options - Item deletion options
    * @returns A Promise resolving to the deleted Owned Item data
    */
-  deleteOwnedItem(itemId: string, options?: any): Promise<ActiveEffect | Actor.OwnedItemData<D>>;
-  deleteOwnedItem(itemId: string[], options?: any): Promise<Array<ActiveEffect | Actor.OwnedItemData<D>>>;
+  deleteOwnedItem(itemId: string, options?: any): Promise<Actor.OwnedItemData<D>>;
+  deleteOwnedItem(itemId: string[], options?: any): Promise<Array<Actor.OwnedItemData<D>>>;
 
   /* -------------------------------------------- */
   /*  DEPRECATED                                  */

--- a/types/framework/entities/actor.d.ts
+++ b/types/framework/entities/actor.d.ts
@@ -392,10 +392,13 @@ declare class Actor<
    * @param options  - Item update options
    * @returns A Promise resolving to the updated Owned Item data
    */
-  updateOwnedItem(itemData: DeepPartial<Actor.OwnedItemData<D>>, options?: any): Promise<Actor.OwnedItemData<D>>;
+  updateOwnedItem(
+    itemData: DeepPartial<Actor.OwnedItemData<D>>,
+    options?: Entity.UpdateOptions
+  ): Promise<Actor.OwnedItemData<D>>;
   updateOwnedItem(
     itemData: DeepPartial<Actor.OwnedItemData<D>>[],
-    options?: any
+    options?: Entity.UpdateOptions
   ): Promise<Array<Actor.OwnedItemData<D>>>;
 
   /* -------------------------------------------- */
@@ -408,8 +411,8 @@ declare class Actor<
    * @param options - Item deletion options
    * @returns A Promise resolving to the deleted Owned Item data
    */
-  deleteOwnedItem(itemId: string, options?: any): Promise<Actor.OwnedItemData<D>>;
-  deleteOwnedItem(itemId: string[], options?: any): Promise<Array<Actor.OwnedItemData<D>>>;
+  deleteOwnedItem(itemId: string, options?: Entity.DeleteOptions): Promise<Actor.OwnedItemData<D>>;
+  deleteOwnedItem(itemId: string[], options?: Entity.DeleteOptions): Promise<Array<Actor.OwnedItemData<D>>>;
 
   /* -------------------------------------------- */
   /*  DEPRECATED                                  */

--- a/types/framework/entities/embeddedEntity.d.ts
+++ b/types/framework/entities/embeddedEntity.d.ts
@@ -1,8 +1,10 @@
 /**
  * An abstract class implementation for an EmbeddedEntity object within a parent Entity
+ *
+ * @typeParam P - Type of the parent of the `EmbeddedEntity`.
  */
-declare abstract class EmbeddedEntity<D extends EmbeddedEntity.Data = EmbeddedEntity.Data> {
-  constructor(data: D, parent: Entity);
+declare abstract class EmbeddedEntity<D extends EmbeddedEntity.Data = EmbeddedEntity.Data, P extends Entity = Entity> {
+  constructor(data: D, parent: P);
 
   /**
    * The embedded entity data object
@@ -12,7 +14,7 @@ declare abstract class EmbeddedEntity<D extends EmbeddedEntity.Data = EmbeddedEn
   /**
    * The parent Entity to which this belongs
    */
-  parent: Entity;
+  parent: P;
 
   /* -------------------------------------------- */
 

--- a/types/framework/entities/item.d.ts
+++ b/types/framework/entities/item.d.ts
@@ -58,7 +58,7 @@ declare class Item<D extends Item.Data = Item.Data<any>> extends Entity<D> {
   /**
    * ActiveEffects are prepared by the Item.prepareEmbeddedEntities() method
    */
-  effects: Collection<ActiveEffect>;
+  effects: Collection<ActiveEffect<this>>;
 
   /** @override */
   static get config(): Entity.Config<Item>;
@@ -81,7 +81,7 @@ declare class Item<D extends Item.Data = Item.Data<any>> extends Entity<D> {
    * @param effects - The raw array of active effect objects
    * @returns The prepared active effects collection
    */
-  protected _prepareActiveEffects(effects: ActiveEffect.Data[]): Collection<ActiveEffect>;
+  protected _prepareActiveEffects(effects: ActiveEffect.Data[]): Collection<ActiveEffect<this>>;
 
   /**
    * Prepare a data object which defines the data schema used by dice roll commands against this Item
@@ -109,7 +109,7 @@ declare class Item<D extends Item.Data = Item.Data<any>> extends Entity<D> {
    * If the Item is owned, the returned instances are the ActiveEffect instances which exist on the owning Actor.
    * If the Item is unowned, the returned instances are the ActiveEffect instances which exist on the Item itself.
    */
-  get transferredEffects(): ActiveEffect[];
+  get transferredEffects(): ActiveEffect<Actor<Actor.Data<any, D>, this> | this>[];
 
   /**
    * A convenience reference to the item type (data.type) of this Item


### PR DESCRIPTION
This slightly improved the type definitions of `ActiveEffect`, mainly by making it generic in the parent.

Fixes #241