### PR TITLE
Fix Entity.prepareData

### DIFF
--- a/types/framework/entities/actor.d.ts
+++ b/types/framework/entities/actor.d.ts
@@ -178,7 +178,7 @@ declare class Actor<
    * Returns void
    * @override
    */
-  prepareData(): any;
+  prepareData(): void;
 
   /**
    * First prepare any derived data which is actor-specific and does not depend on Items or Active Effects

--- a/types/framework/entities/item.d.ts
+++ b/types/framework/entities/item.d.ts
@@ -71,7 +71,7 @@ declare class Item<D extends Item.Data = Item.Data<any>> extends Entity<D> {
    * Returns void
    * @override
    */
-  prepareData(): any;
+  prepareData(): void;
 
   /** @override */
   prepareEmbeddedEntities(): void;

--- a/types/framework/entity.d.ts
+++ b/types/framework/entity.d.ts
@@ -97,7 +97,7 @@ declare class Entity<D extends Entity.Data = Entity.Data> {
    * This method can be used to derive any internal attributes which are computed in a formulaic manner.
    * For example, in a d20 system - computing an ability modifier based on the value of that ability score.
    */
-  prepareData(): Entity.Data;
+  prepareData(): D | void;
 
   /**
    * Prepare Embedded Entities which exist within this parent Entity.


### PR DESCRIPTION
This also adjusts the return type of `Actor.prepareData` and `Item.prepareData` to `void`.

Fixes #244 