### PR TITLE
Adds FormDataExtended, expands a few types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -107,6 +107,7 @@ import './types/ui/activeeffectconfig';
 
 //-- --//
 
+import './types/formdataextended';
 import './types/game';
 import './types/handlebars';
 import './types/pixi';

--- a/types/core/hooks.d.ts
+++ b/types/core/hooks.d.ts
@@ -52,7 +52,14 @@ declare class Hooks {
    * @param hook	The unique name of the hooked event
    * @param fn	The function that should be removed from the set of hooked callbacks
    */
-  static off(hook: string, fn: Function): void;
+  static off(hook: string, fn: Function | number): void;
+  /**
+   * Unregister a callback handler for a particular hook event
+   *
+   * @param hook	The unique name of the hooked event
+   * @param hookId	The ID of the hook returned from a previous hook setup call.
+   */
+  static off(hook: string, hookId: number): void;
 
   /**
    * Call all hook listeners in the order in which they were registered

--- a/types/formdataextended.d.ts
+++ b/types/formdataextended.d.ts
@@ -1,0 +1,36 @@
+/**
+ * An extension of the native FormData implementation.
+ *
+ * This class functions the same way that the default FormData does, but it is more opinionated about how
+ * input fields of certain types should be evaluated and handled.
+ *
+ * It also adds support for certain Foundry VTT specific concepts including:
+ *  Support for defined data types and type conversion
+ *  Support for TinyMCE editors
+ *  Support for editable HTML elements
+ *
+ * @extends {FormData}
+ *
+ * @param {HTMLFormElement} form        The form being processed
+ * @param {object[]} [editors]          An array of TinyMCE editor instances which are present in this form
+ * @param {{string, string}} [dtypes]   A mapping of data types for form fields
+ */
+declare class FormDataExtended extends FormData {
+  constructor(form: HTMLFormElement, options?: { editors: object[]; dtypes: Record<string, string> });
+
+  /* -------------------------------------------- */
+
+  /**
+   * Process the HTML form element to populate the FormData instance.
+   * @param {HTMLFormElement} form      The HTML form
+   */
+  process(form: HTMLFormElement): void;
+
+  /* -------------------------------------------- */
+
+  /**
+   * Export the FormData as an object
+   * @return {object}
+   */
+  toObject(): any;
+}

--- a/types/framework/entities/actor.d.ts
+++ b/types/framework/entities/actor.d.ts
@@ -1,6 +1,9 @@
 declare interface ActorData<DataType = any> extends EntityData<DataType> {
   img: string;
   token: any;
+  items: ItemData[];
+  folder: string;
+  permission: Record<string, typeof CONST.ENTITY_PERMISSIONS[keyof typeof CONST.ENTITY_PERMISSIONS]>;
 }
 
 /**

--- a/types/framework/entities/folder.d.ts
+++ b/types/framework/entities/folder.d.ts
@@ -1,3 +1,5 @@
 declare class Folders extends Collection<Folder> {}
 
-declare class Folder extends Entity {}
+declare class Folder<EntityType = Entity> extends Entity {
+  get entities(): EntityType[];
+}

--- a/types/pixi/placeableobject.d.ts
+++ b/types/pixi/placeableobject.d.ts
@@ -163,7 +163,7 @@ declare class PlaceableObject extends PIXI.Container {
    * Clear the display of the existing object
    * @return	The cleared object
    */
-  clear(): PlaceableObject;
+  clear(): this;
 
   /**
    * Clone the placeable object, returning a new object with identical attributes
@@ -172,12 +172,12 @@ declare class PlaceableObject extends PIXI.Container {
    *
    * @return	A new object with identical data
    */
-  clone(): PlaceableObject;
+  clone(): this;
 
   /**
    * Draw the placeable object into its parent container
    */
-  draw(): Promise<PlaceableObject>;
+  draw(): Promise<this>;
 
   /**
    * Draw the primary Sprite for the PlaceableObject
@@ -188,16 +188,16 @@ declare class PlaceableObject extends PIXI.Container {
    * Refresh the current display state of the Placeable Object
    * @return	The refreshed object
    */
-  refresh(): PlaceableObject;
+  refresh(): this;
 
   /** @extends {Entity.createEmbeddedEntity} */
   static create(data: object, options?: object): Promise<PlaceableObject>;
 
   /** @extends {Entity.updateEmbeddedEntity} */
-  update(updateData: object, options?: object): Promise<PlaceableObject>;
+  update(updateData: object, options?: object): Promise<this>;
 
   /** @extends {Entity.deleteEmbeddedEntity} */
-  delete(createData: object, options?: object): Promise<PlaceableObject>;
+  delete(options?: object): Promise<this>;
 
   /**
    * Get the value of a "flag" for this PlaceableObject
@@ -228,7 +228,7 @@ declare class PlaceableObject extends PIXI.Container {
    *
    * @return		A Promise resolving to the updated PlaceableObject
    */
-  setFlag(scope: string, key: string, value: any): Promise<PlaceableObject>;
+  setFlag(scope: string, key: string, value: any): Promise<this>;
 
   /**
    * Remove a flag assigned to the Entity
@@ -236,7 +236,7 @@ declare class PlaceableObject extends PIXI.Container {
    * @param key	The flag key
    * @return		A Promise resolving to the updated Entity
    */
-  unsetFlag(scope: string, key: string): Promise<Entity>;
+  unsetFlag(scope: string, key: string): Promise<this>;
 
   /**
    * Register pending canvas operations which should occur after a new PlaceableObject of this type is created
@@ -289,7 +289,7 @@ declare class PlaceableObject extends PIXI.Container {
    * @param snap	Snap the angle of rotation to a certain target degree increment
    * @return		A Promise which resolves once the rotation has completed
    */
-  rotate(angle: number, snap: number): Promise<PlaceableObject>;
+  rotate(angle: number, snap: number): Promise<this>;
 
   /**
    * Determine a new angle of rotation for a PlaceableObject either from an explicit angle or from a delta offset.

--- a/types/pixi/placeables/token.d.ts
+++ b/types/pixi/placeables/token.d.ts
@@ -1,4 +1,8 @@
-// @TODO: Types
+declare interface TokenData<DataType = any> extends EntityData<DataType> {
+  img: string;
+  permission: Record<string, typeof CONST.ENTITY_PERMISSIONS[keyof typeof CONST.ENTITY_PERMISSIONS]>;
+  actorData: ActorData;
+}
 
 /**
  * An instance of the Token class represents an Actor within a viewed Scene on the game canvas.
@@ -174,9 +178,9 @@ declare class Token extends PlaceableObject {
   /* Rendering
 	/* -------------------------------------------- */
 
-  draw(): Promise<any>;
+  draw(): Promise<this>;
 
-  refresh(): PlaceableObject;
+  refresh(): this;
 
   protected _refreshBorder(): void;
 
@@ -207,4 +211,21 @@ declare class Token extends PlaceableObject {
    * @param texture The texture file-path of the effect icon to toggle on the Token.
    */
   toggleEffect(texture: string): Promise<void>;
+
+  /* -------------------------------------------- */
+  /*  Factory Functions
+	/* -------------------------------------------- */
+
+  /**
+   * A factory method to create a Token instance from an Actor entity.
+   * The Token is not automatically saved to the database, it is up to the caller whether or not they wish to do that.
+   *
+   * @param {Actor} actor         The input actor entity
+   * @param {object} [tokenData]  Additional data, such as x, y, rotation, etc. for the created token
+   * @return {Promise<Token>}     The created Token instance
+   */
+  static fromActor(actor: Actor, tokenData?: any): Promise<Token>;
+
+  /** @extends {Entity.createEmbeddedEntity} */
+  static create(data: object, options?: object): Promise<Token>;
 }


### PR DESCRIPTION
This change encompasses a bunch of small changes I made when converting foundryvtt-summoner over to use TS.

* Adds `FormDataExtended`
* Adds override for calling `Hooks.off` with numbers returned from `Hooks.on`.
* Adds a few more fields to `ActorData`.  The permissions looks funky.  Wasn't sure where to store a common type like that.
* Adds `Folder.entities`.
* Adds `Token.fromActor`.
* Adds `Token.create` override that returns a `Token` instead of a `PlaceableObject`
* Updates `Token` and `PlaceableObject` to use `this` in return values.

Hopefully this is helpful!  Glad to contribute.