### PR TITLE
Make it possible to dynamically add properties to a Game

### DIFF
--- a/types/game.d.ts
+++ b/types/game.d.ts
@@ -171,7 +171,7 @@ declare let ui: {
  * The core Game instance which encapsulates the data, settings, and states relevant for managing the game experience.
  * The singleton instance of the Game class is available as the global variable `game`.
  */
-declare class Game {
+declare class Game implements Record<string, unknown> {
   /**
    * @param view      - The named view which is active for this game instance.
    * @param data      - An object of all the World data vended by the server when the client first connects


### PR DESCRIPTION
This simply makes `Game` extends `Record<string, unknown>`, effectively making it possible to add properties to any instance of `Game` (such as `game`):
```ts
game.myCustomProp = 'some string';
```
Unfortunately this is not very helpful for retrieval of custom properties from a `Game` as it will always be typed as `unknown` but it at least covers the common use case of adding stuff to `game` in order to make it available to be used in macros. If we find a better solution that also covers retrieval, we can switch to that solution.

fixes #239