### PR TITLE
Small Dialog Fixes

### DIFF
--- a/types/applications/dialog.d.ts
+++ b/types/applications/dialog.d.ts
@@ -32,7 +32,7 @@ declare class Dialog extends Application {
    * @param data    - An object of dialog data which configures how the modal window is rendered
    * @param options - Dialog rendering options, see {@link Application}
    */
-  constructor(data: Dialog.Data, options: Partial<Dialog.Options>);
+  constructor(data: Dialog.Data, options?: Partial<Dialog.Options>);
 
   data: Dialog.Data;
 

--- a/types/applications/dialog.d.ts
+++ b/types/applications/dialog.d.ts
@@ -277,12 +277,12 @@ declare namespace Dialog {
     /**
      * A Font Awesome icon for the button
      */
-    icon: string;
+    icon?: string;
 
     /**
      * The label for the button
      */
-    label: string;
+    label?: string;
 
     /**
      * A callback function that fires when the button is clicked


### PR DESCRIPTION
- Make the `options` parameter in `Dialog`'s constructor optional
- Make `icon` and `label` optional in `Dialog.Button`. The JSDoc documents that differently but in the end, these string are just passed to handlebars which simply doesn't render them if you omit them.

Fixes #266
Fixes #267