### PR TITLE
Remove default assignee from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,7 +3,7 @@ name: Feature request
 about: Suggest an idea for this project beyond plain Foundry types
 title: ''
 labels: enhancement
-assignees: kmoschcau
+assignees:
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/wrong_type.md
+++ b/.github/ISSUE_TEMPLATE/wrong_type.md
@@ -3,7 +3,7 @@ name: Wrong Type
 about: Create a report to help us improve
 title: ''
 labels: bug
-assignees: kmoschcau
+assignees:
 
 ---
 


### PR DESCRIPTION
This change has already been done in foundry-0.7.9 but it's not effective because GitHub looks at the templates in the master branch (as it is the default branch)