### PR TITLE
Make MODIFIERS extendable for all dice terms

### DIFF
--- a/test-d/types/core/rolls/diceTerms/coin.test-d.ts
+++ b/test-d/types/core/rolls/diceTerms/coin.test-d.ts
@@ -1,0 +1,11 @@
+Coin.MODIFIERS.testModifier1 = function (this: DiceTerm) {
+  return;
+};
+
+Coin.MODIFIERS.testModifier2 = function (this: DiceTerm) {
+  return this;
+};
+
+Coin.MODIFIERS.testModifier3 = function (this: DiceTerm, modifier: string) {
+  return modifier.length > 0 ? undefined : this;
+};

--- a/test-d/types/core/rolls/diceTerms/die.test-d.ts
+++ b/test-d/types/core/rolls/diceTerms/die.test-d.ts
@@ -1,0 +1,11 @@
+Die.MODIFIERS.testModifier1 = function (this: DiceTerm) {
+  return;
+};
+
+Die.MODIFIERS.testModifier2 = function (this: DiceTerm) {
+  return this;
+};
+
+Die.MODIFIERS.testModifier3 = function (this: DiceTerm, modifier: string) {
+  return modifier.length > 0 ? undefined : this;
+};

--- a/test-d/types/core/rolls/diceTerms/fateDie.test-d.ts
+++ b/test-d/types/core/rolls/diceTerms/fateDie.test-d.ts
@@ -1,0 +1,11 @@
+FateDie.MODIFIERS.testModifier1 = function (this: DiceTerm) {
+  return;
+};
+
+FateDie.MODIFIERS.testModifier2 = function (this: DiceTerm) {
+  return this;
+};
+
+FateDie.MODIFIERS.testModifier3 = function (this: DiceTerm, modifier: string) {
+  return modifier.length > 0 ? undefined : this;
+};

--- a/types/core/rolls/diceTerms/coin.d.ts
+++ b/types/core/rolls/diceTerms/coin.d.ts
@@ -38,7 +38,7 @@ declare class Coin extends DiceTerm {
 
   static DENOMINATION: 'c';
 
-  static MODIFIERS: {
+  static MODIFIERS: typeof DiceTerm.MODIFIERS & {
     c: 'call';
   };
 

--- a/types/core/rolls/diceTerms/diceTerm.d.ts
+++ b/types/core/rolls/diceTerms/diceTerm.d.ts
@@ -292,7 +292,7 @@ declare abstract class DiceTerm {
   /**
    * Define the modifiers that can be used for this particular DiceTerm type.
    */
-  static MODIFIERS: Record<string, string | ((diceTerm: DiceTerm, m: string) => void)>;
+  static MODIFIERS: Partial<Record<string, string | ((this: DiceTerm, modifier: string) => void | DiceTerm)>>;
 
   /**
    * A regular expression pattern which identifies a potential DiceTerm modifier

--- a/types/core/rolls/diceTerms/die.d.ts
+++ b/types/core/rolls/diceTerms/die.d.ts
@@ -170,7 +170,7 @@ declare class Die extends DiceTerm {
   /**
    * @override
    */
-  static MODIFIERS: {
+  static MODIFIERS: typeof DiceTerm.MODIFIERS & {
     r: 'reroll';
     x: 'explode';
     xo: 'explodeOnce';


### PR DESCRIPTION
I tried to make it work to have the `MODIFIERS` of the subclasses accept functions that take their concrete type (e.g. `Die`) as this parameter instead of the generic `DiceTerm`. However, Typescript complained that the subclass is not properly extending `DiceTerm` then. I guess this should be good enough for most uses cases anyways.