### PR TITLE
Update FormApplication to be less opinionated about getData return type.

### DIFF
--- a/test-d/types/applications/forms/actorSheet.test-d.ts
+++ b/test-d/types/applications/forms/actorSheet.test-d.ts
@@ -5,11 +5,16 @@ type TestItemData = Item.Data<{ foo: string }>;
 class TestItem extends Item<TestItemData> {}
 
 type TestActorData = Actor.Data<{ bar: number }, TestItemData>;
-class TestActor extends Actor<TestActorData, TestItem> {}
+class TestActor extends Actor<TestActorData, TestItem> {
+  foo = 'bar';
+}
 const testActor = new TestActor();
 
 class TestActorSheet extends ActorSheet<ActorSheet.Data<TestActor>> {}
 const testActorSheet = new TestActorSheet(testActor);
+
+expectType<TestActor>(testActorSheet.actor);
+expectType<string>(testActorSheet.actor.foo);
 
 const sheetData = await testActorSheet.getData();
 

--- a/test-d/types/applications/forms/actorSheet.test-d.ts
+++ b/test-d/types/applications/forms/actorSheet.test-d.ts
@@ -8,7 +8,7 @@ type TestActorData = Actor.Data<{ bar: number }, TestItemData>;
 class TestActor extends Actor<TestActorData, TestItem> {}
 const testActor = new TestActor();
 
-class TestActorSheet extends ActorSheet<TestActor> {}
+class TestActorSheet extends ActorSheet<ActorSheet.Data<TestActor>> {}
 const testActorSheet = new TestActorSheet(testActor);
 
 const sheetData = await testActorSheet.getData();

--- a/test-d/types/applications/forms/itemSheet.test-d.ts
+++ b/test-d/types/applications/forms/itemSheet.test-d.ts
@@ -2,11 +2,16 @@ import '../../../../index';
 import { expectType } from 'tsd';
 
 type TestItemData = Item.Data<{ foo: string }>;
-class TestItem extends Item<TestItemData> {}
+class TestItem extends Item<TestItemData> {
+  foo = 'bar';
+}
 const testItem = new TestItem();
 
 class TestItemSheet extends ItemSheet<ItemSheet.Data<TestItem>> {}
 const testItemSheet = new TestItemSheet(testItem);
+
+expectType<TestItem>(testItemSheet.item);
+expectType<string>(testItemSheet.item.foo);
 
 const sheetData = await testItemSheet.getData();
 

--- a/test-d/types/applications/forms/itemSheet.test-d.ts
+++ b/test-d/types/applications/forms/itemSheet.test-d.ts
@@ -5,7 +5,7 @@ type TestItemData = Item.Data<{ foo: string }>;
 class TestItem extends Item<TestItemData> {}
 const testItem = new TestItem();
 
-class TestItemSheet extends ItemSheet<TestItem> {}
+class TestItemSheet extends ItemSheet<ItemSheet.Data<TestItem>> {}
 const testItemSheet = new TestItemSheet(testItem);
 
 const sheetData = await testItemSheet.getData();

--- a/types/applications/baseEntitySheet.d.ts
+++ b/types/applications/baseEntitySheet.d.ts
@@ -1,9 +1,13 @@
 /**
  * Extend the FormApplication pattern to incorporate specific logic for viewing or editing Entity instances.
  * See the FormApplication documentation for more complete description of this interface.
+ * @typeParam D - The data structure used to render the handlebars template.
  * @typeParam O - the type of the Entity which should be managed by this form sheet
  */
-declare class BaseEntitySheet<O extends Entity = Entity> extends FormApplication<BaseEntitySheet.Data<O>, O> {
+declare class BaseEntitySheet<
+  D extends object = BaseEntitySheet.Data<Entity>,
+  O extends Entity = D extends BaseEntitySheet.Data<infer T> ? T : Entity
+> extends FormApplication<D, O> {
   /**
    * @param object  - An Entity which should be managed by this form sheet.
    * @param options - Optional configuration parameters for how the form behaves.
@@ -40,7 +44,7 @@ declare class BaseEntitySheet<O extends Entity = Entity> extends FormApplication
    * @param options - (unused)
    * @override
    */
-  getData(options?: Application.RenderOptions): BaseEntitySheet.Data<O> | Promise<BaseEntitySheet.Data<O>>;
+  getData(options?: Application.RenderOptions): D | Promise<D>;
 
   /**
    * @override

--- a/types/applications/baseEntitySheet.d.ts
+++ b/types/applications/baseEntitySheet.d.ts
@@ -3,7 +3,7 @@
  * See the FormApplication documentation for more complete description of this interface.
  * @typeParam O - the type of the Entity which should be managed by this form sheet
  */
-declare class BaseEntitySheet<O extends Entity = Entity> extends FormApplication<O> {
+declare class BaseEntitySheet<O extends Entity = Entity> extends FormApplication<BaseEntitySheet.Data<O>, O> {
   /**
    * @param object  - An Entity which should be managed by this form sheet.
    * @param options - Optional configuration parameters for how the form behaves.
@@ -59,7 +59,7 @@ declare namespace BaseEntitySheet {
    * @typeParam D - the type of the data in the Entity
    * @typeParam O - the type of the Entity which should be managed by this form sheet
    */
-  interface Data<O extends Entity = Entity> extends FormApplication.Data<O> {
+  interface Data<O extends Entity = Entity> {
     cssClass: string;
     editable: boolean;
     entity: Duplicated<O['data']>;

--- a/types/applications/formApplication.d.ts
+++ b/types/applications/formApplication.d.ts
@@ -6,9 +6,13 @@
  * 2) The template used contains one (and only one) HTML form as it's outer-most element
  * 3) This abstract layer has no knowledge of what is being updated, so the implementation must define _updateObject
  *
+ * @typeParam D - The data structure used to render the handlebars template.
  * @typeParam O - the type of the object or entity target which we are using this form to modify
  */
-declare abstract class FormApplication<O = {}> extends Application {
+declare abstract class FormApplication<
+  D extends object = FormApplication.Data<{}>,
+  O extends object = D extends FormApplication.Data<infer T> ? T : {}
+> extends Application {
   /**
    * @param object  - Some object or entity which is the target to be updated.
    *                 (default: `{}`)
@@ -60,7 +64,7 @@ declare abstract class FormApplication<O = {}> extends Application {
    * @param options - (unused) (default: `{}`)
    * @override
    */
-  getData(options?: Application.RenderOptions): FormApplication.Data<O> | Promise<FormApplication.Data<O>>;
+  getData(options?: Application.RenderOptions): D | Promise<D>;
 
   /**
    * @override
@@ -71,7 +75,7 @@ declare abstract class FormApplication<O = {}> extends Application {
    * @param options - (unused)
    * @override
    */
-  protected _renderInner(data: object, options?: Application.RenderOptions): Promise<JQuery>;
+  protected _renderInner(data: D, options?: Application.RenderOptions): Promise<JQuery>;
 
   /**
    * Activate the default set of listeners for the Entity sheet
@@ -196,7 +200,7 @@ declare namespace FormApplication {
   }
 
   interface Data<O> {
-    object?: Duplicated<O>;
+    object: Duplicated<O>;
     options: FormApplication.Options;
     title: string;
   }

--- a/types/applications/forms/actorSheet.d.ts
+++ b/types/applications/forms/actorSheet.d.ts
@@ -5,10 +5,13 @@
  *
  * System modifications may elect to override this class to better suit their own game system by re-defining the value
  * `CONFIG.Actor.sheetClass`.
- *
+ * @typeParam D - The data structure used to render the handlebars template.
  * @typeParam O - the type of the Entity which should be managed by this form sheet
  */
-declare class ActorSheet<O extends Actor = Actor> extends BaseEntitySheet<O> {
+declare class ActorSheet<
+  D extends object = ActorSheet.Data<Actor>,
+  O extends Actor = D extends ActorSheet.Data<infer T> ? T : Actor
+> extends BaseEntitySheet<D, O> {
   /**
    * @param actor   - The Actor instance being displayed within the sheet.
    * @param options - Additional options which modify the rendering of the
@@ -39,7 +42,7 @@ declare class ActorSheet<O extends Actor = Actor> extends BaseEntitySheet<O> {
    * @param options - (unused)
    * @override
    */
-  getData(options?: Application.RenderOptions): ActorSheet.Data<O> | Promise<ActorSheet.Data<O>>;
+  getData(options?: Application.RenderOptions): D | Promise<D>;
 
   /**
    * @override

--- a/types/applications/forms/itemSheet.d.ts
+++ b/types/applications/forms/itemSheet.d.ts
@@ -5,11 +5,13 @@
  *
  * System modifications may elect to override this class to better suit their own game system by re-defining the value
  * `CONFIG.Item.sheetClass`.
- *
- * @typeParam O - the type of the Entity which should be managed by this form
- *                sheet
+ * @typeParam D - The data structure used to render the handlebars template.
+ * @typeParam O - the type of the Entity which should be managed by this form sheet
  */
-declare class ItemSheet<O extends Item = Item> extends BaseEntitySheet<O> {
+declare class ItemSheet<
+  D extends object = ActorSheet.Data<Actor>,
+  O extends Item = D extends ItemSheet.Data<infer T> ? T : Item
+> extends BaseEntitySheet<D, O> {
   /**
    * @param item    - The Item instance being displayed within the sheet.
    * @param options - Additional options which modify the rendering of the item.
@@ -41,7 +43,7 @@ declare class ItemSheet<O extends Item = Item> extends BaseEntitySheet<O> {
    * @param options - (unused)
    * @override
    */
-  getData(options?: any): ItemSheet.Data<O> | Promise<ItemSheet.Data<O>>;
+  getData(options?: any): D | Promise<D>;
 
   /** @override */
   protected _getHeaderButtons(): Application.HeaderButton[];

--- a/types/core/settings/clientSettings.d.ts
+++ b/types/core/settings/clientSettings.d.ts
@@ -166,7 +166,7 @@ declare namespace ClientSettings {
     module: string;
   }
 
-  interface CompleteMenuSettings<F extends FormApplication = FormApplication> extends PartialMenuSettings<F> {
+  interface CompleteMenuSettings extends PartialMenuSettings {
     key: string;
     module: string;
   }
@@ -187,12 +187,12 @@ declare namespace ClientSettings {
     type?: ConstructorOf<T>;
   }
 
-  interface PartialMenuSettings<F extends FormApplication = FormApplication> {
+  interface PartialMenuSettings {
     hint?: string;
     icon?: string;
     label?: string;
     name?: string;
     restricted: boolean;
-    type: ConstructorOf<F>;
+    type: ConstructorOf<FormApplication<object>>;
   }
 }

--- a/types/framework/entity.d.ts
+++ b/types/framework/entity.d.ts
@@ -170,13 +170,13 @@ declare class Entity<D extends Entity.Data = Entity.Data> {
    * actor.sheet // ActorSheet
    * ```
    */
-  get sheet(): BaseEntitySheet;
+  get sheet(): BaseEntitySheet<BaseEntitySheet.Data<this>, this> | null;
 
   /**
    * Obtain a reference to the BaseEntitySheet implementation which should be used to render the Entity instance
    * configuration sheet.
    */
-  protected get _sheetClass(): BaseEntitySheet;
+  protected get _sheetClass(): BaseEntitySheet<BaseEntitySheet.Data<this>, this> | null;
 
   /**
    * Return a reference to the Folder which this Entity belongs to, if any.


### PR DESCRIPTION
Makes FormApplication generic on the return type of getData. Updates
BaseEntitySheet to match these changes. Makes the O parameter default to
inferred from D in the case that it extends the default return type, or
{} if not.