### PR TITLE
Make update more permissive

### DIFF
--- a/types/framework/entities/activeEffect.d.ts
+++ b/types/framework/entities/activeEffect.d.ts
@@ -133,7 +133,10 @@ declare class ActiveEffect<P extends Actor | Item = Actor | Item> extends Embedd
    * @param options - Configuration options which modify the request.
    * @returns The updated ActiveEffect data.
    */
-  update(data: DeepPartial<ActiveEffect.Data>, options?: Entity.UpdateOptions): Promise<ActiveEffect.Data>;
+  update(
+    data: DeepPartial<ActiveEffect.Data> & Partial<Record<string, any>>,
+    options?: Entity.UpdateOptions
+  ): Promise<ActiveEffect.Data>;
 
   /* -------------------------------------------- */
 

--- a/types/framework/entities/activeEffect.d.ts
+++ b/types/framework/entities/activeEffect.d.ts
@@ -157,7 +157,9 @@ declare class ActiveEffect<P extends Actor | Item = Actor | Item> extends Embedd
    * @param args - Initialization arguments passed to the ActiveEffect constructor.
    * @returns The constructed ActiveEffect instance.
    */
-  static create<P extends Actor | Item = Actor | Item>(...args: [DeepPartial<ActiveEffect.Data>, P]): ActiveEffect<P>;
+  static create<P extends Actor | Item = Actor | Item>(
+    ...args: [DeepPartial<ActiveEffect.Data> & Partial<Record<string, any>>, P]
+  ): ActiveEffect<P>;
 
   /* -------------------------------------------- */
 

--- a/types/framework/entities/actor.d.ts
+++ b/types/framework/entities/actor.d.ts
@@ -289,7 +289,7 @@ declare class Actor<
   /* -------------------------------------------- */
 
   /** @override */
-  update(data: DeepPartial<D>, options?: Entity.UpdateOptions): Promise<this>;
+  update(data: DeepPartial<D> & Partial<Record<string, any>>, options?: Entity.UpdateOptions): Promise<this>;
 
   /** @override */
   delete(options?: Entity.DeleteOptions): Promise<Actor>;

--- a/types/framework/entities/chatMessage.d.ts
+++ b/types/framework/entities/chatMessage.d.ts
@@ -105,9 +105,12 @@ declare class ChatMessage extends Entity<ChatMessage.Data> {
   /* -------------------------------------------- */
 
   /** @override */
-  static create(data: DeepPartial<ChatMessage.CreateData>, options?: Entity.CreateOptions): Promise<ChatMessage | null>;
   static create(
-    data: DeepPartial<ChatMessage.CreateData>[],
+    data: DeepPartial<ChatMessage.CreateData> & Partial<Record<string, any>>,
+    options?: Entity.CreateOptions
+  ): Promise<ChatMessage | null>;
+  static create(
+    data: (DeepPartial<ChatMessage.CreateData> & Partial<Record<string, any>>)[],
     options?: Entity.CreateOptions
   ): Promise<ChatMessage[] | null>;
 

--- a/types/framework/entities/item.d.ts
+++ b/types/framework/entities/item.d.ts
@@ -146,7 +146,7 @@ declare class Item<D extends Item.Data = Item.Data<any>> extends Entity<D> {
   /* -------------------------------------------- */
 
   /** @override */
-  update(data: DeepPartial<D>, options?: Entity.UpdateOptions): Promise<this>;
+  update(data: DeepPartial<D> & Partial<Record<string, any>>, options?: Entity.UpdateOptions): Promise<this>;
 
   /** @override */
   delete(options?: Entity.DeleteOptions): Promise<Item>;

--- a/types/framework/entities/scene.d.ts
+++ b/types/framework/entities/scene.d.ts
@@ -123,8 +123,14 @@ declare class Scene extends Entity<Scene.Data> {
   clone(createData?: Scene.Data, options?: Entity.CreateOptions): Promise<Scene>;
 
   /** @override */
-  static create(data: DeepPartial<Scene.Data>, options?: Entity.CreateOptions): Promise<Scene | null>;
-  static create(data: DeepPartial<Scene.Data>[], options?: Entity.CreateOptions): Promise<Scene[] | null>;
+  static create(
+    data: DeepPartial<Scene.Data> & Partial<Record<string, any>>,
+    options?: Entity.CreateOptions
+  ): Promise<Scene | null>;
+  static create(
+    data: (DeepPartial<Scene.Data> & Partial<Record<string, any>>)[],
+    options?: Entity.CreateOptions
+  ): Promise<Scene[] | null>;
 
   /** @override */
   update(data: DeepPartial<Scene.Data> & Partial<Record<string, any>>, options: Entity.UpdateOptions): Promise<this>;

--- a/types/framework/entities/scene.d.ts
+++ b/types/framework/entities/scene.d.ts
@@ -127,7 +127,7 @@ declare class Scene extends Entity<Scene.Data> {
   static create(data: DeepPartial<Scene.Data>[], options?: Entity.CreateOptions): Promise<Scene[] | null>;
 
   /** @override */
-  update(data: DeepPartial<Scene.Data>, options: Entity.UpdateOptions): Promise<this>;
+  update(data: DeepPartial<Scene.Data> & Partial<Record<string, any>>, options: Entity.UpdateOptions): Promise<this>;
 
   /** @override */
   protected _onCreate(data: Scene.Data, options: any, userId: string): void;

--- a/types/framework/entity.d.ts
+++ b/types/framework/entity.d.ts
@@ -311,8 +311,14 @@ declare class Entity<D extends Entity.Data = Entity.Data> {
    * const created: Actor[] | null = await Actor.create(data, {temporary: true}); // Not saved to the database
    * ```
    */
-  static create<T extends Entity>(data: DeepPartial<T['data']>, options?: Entity.CreateOptions): Promise<T | null>;
-  static create<T extends Entity>(data: DeepPartial<T['data']>[], options?: Entity.CreateOptions): Promise<T[] | null>;
+  static create<T extends Entity>(
+    data: DeepPartial<T['data']> & Partial<Record<string, any>>,
+    options?: Entity.CreateOptions
+  ): Promise<T | null>;
+  static create<T extends Entity>(
+    data: (DeepPartial<T['data']> & Partial<Record<string, any>>)[],
+    options?: Entity.CreateOptions
+  ): Promise<T[] | null>;
 
   /**
    * Handle a SocketResponse from the server when one or multiple Entities are created

--- a/types/framework/entity.d.ts
+++ b/types/framework/entity.d.ts
@@ -346,8 +346,14 @@ declare class Entity<D extends Entity.Data = Entity.Data> {
    * const updated = await Entity.update<Actor>(data); // Returns an Array of Entities, updated in the database
    * ```
    */
-  static update<T extends Entity>(data: DeepPartial<T['data']>, options?: Entity.UpdateOptions): Promise<T>;
-  static update<T extends Entity>(data: DeepPartial<T['data']>[], options?: Entity.UpdateOptions): Promise<T[]>;
+  static update<T extends Entity>(
+    data: DeepPartial<T['data']> & Partial<Record<string, any>>,
+    options?: Entity.UpdateOptions
+  ): Promise<T>;
+  static update<T extends Entity>(
+    data: (DeepPartial<T['data']> & Partial<Record<string, any>>)[],
+    options?: Entity.UpdateOptions
+  ): Promise<T[]>;
 
   /**
    * Handle a SocketResponse from the server when one or multiple Entities are updated
@@ -370,7 +376,7 @@ declare class Entity<D extends Entity.Data = Entity.Data> {
    * @param data - A Data object which updates the Entity
    * @param options - Additional options which customize the update workflow
    */
-  update(data: DeepPartial<D>, options?: Entity.UpdateOptions): Promise<this>;
+  update(data: DeepPartial<D> & Partial<Record<string, any>>, options?: Entity.UpdateOptions): Promise<this>;
 
   /**
    * Delete one or multiple existing entities using provided ids.

--- a/types/pixi/placeableObjects/placeableObject.d.ts
+++ b/types/pixi/placeableObjects/placeableObject.d.ts
@@ -204,15 +204,15 @@ declare abstract class PlaceableObject<D extends PlaceableObject.Data = Placeabl
   abstract refresh(): unknown;
 
   static create<T extends PlaceableObject>(
-    data: DeepPartial<T['data']>,
+    data: DeepPartial<T['data']> & Partial<Record<string, any>>,
     options?: Entity.CreateOptions
   ): Promise<T | void>;
   static create<T extends PlaceableObject>(
-    data: DeepPartial<T['data']>[],
+    data: (DeepPartial<T['data']> & Partial<Record<string, any>>)[],
     options?: Entity.CreateOptions
   ): Promise<T[] | void>;
 
-  update(data: DeepPartial<D>, options?: Entity.UpdateOptions): Promise<this>;
+  update(data: DeepPartial<D> & Partial<Record<string, any>>, options?: Entity.UpdateOptions): Promise<this>;
 
   delete(options?: Entity.DeleteOptions): Promise<this>;
 


### PR DESCRIPTION
The plan is to allow dot notation keys, but with current typescript, it is impossible to type check them. There is a question as to whether this should be locked behind an opt in parameter since having these keys allowed means that misspelled and nonexistent keys won't be caught. And if it is switchable behavior, which should be the default?