### PR TITLE
Improve Entity.create

### DIFF
--- a/test-d/types/framework/entity.test-d.ts
+++ b/test-d/types/framework/entity.test-d.ts
@@ -24,3 +24,12 @@ expectType<Promise<CustomEntity | null>>(CustomEntity.create([customData] as con
 expectType<Promise<CustomEntity[] | null>>(CustomEntity.create([customData, customData] as const));
 expectType<Promise<CustomEntity[] | null>>(CustomEntity.create([customData, customData, customData] as const));
 expectType<Promise<CustomEntity | CustomEntity[] | null>>(CustomEntity.create(customDataProducer()));
+
+declare const actualCustomData: CustomEntityData;
+
+expectType<Promise<CustomEntity | null>>(CustomEntity.create(actualCustomData));
+expectType<Promise<CustomEntity | null>>(CustomEntity.create([actualCustomData] as const));
+expectType<Promise<CustomEntity[] | null>>(CustomEntity.create([actualCustomData, actualCustomData] as const));
+expectType<Promise<CustomEntity[] | null>>(
+  CustomEntity.create([actualCustomData, actualCustomData, actualCustomData] as const)
+);

--- a/test-d/types/framework/entity.test-d.ts
+++ b/test-d/types/framework/entity.test-d.ts
@@ -1,0 +1,26 @@
+import { expectType } from 'tsd';
+import '../../../index';
+
+declare const data: DeepPartial<Entity.Data>;
+declare function dataProducer(): DeepPartial<Entity.Data>[];
+
+expectType<Promise<[]>>(Entity.create([]));
+expectType<Promise<Entity | null>>(Entity.create(data));
+expectType<Promise<Entity | null>>(Entity.create([data] as const));
+expectType<Promise<Entity[] | null>>(Entity.create([data, data] as const));
+expectType<Promise<Entity[] | null>>(Entity.create([data, data, data] as const));
+expectType<Promise<Entity | Entity[] | null>>(Entity.create(dataProducer()));
+
+interface CustomEntityData extends Entity.Data {
+  customField: boolean;
+}
+declare class CustomEntity extends Entity<CustomEntityData> {}
+declare const customData: DeepPartial<CustomEntityData>;
+declare function customDataProducer(): DeepPartial<CustomEntityData>[];
+
+expectType<Promise<[]>>(CustomEntity.create([]));
+expectType<Promise<CustomEntity | null>>(CustomEntity.create(customData));
+expectType<Promise<CustomEntity | null>>(CustomEntity.create([customData] as const));
+expectType<Promise<CustomEntity[] | null>>(CustomEntity.create([customData, customData] as const));
+expectType<Promise<CustomEntity[] | null>>(CustomEntity.create([customData, customData, customData] as const));
+expectType<Promise<CustomEntity | CustomEntity[] | null>>(CustomEntity.create(customDataProducer()));

--- a/types/framework/entity.d.ts
+++ b/types/framework/entity.d.ts
@@ -311,8 +311,22 @@ declare class Entity<D extends Entity.Data = Entity.Data> {
    * const created: Actor[] | null = await Actor.create(data, {temporary: true}); // Not saved to the database
    * ```
    */
-  static create<T extends Entity>(data: DeepPartial<T['data']>, options?: Entity.CreateOptions): Promise<T | null>;
-  static create<T extends Entity>(data: DeepPartial<T['data']>[], options?: Entity.CreateOptions): Promise<T[] | null>;
+  static create<T extends Entity>(
+    this: ConstructorOf<T>,
+    data: DeepPartial<T['data']>,
+    options?: Entity.CreateOptions
+  ): Promise<T | null>;
+  static create<T extends Entity, D extends ReadonlyArray<DeepPartial<T['data']>>>(
+    this: ConstructorOf<T>,
+    data: D,
+    options?: Entity.CreateOptions
+  ): D extends never[]
+    ? Promise<[]>
+    : IsReadonlyArrayWithKey<D, 0> extends true
+    ? IsReadonlyArrayWithKey<D, 1> extends true
+      ? Promise<T[] | null>
+      : Promise<T | null>
+    : Promise<T | T[] | null>;
 
   /**
    * Handle a SocketResponse from the server when one or multiple Entities are created

--- a/types/typesUtils.d.ts
+++ b/types/typesUtils.d.ts
@@ -58,3 +58,10 @@ type OmitAssignableFromType<T extends object, U> = { [k in keyof T as U extends 
  * @internal
  */
 type OmitNotAssignableFromType<T extends object, U> = { [k in keyof T as U extends T[k] ? k : never]: T[k] };
+
+/**
+ * `true` if `T` is a `ReadonlyArray` with compile time known length of at least `N + 1`, `false` otherwise.
+ * @typeParam T - The `ReadonlyArray` to check.
+ * @typeParam N - The key to check for existence in `T`.
+ */
+type IsReadonlyArrayWithKey<T extends ReadonlyArray<any>, N extends number> = `${N}` extends keyof T ? true : false;


### PR DESCRIPTION
This PR improves `Entity.create` in 2 ways:
- The return type is now correct also when an array of length 1 is passed
- When calling `create` on a class that is extending `Entity`, the return type correctly uses that subclass instead of `Entity` automatically, i.e. it is no longer necessary to explicitly provide the resulting class as type parameter or cast.