### PR TITLE
Improve typing of Entity

### DIFF
--- a/test-d/types/framework/entity.test-d.ts
+++ b/test-d/types/framework/entity.test-d.ts
@@ -8,7 +8,6 @@ declare class CustomEntity extends Entity<CustomEntityData> {}
 declare const actualCustomData: CustomEntityData;
 
 // create
-
 declare const createData: DeepPartial<Entity.Data>;
 declare function createDataProducer(): DeepPartial<Entity.Data>[];
 declare const customCreateData: DeepPartial<CustomEntityData>;
@@ -38,7 +37,6 @@ expectType<Promise<CustomEntity[] | null>>(
 );
 
 // update
-
 declare const updateData: DeepPartial<Entity.Data> & { _id: string };
 declare function updateDataProducer(): (DeepPartial<Entity.Data> & { _id: string })[];
 declare const customUpdateData: DeepPartial<CustomEntityData> & { _id: string };

--- a/test-d/types/framework/entity.test-d.ts
+++ b/test-d/types/framework/entity.test-d.ts
@@ -3,20 +3,21 @@ import '../../../index';
 
 declare const data: DeepPartial<Entity.Data>;
 declare function dataProducer(): DeepPartial<Entity.Data>[];
-
-expectType<Promise<[]>>(Entity.create([]));
-expectType<Promise<Entity | null>>(Entity.create(data));
-expectType<Promise<Entity | null>>(Entity.create([data] as const));
-expectType<Promise<Entity[] | null>>(Entity.create([data, data] as const));
-expectType<Promise<Entity[] | null>>(Entity.create([data, data, data] as const));
-expectType<Promise<Entity | Entity[] | null>>(Entity.create(dataProducer()));
-
 interface CustomEntityData extends Entity.Data {
   customField: boolean;
 }
 declare class CustomEntity extends Entity<CustomEntityData> {}
 declare const customData: DeepPartial<CustomEntityData>;
 declare function customDataProducer(): DeepPartial<CustomEntityData>[];
+declare const actualCustomData: CustomEntityData;
+
+// create
+expectType<Promise<[]>>(Entity.create([]));
+expectType<Promise<Entity | null>>(Entity.create(data));
+expectType<Promise<Entity | null>>(Entity.create([data] as const));
+expectType<Promise<Entity[] | null>>(Entity.create([data, data] as const));
+expectType<Promise<Entity[] | null>>(Entity.create([data, data, data] as const));
+expectType<Promise<Entity | Entity[] | null>>(Entity.create(dataProducer()));
 
 expectType<Promise<[]>>(CustomEntity.create([]));
 expectType<Promise<CustomEntity | null>>(CustomEntity.create(customData));
@@ -25,11 +26,49 @@ expectType<Promise<CustomEntity[] | null>>(CustomEntity.create([customData, cust
 expectType<Promise<CustomEntity[] | null>>(CustomEntity.create([customData, customData, customData] as const));
 expectType<Promise<CustomEntity | CustomEntity[] | null>>(CustomEntity.create(customDataProducer()));
 
-declare const actualCustomData: CustomEntityData;
-
 expectType<Promise<CustomEntity | null>>(CustomEntity.create(actualCustomData));
 expectType<Promise<CustomEntity | null>>(CustomEntity.create([actualCustomData] as const));
 expectType<Promise<CustomEntity[] | null>>(CustomEntity.create([actualCustomData, actualCustomData] as const));
 expectType<Promise<CustomEntity[] | null>>(
   CustomEntity.create([actualCustomData, actualCustomData, actualCustomData] as const)
 );
+
+// update
+expectType<Promise<[]>>(Entity.update([]));
+expectType<Promise<Entity | null>>(Entity.update(data));
+expectType<Promise<Entity | null>>(Entity.update([data] as const));
+expectType<Promise<Entity[] | null>>(Entity.update([data, data] as const));
+expectType<Promise<Entity[] | null>>(Entity.update([data, data, data] as const));
+expectType<Promise<Entity | Entity[] | null>>(Entity.update(dataProducer()));
+
+expectType<Promise<[]>>(CustomEntity.update([]));
+expectType<Promise<CustomEntity | null>>(CustomEntity.update(customData));
+expectType<Promise<CustomEntity | null>>(CustomEntity.update([customData] as const));
+expectType<Promise<CustomEntity[] | null>>(CustomEntity.update([customData, customData] as const));
+expectType<Promise<CustomEntity[] | null>>(CustomEntity.update([customData, customData, customData] as const));
+expectType<Promise<CustomEntity | CustomEntity[] | null>>(CustomEntity.update(customDataProducer()));
+
+expectType<Promise<CustomEntity | null>>(CustomEntity.update(actualCustomData));
+expectType<Promise<CustomEntity | null>>(CustomEntity.update([actualCustomData] as const));
+expectType<Promise<CustomEntity[] | null>>(CustomEntity.update([actualCustomData, actualCustomData] as const));
+expectType<Promise<CustomEntity[] | null>>(
+  CustomEntity.update([actualCustomData, actualCustomData, actualCustomData] as const)
+);
+
+// delete
+declare const id: string;
+declare function idProducer(): string[];
+
+expectType<Promise<[]>>(Entity.update([]));
+expectType<Promise<Entity | null>>(Entity.delete(id));
+expectType<Promise<Entity | null>>(Entity.delete([id] as const));
+expectType<Promise<Entity[] | null>>(Entity.delete([id, id] as const));
+expectType<Promise<Entity[] | null>>(Entity.delete([id, id, id] as const));
+expectType<Promise<Entity | Entity[] | null>>(Entity.delete(idProducer()));
+
+expectType<Promise<[]>>(CustomEntity.delete([]));
+expectType<Promise<CustomEntity | null>>(CustomEntity.delete(id));
+expectType<Promise<CustomEntity | null>>(CustomEntity.delete([id] as const));
+expectType<Promise<CustomEntity[] | null>>(CustomEntity.delete([id, id] as const));
+expectType<Promise<CustomEntity[] | null>>(CustomEntity.delete([id, id, id] as const));
+expectType<Promise<CustomEntity | CustomEntity[] | null>>(CustomEntity.delete(idProducer()));

--- a/test-d/types/framework/entity.test-d.ts
+++ b/test-d/types/framework/entity.test-d.ts
@@ -1,30 +1,34 @@
 import { expectType } from 'tsd';
 import '../../../index';
 
-declare const data: DeepPartial<Entity.Data>;
-declare function dataProducer(): DeepPartial<Entity.Data>[];
 interface CustomEntityData extends Entity.Data {
   customField: boolean;
 }
 declare class CustomEntity extends Entity<CustomEntityData> {}
-declare const customData: DeepPartial<CustomEntityData>;
-declare function customDataProducer(): DeepPartial<CustomEntityData>[];
 declare const actualCustomData: CustomEntityData;
 
 // create
+
+declare const createData: DeepPartial<Entity.Data>;
+declare function createDataProducer(): DeepPartial<Entity.Data>[];
+declare const customCreateData: DeepPartial<CustomEntityData>;
+declare function customCreateDataProducer(): DeepPartial<CustomEntityData>[];
+
 expectType<Promise<[]>>(Entity.create([]));
-expectType<Promise<Entity | null>>(Entity.create(data));
-expectType<Promise<Entity | null>>(Entity.create([data] as const));
-expectType<Promise<Entity[] | null>>(Entity.create([data, data] as const));
-expectType<Promise<Entity[] | null>>(Entity.create([data, data, data] as const));
-expectType<Promise<Entity | Entity[] | null>>(Entity.create(dataProducer()));
+expectType<Promise<Entity | null>>(Entity.create(createData));
+expectType<Promise<Entity | null>>(Entity.create([createData] as const));
+expectType<Promise<Entity[] | null>>(Entity.create([createData, createData] as const));
+expectType<Promise<Entity[] | null>>(Entity.create([createData, createData, createData] as const));
+expectType<Promise<Entity | Entity[] | null>>(Entity.create(createDataProducer()));
 
 expectType<Promise<[]>>(CustomEntity.create([]));
-expectType<Promise<CustomEntity | null>>(CustomEntity.create(customData));
-expectType<Promise<CustomEntity | null>>(CustomEntity.create([customData] as const));
-expectType<Promise<CustomEntity[] | null>>(CustomEntity.create([customData, customData] as const));
-expectType<Promise<CustomEntity[] | null>>(CustomEntity.create([customData, customData, customData] as const));
-expectType<Promise<CustomEntity | CustomEntity[] | null>>(CustomEntity.create(customDataProducer()));
+expectType<Promise<CustomEntity | null>>(CustomEntity.create(customCreateData));
+expectType<Promise<CustomEntity | null>>(CustomEntity.create([customCreateData] as const));
+expectType<Promise<CustomEntity[] | null>>(CustomEntity.create([customCreateData, customCreateData] as const));
+expectType<Promise<CustomEntity[] | null>>(
+  CustomEntity.create([customCreateData, customCreateData, customCreateData] as const)
+);
+expectType<Promise<CustomEntity | CustomEntity[] | null>>(CustomEntity.create(customCreateDataProducer()));
 
 expectType<Promise<CustomEntity | null>>(CustomEntity.create(actualCustomData));
 expectType<Promise<CustomEntity | null>>(CustomEntity.create([actualCustomData] as const));
@@ -34,19 +38,27 @@ expectType<Promise<CustomEntity[] | null>>(
 );
 
 // update
+
+declare const updateData: DeepPartial<Entity.Data> & { _id: string };
+declare function updateDataProducer(): (DeepPartial<Entity.Data> & { _id: string })[];
+declare const customUpdateData: DeepPartial<CustomEntityData> & { _id: string };
+declare function customUpdateDataProducer(): (DeepPartial<CustomEntityData> & { _id: string })[];
+
 expectType<Promise<[]>>(Entity.update([]));
-expectType<Promise<Entity | null>>(Entity.update(data));
-expectType<Promise<Entity | null>>(Entity.update([data] as const));
-expectType<Promise<Entity[] | null>>(Entity.update([data, data] as const));
-expectType<Promise<Entity[] | null>>(Entity.update([data, data, data] as const));
-expectType<Promise<Entity | Entity[] | null>>(Entity.update(dataProducer()));
+expectType<Promise<Entity | null>>(Entity.update(updateData));
+expectType<Promise<Entity | null>>(Entity.update([updateData] as const));
+expectType<Promise<Entity[] | null>>(Entity.update([updateData, updateData] as const));
+expectType<Promise<Entity[] | null>>(Entity.update([updateData, updateData, updateData] as const));
+expectType<Promise<Entity | Entity[] | null>>(Entity.update(updateDataProducer()));
 
 expectType<Promise<[]>>(CustomEntity.update([]));
-expectType<Promise<CustomEntity | null>>(CustomEntity.update(customData));
-expectType<Promise<CustomEntity | null>>(CustomEntity.update([customData] as const));
-expectType<Promise<CustomEntity[] | null>>(CustomEntity.update([customData, customData] as const));
-expectType<Promise<CustomEntity[] | null>>(CustomEntity.update([customData, customData, customData] as const));
-expectType<Promise<CustomEntity | CustomEntity[] | null>>(CustomEntity.update(customDataProducer()));
+expectType<Promise<CustomEntity | null>>(CustomEntity.update(customUpdateData));
+expectType<Promise<CustomEntity | null>>(CustomEntity.update([customUpdateData] as const));
+expectType<Promise<CustomEntity[] | null>>(CustomEntity.update([customUpdateData, customUpdateData] as const));
+expectType<Promise<CustomEntity[] | null>>(
+  CustomEntity.update([customUpdateData, customUpdateData, customUpdateData] as const)
+);
+expectType<Promise<CustomEntity | CustomEntity[] | null>>(CustomEntity.update(customUpdateDataProducer()));
 
 expectType<Promise<CustomEntity | null>>(CustomEntity.update(actualCustomData));
 expectType<Promise<CustomEntity | null>>(CustomEntity.update([actualCustomData] as const));

--- a/test-d/types/framework/entity.test-d.ts
+++ b/test-d/types/framework/entity.test-d.ts
@@ -9,76 +9,61 @@ declare const actualCustomData: CustomEntityData;
 
 // create
 declare const createData: DeepPartial<Entity.Data>;
-declare function createDataProducer(): DeepPartial<Entity.Data>[];
 declare const customCreateData: DeepPartial<CustomEntityData>;
-declare function customCreateDataProducer(): DeepPartial<CustomEntityData>[];
 
-expectType<Promise<[]>>(Entity.create([]));
+expectType<Promise<Entity | Entity[] | null>>(Entity.create([]));
 expectType<Promise<Entity | null>>(Entity.create(createData));
-expectType<Promise<Entity | null>>(Entity.create([createData] as const));
-expectType<Promise<Entity[] | null>>(Entity.create([createData, createData] as const));
-expectType<Promise<Entity[] | null>>(Entity.create([createData, createData, createData] as const));
-expectType<Promise<Entity | Entity[] | null>>(Entity.create(createDataProducer()));
+expectType<Promise<Entity | Entity[] | null>>(Entity.create([createData, createData]));
+expectType<Promise<Entity | Entity[] | null>>(Entity.create([createData] as const));
+expectType<Promise<Entity | Entity[] | null>>(Entity.create([createData, createData] as const));
 
-expectType<Promise<[]>>(CustomEntity.create([]));
+expectType<Promise<CustomEntity | CustomEntity[] | null>>(CustomEntity.create([]));
 expectType<Promise<CustomEntity | null>>(CustomEntity.create(customCreateData));
-expectType<Promise<CustomEntity | null>>(CustomEntity.create([customCreateData] as const));
-expectType<Promise<CustomEntity[] | null>>(CustomEntity.create([customCreateData, customCreateData] as const));
-expectType<Promise<CustomEntity[] | null>>(
-  CustomEntity.create([customCreateData, customCreateData, customCreateData] as const)
+expectType<Promise<CustomEntity | CustomEntity[] | null>>(CustomEntity.create([customCreateData, customCreateData]));
+expectType<Promise<CustomEntity | CustomEntity[] | null>>(CustomEntity.create([customCreateData] as const));
+expectType<Promise<CustomEntity | CustomEntity[] | null>>(
+  CustomEntity.create([customCreateData, customCreateData] as const)
 );
-expectType<Promise<CustomEntity | CustomEntity[] | null>>(CustomEntity.create(customCreateDataProducer()));
 
 expectType<Promise<CustomEntity | null>>(CustomEntity.create(actualCustomData));
-expectType<Promise<CustomEntity | null>>(CustomEntity.create([actualCustomData] as const));
-expectType<Promise<CustomEntity[] | null>>(CustomEntity.create([actualCustomData, actualCustomData] as const));
-expectType<Promise<CustomEntity[] | null>>(
-  CustomEntity.create([actualCustomData, actualCustomData, actualCustomData] as const)
+expectType<Promise<CustomEntity | CustomEntity[] | null>>(CustomEntity.create([actualCustomData, actualCustomData]));
+expectType<Promise<CustomEntity | CustomEntity[] | null>>(CustomEntity.create([actualCustomData] as const));
+expectType<Promise<CustomEntity | CustomEntity[] | null>>(
+  CustomEntity.create([actualCustomData, actualCustomData] as const)
 );
 
 // update
 declare const updateData: DeepPartial<Entity.Data> & { _id: string };
-declare function updateDataProducer(): (DeepPartial<Entity.Data> & { _id: string })[];
 declare const customUpdateData: DeepPartial<CustomEntityData> & { _id: string };
-declare function customUpdateDataProducer(): (DeepPartial<CustomEntityData> & { _id: string })[];
 
-expectType<Promise<[]>>(Entity.update([]));
-expectType<Promise<Entity | null>>(Entity.update(updateData));
-expectType<Promise<Entity | null>>(Entity.update([updateData] as const));
-expectType<Promise<Entity[] | null>>(Entity.update([updateData, updateData] as const));
-expectType<Promise<Entity[] | null>>(Entity.update([updateData, updateData, updateData] as const));
-expectType<Promise<Entity | Entity[] | null>>(Entity.update(updateDataProducer()));
+expectType<Promise<Entity | Entity[]>>(Entity.update([]));
+expectType<Promise<Entity | []>>(Entity.update(updateData));
+expectType<Promise<Entity | Entity[]>>(Entity.update([updateData, updateData]));
+expectType<Promise<Entity | Entity[]>>(Entity.update([updateData] as const));
+expectType<Promise<Entity | Entity[]>>(Entity.update([updateData, updateData] as const));
 
-expectType<Promise<[]>>(CustomEntity.update([]));
-expectType<Promise<CustomEntity | null>>(CustomEntity.update(customUpdateData));
-expectType<Promise<CustomEntity | null>>(CustomEntity.update([customUpdateData] as const));
-expectType<Promise<CustomEntity[] | null>>(CustomEntity.update([customUpdateData, customUpdateData] as const));
-expectType<Promise<CustomEntity[] | null>>(
-  CustomEntity.update([customUpdateData, customUpdateData, customUpdateData] as const)
-);
-expectType<Promise<CustomEntity | CustomEntity[] | null>>(CustomEntity.update(customUpdateDataProducer()));
+expectType<Promise<CustomEntity | CustomEntity[]>>(CustomEntity.update([]));
+expectType<Promise<CustomEntity | []>>(CustomEntity.update(customUpdateData));
+expectType<Promise<CustomEntity | CustomEntity[]>>(CustomEntity.update([customUpdateData, customUpdateData]));
+expectType<Promise<CustomEntity | CustomEntity[]>>(CustomEntity.update([customUpdateData] as const));
+expectType<Promise<CustomEntity | CustomEntity[]>>(CustomEntity.update([customUpdateData, customUpdateData] as const));
 
-expectType<Promise<CustomEntity | null>>(CustomEntity.update(actualCustomData));
-expectType<Promise<CustomEntity | null>>(CustomEntity.update([actualCustomData] as const));
-expectType<Promise<CustomEntity[] | null>>(CustomEntity.update([actualCustomData, actualCustomData] as const));
-expectType<Promise<CustomEntity[] | null>>(
-  CustomEntity.update([actualCustomData, actualCustomData, actualCustomData] as const)
-);
+expectType<Promise<CustomEntity | []>>(CustomEntity.update(actualCustomData));
+expectType<Promise<CustomEntity | CustomEntity[]>>(CustomEntity.update([actualCustomData, actualCustomData]));
+expectType<Promise<CustomEntity | CustomEntity[]>>(CustomEntity.update([actualCustomData] as const));
+expectType<Promise<CustomEntity | CustomEntity[]>>(CustomEntity.update([actualCustomData, actualCustomData] as const));
 
 // delete
 declare const id: string;
-declare function idProducer(): string[];
 
-expectType<Promise<[]>>(Entity.update([]));
+expectType<Promise<Entity | Entity[] | null>>(Entity.delete([]));
 expectType<Promise<Entity | null>>(Entity.delete(id));
-expectType<Promise<Entity | null>>(Entity.delete([id] as const));
-expectType<Promise<Entity[] | null>>(Entity.delete([id, id] as const));
-expectType<Promise<Entity[] | null>>(Entity.delete([id, id, id] as const));
-expectType<Promise<Entity | Entity[] | null>>(Entity.delete(idProducer()));
+expectType<Promise<Entity | Entity[] | null>>(Entity.delete([id, id]));
+expectType<Promise<Entity | Entity[] | null>>(Entity.delete([id] as const));
+expectType<Promise<Entity | Entity[] | null>>(Entity.delete([id, id] as const));
 
-expectType<Promise<[]>>(CustomEntity.delete([]));
+expectType<Promise<CustomEntity | CustomEntity[] | null>>(CustomEntity.delete([]));
 expectType<Promise<CustomEntity | null>>(CustomEntity.delete(id));
-expectType<Promise<CustomEntity | null>>(CustomEntity.delete([id] as const));
-expectType<Promise<CustomEntity[] | null>>(CustomEntity.delete([id, id] as const));
-expectType<Promise<CustomEntity[] | null>>(CustomEntity.delete([id, id, id] as const));
-expectType<Promise<CustomEntity | CustomEntity[] | null>>(CustomEntity.delete(idProducer()));
+expectType<Promise<CustomEntity | CustomEntity[] | null>>(CustomEntity.delete([id, id]));
+expectType<Promise<CustomEntity | CustomEntity[] | null>>(CustomEntity.delete([id] as const));
+expectType<Promise<CustomEntity | CustomEntity[] | null>>(CustomEntity.delete([id, id] as const));

--- a/types/framework/entities/actor.d.ts
+++ b/types/framework/entities/actor.d.ts
@@ -292,7 +292,7 @@ declare class Actor<
   update(data: DeepPartial<D>, options?: Entity.UpdateOptions): Promise<this>;
 
   /** @override */
-  delete(options?: Entity.DeleteOptions): Promise<Actor>;
+  delete(options?: Entity.DeleteOptions): Promise<this>;
 
   /** @override */
   protected _onUpdate(data: DeepPartial<D>, options: Entity.UpdateOptions, userId: string, context?: any): void;

--- a/types/framework/entities/chatMessage.d.ts
+++ b/types/framework/entities/chatMessage.d.ts
@@ -105,11 +105,7 @@ declare class ChatMessage extends Entity<ChatMessage.Data> {
   /* -------------------------------------------- */
 
   /** @override */
-  static create(data: DeepPartial<ChatMessage.CreateData>, options?: Entity.CreateOptions): Promise<ChatMessage | null>;
-  static create(
-    data: DeepPartial<ChatMessage.CreateData>[],
-    options?: Entity.CreateOptions
-  ): Promise<ChatMessage[] | null>;
+  static create: Entity.CreateFunction<ChatMessage>;
 
   /**
    * Preprocess the data object used to create a new Chat Message to automatically convert some Objects to the

--- a/types/framework/entities/chatMessage.d.ts
+++ b/types/framework/entities/chatMessage.d.ts
@@ -105,7 +105,16 @@ declare class ChatMessage extends Entity<ChatMessage.Data> {
   /* -------------------------------------------- */
 
   /** @override */
-  static create: Entity.CreateFunction<ChatMessage>;
+  static create<T extends ChatMessage>(
+    this: ConstructorOf<T>,
+    data: DeepPartial<ChatMessage.CreateData>,
+    options?: Entity.CreateOptions
+  ): Promise<T | null>;
+  static create<T extends ChatMessage>(
+    this: ConstructorOf<T>,
+    data: ReadonlyArray<DeepPartial<ChatMessage.CreateData>>,
+    options?: Entity.CreateOptions
+  ): Promise<T | T[] | null>;
 
   /**
    * Preprocess the data object used to create a new Chat Message to automatically convert some Objects to the

--- a/types/framework/entities/item.d.ts
+++ b/types/framework/entities/item.d.ts
@@ -149,12 +149,12 @@ declare class Item<D extends Item.Data = Item.Data<any>> extends Entity<D> {
   update(data: DeepPartial<D>, options?: Entity.UpdateOptions): Promise<this>;
 
   /** @override */
-  delete(options?: Entity.DeleteOptions): Promise<Item>;
+  delete(options?: Entity.DeleteOptions): Promise<this>;
 
   /**
    * A convenience constructor method to create an Item instance which is owned by an Actor
    */
-  static createOwned(itemData: DeepPartial<Item.Data>, actor: Actor): Item;
+  static createOwned<T extends Item>(this: ConstructorOf<T>, itemData: DeepPartial<Item.Data>, actor: Actor): T;
 }
 
 declare namespace Item {

--- a/types/framework/entities/scene.d.ts
+++ b/types/framework/entities/scene.d.ts
@@ -120,7 +120,7 @@ declare class Scene extends Entity<Scene.Data> {
   /* -------------------------------------------- */
 
   /** @override */
-  clone(createData?: Scene.Data, options?: Entity.CreateOptions): Promise<Scene>;
+  clone(createData?: DeepPartial<Scene.Data>, options?: Entity.CreateOptions): Promise<this>;
 
   /** @override */
   static create: Entity.CreateFunction<Scene>;

--- a/types/framework/entities/scene.d.ts
+++ b/types/framework/entities/scene.d.ts
@@ -123,7 +123,16 @@ declare class Scene extends Entity<Scene.Data> {
   clone(createData?: DeepPartial<Scene.Data>, options?: Entity.CreateOptions): Promise<this>;
 
   /** @override */
-  static create: Entity.CreateFunction<Scene>;
+  static create<T extends Scene>(
+    this: ConstructorOf<T>,
+    data: DeepPartial<T['data']>,
+    options?: Entity.CreateOptions
+  ): Promise<T | null>;
+  static create<T extends Scene>(
+    this: ConstructorOf<T>,
+    data: ReadonlyArray<DeepPartial<T['data']>>,
+    options?: Entity.CreateOptions
+  ): Promise<T | T[] | null>;
 
   /** @override */
   update(data: DeepPartial<Scene.Data>, options: Entity.UpdateOptions): Promise<this>;

--- a/types/framework/entities/scene.d.ts
+++ b/types/framework/entities/scene.d.ts
@@ -123,8 +123,7 @@ declare class Scene extends Entity<Scene.Data> {
   clone(createData?: Scene.Data, options?: Entity.CreateOptions): Promise<Scene>;
 
   /** @override */
-  static create(data: DeepPartial<Scene.Data>, options?: Entity.CreateOptions): Promise<Scene | null>;
-  static create(data: DeepPartial<Scene.Data>[], options?: Entity.CreateOptions): Promise<Scene[] | null>;
+  static create: Entity.CreateFunction<Scene>;
 
   /** @override */
   update(data: DeepPartial<Scene.Data>, options: Entity.UpdateOptions): Promise<this>;

--- a/types/framework/entity.d.ts
+++ b/types/framework/entity.d.ts
@@ -301,7 +301,16 @@ declare class Entity<D extends Entity.Data = Entity.Data> {
    * const created: Actor[] | null = await Actor.create(data, {temporary: true}); // Not saved to the database
    * ```
    */
-  static create: Entity.CreateFunction<Entity>;
+  static create<T extends Entity>(
+    this: ConstructorOf<T>,
+    data: DeepPartial<T['data']>,
+    options?: Entity.CreateOptions
+  ): Promise<T | null>;
+  static create<T extends Entity>(
+    this: ConstructorOf<T>,
+    data: ReadonlyArray<DeepPartial<T['data']>>,
+    options?: Entity.CreateOptions
+  ): Promise<T | T[] | null>;
 
   /**
    * Handle a SocketResponse from the server when one or multiple Entities are created
@@ -335,7 +344,16 @@ declare class Entity<D extends Entity.Data = Entity.Data> {
    * const updated = await Entity.update<Actor>(data); // Returns an Array of Entities, updated in the database
    * ```
    */
-  static update: Entity.UpdateFunction<Entity>;
+  static update<T extends Entity>(
+    this: ConstructorOf<T>,
+    data: DeepPartial<T['data']> & { _id: string },
+    options?: Entity.UpdateOptions
+  ): Promise<T | []>;
+  static update<T extends Entity>(
+    this: ConstructorOf<T>,
+    data: ReadonlyArray<DeepPartial<T['data']> & { _id: string }>,
+    options?: Entity.UpdateOptions
+  ): Promise<T | T[]>;
 
   /**
    * Handle a SocketResponse from the server when one or multiple Entities are updated
@@ -380,7 +398,16 @@ declare class Entity<D extends Entity.Data = Entity.Data> {
    * const deleted = await Entity.delete(ids) // Returns an Array of deleted Entities
    * ```
    */
-  static delete: Entity.DeleteFunction<Entity>;
+  static delete<T extends Entity>(
+    this: ConstructorOf<T>,
+    data: string,
+    options?: Entity.DeleteOptions
+  ): Promise<T | null>;
+  static delete<T extends Entity>(
+    this: ConstructorOf<T>,
+    data: ReadonlyArray<string>,
+    options?: Entity.DeleteOptions
+  ): Promise<T | T[] | null>;
 
   /**
    * Handle a SocketResponse from the server when one or multiple Entities are deleted
@@ -778,46 +805,4 @@ declare namespace Entity {
      */
     flags: Record<string, any>;
   }
-
-  type CreateSingleFunction<E extends Entity> = <T extends E>(
-    this: ConstructorOf<T>,
-    data: DeepPartial<T['data']>,
-    options?: CreateOptions
-  ) => Promise<T | null>;
-
-  type CreateArrayFunction<E extends Entity> = <T extends E>(
-    this: ConstructorOf<T>,
-    data: ReadonlyArray<DeepPartial<T['data']>>,
-    options?: CreateOptions
-  ) => Promise<T | T[] | null>;
-
-  type CreateFunction<E extends Entity> = CreateSingleFunction<E> & CreateArrayFunction<E>;
-
-  type UpdateSingleFunction<E extends Entity> = <T extends E>(
-    this: ConstructorOf<T>,
-    data: DeepPartial<T['data']> & { _id: string },
-    options?: UpdateOptions
-  ) => Promise<T | []>;
-
-  type UpdateArrayFunction<E extends Entity> = <T extends E>(
-    this: ConstructorOf<T>,
-    data: ReadonlyArray<DeepPartial<T['data']> & { _id: string }>,
-    options?: UpdateOptions
-  ) => Promise<T | T[]>;
-
-  type UpdateFunction<E extends Entity> = UpdateSingleFunction<E> & UpdateArrayFunction<E>;
-
-  type DeleteSingleFunction<E extends Entity> = <T extends E>(
-    this: ConstructorOf<T>,
-    data: string,
-    options?: DeleteOptions
-  ) => Promise<T | null>;
-
-  type DeleteArrayFunction<E extends Entity> = <T extends E>(
-    this: ConstructorOf<T>,
-    data: ReadonlyArray<string>,
-    options?: DeleteOptions
-  ) => Promise<T | T[] | null>;
-
-  type DeleteFunction<E extends Entity> = DeleteSingleFunction<E> & DeleteArrayFunction<E>;
 }

--- a/types/framework/entity.d.ts
+++ b/types/framework/entity.d.ts
@@ -829,11 +829,14 @@ declare namespace Entity {
 
   type UpdateSingleFunction<E extends Entity> = <T extends E>(
     this: ConstructorOf<T>,
-    data: DeepPartial<T['data']>,
+    data: DeepPartial<T['data']> & { _id: string },
     options?: UpdateOptions
   ) => Promise<T | null>;
 
-  type UpdateArrayFunction<E extends Entity> = <T extends E, D extends ReadonlyArray<DeepPartial<T['data']>>>(
+  type UpdateArrayFunction<E extends Entity> = <
+    T extends E,
+    D extends ReadonlyArray<DeepPartial<T['data']> & { _id: string }>
+  >(
     this: ConstructorOf<T>,
     data: D,
     options?: UpdateOptions

--- a/types/framework/entity.d.ts
+++ b/types/framework/entity.d.ts
@@ -271,14 +271,14 @@ declare class Entity<D extends Entity.Data = Entity.Data> {
    * @param user - The User to test
    * @param action - The name of the action
    * @remarks
-   * args is untyped because of a mismatch between most entites and User that is likely to be fixed in Foundry 0.8.x
+   * args is untyped because of a mismatch between most entities and User that is likely to be fixed in Foundry 0.8.x
    *
    */
   can(...args: any): boolean;
   // TODO: This is intentionally untyped. This is a known issue that will likely be fixed in 0.8.x
 
   /**
-   * Test for whether this Entity can be owned by any non- gamemaster player.
+   * Test for whether this Entity can be owned by any non-gamemaster player.
    */
   get hasPlayerOwner(): boolean;
 
@@ -322,7 +322,7 @@ declare class Entity<D extends Entity.Data = Entity.Data> {
    * @param result  - An Array of created Entity data
    * @param userId  - The id of the requesting User
    */
-  protected static _handleCreate({ request, result, userId }: any): Entity[];
+  protected static _handleCreate<T extends Entity>(this: ConstructorOf<T>, { request, result, userId }: any): T[];
 
   /**
    * Entity- specific actions that should occur when the Entity is first created
@@ -356,7 +356,7 @@ declare class Entity<D extends Entity.Data = Entity.Data> {
    * @param result  - An Array of updated Entity data
    * @param userId  - The id of the requesting User
    */
-  protected static _handleUpdate({ request, result, userId }: any): Entity[];
+  protected static _handleUpdate<T extends Entity>(this: ConstructorOf<T>, { request, result, userId }: any): T[];
 
   /**
    * Entity- specific actions that should occur when the Entity is updated
@@ -401,7 +401,7 @@ declare class Entity<D extends Entity.Data = Entity.Data> {
    * @param result - An Array of deleted Entity ids
    * @param userId - The id of the requesting User
    */
-  protected static _handleDelete({ request, result, userId }: any): Entity[];
+  protected static _handleDelete<T extends Entity>(this: ConstructorOf<T>, { request, result, userId }: any): T[];
 
   /**
    * Entity- specific actions that should occur when the Entity is deleted
@@ -414,7 +414,7 @@ declare class Entity<D extends Entity.Data = Entity.Data> {
    *
    * @param options - Options which customize the deletion workflow
    */
-  delete(options?: Entity.DeleteOptions): Promise<Entity>;
+  delete(options?: Entity.DeleteOptions): Promise<this>;
 
   /* -------------------------------------------- */
   /*  Embedded Entity Management                  */

--- a/types/framework/entity.d.ts
+++ b/types/framework/entity.d.ts
@@ -117,14 +117,10 @@ declare class Entity<D extends Entity.Data = Entity.Data> {
   /**
    * Render all of the Application instances which are connected to this Entity by calling their respective
    * {@link Application#render} methods.
-   * @param force - Force rendering
+   * @param force   - Force rendering
    * @param context - Optional context
    */
   render(force: boolean, context: any): void;
-
-  /* -------------------------------------------- */
-  /*  Properties                                  */
-  /* -------------------------------------------- */
 
   /**
    * Return a reference to the EntityCollection instance which stores Entity instances of this type. This property is
@@ -226,14 +222,10 @@ declare class Entity<D extends Entity.Data = Entity.Data> {
    */
   get limited(): boolean;
 
-  /* -------------------------------------------- */
-  /*  Permission Controls                         */
-  /* -------------------------------------------- */
-
   /**
    * Return an array of User entities who have a certain permission level or greater to the Entity.
    * @param permission - The permission level or level name to test
-   * @param exact - Tests for an exact permission level match, by default this method tests for
+   * @param exact      - Tests for an exact permission level match, by default this method tests for
    *        an equal or greater permission level
    * @returns An array of User entities who match the permission level
    */
@@ -241,10 +233,9 @@ declare class Entity<D extends Entity.Data = Entity.Data> {
 
   /**
    * Test whether a provided User a specific permission level (or greater) over the Entity instance
-   * @param user - The user to test for permission
+   * @param user       - The user to test for permission
    * @param permission - The permission level or level name to test
-   * @param exact - Tests for an exact permission level match, by default this method tests for
-   *                                      an equal or greater permission level.
+   * @param exact      - Tests for an exact permission level match, by default this method tests for an equal or greater permission level.
    *
    * @example <caption>Test whether a specific user has a certain permission</caption>
    * ```typescript
@@ -260,7 +251,7 @@ declare class Entity<D extends Entity.Data = Entity.Data> {
 
   /**
    * Test whether a given User has permission to perform some action on this Entity
-   * @param user - The User requesting creation
+   * @param user   - The User requesting creation
    * @param action - The attempted action
    * @param target - The targeted Entity
    */
@@ -268,7 +259,7 @@ declare class Entity<D extends Entity.Data = Entity.Data> {
 
   /**
    * Test whether a given User has permission to perform some action on this Entity
-   * @param user - The User to test
+   * @param user   - The User to test
    * @param action - The name of the action
    * @remarks
    * args is untyped because of a mismatch between most entities and User that is likely to be fixed in Foundry 0.8.x
@@ -282,10 +273,6 @@ declare class Entity<D extends Entity.Data = Entity.Data> {
    */
   get hasPlayerOwner(): boolean;
 
-  /* -------------------------------------------- */
-  /*  Entity Management Methods                   */
-  /* -------------------------------------------- */
-
   /**
    * Activate the Socket event listeners used to receive responses from events which modify database documents
    * @param socket - The active game socket
@@ -297,7 +284,7 @@ declare class Entity<D extends Entity.Data = Entity.Data> {
    * Data may be provided as a single object to create one Entity, or as an Array of Objects.
    * Entities may be temporary (unsaved to the database) by passing the temporary option as true.
    *
-   * @param data - A Data object or array of Data
+   * @param data    - A Data object or array of Data
    * @param options - Additional options which customize the creation workflow
    *
    * @example
@@ -333,7 +320,7 @@ declare class Entity<D extends Entity.Data = Entity.Data> {
    * Update one or multiple existing entities using provided input data.
    * Data may be provided as a single object to update one Entity, or as an Array of Objects.
    *
-   * @param data - A Data object or array of Data. Each element must contain the _id of an existing Entity.
+   * @param data    - A Data object or array of Data. Each element must contain the _id of an existing Entity.
    * @param options - Additional options which customize the update workflow
    *
    * @example
@@ -359,7 +346,7 @@ declare class Entity<D extends Entity.Data = Entity.Data> {
   protected static _handleUpdate<T extends Entity>(this: ConstructorOf<T>, { request, result, userId }: any): T[];
 
   /**
-   * Entity- specific actions that should occur when the Entity is updated
+   * Entity-specific actions that should occur when the Entity is updated
    */
   protected _onUpdate(data: DeepPartial<D>, options: Entity.UpdateOptions, userId: string): void;
 
@@ -368,7 +355,7 @@ declare class Entity<D extends Entity.Data = Entity.Data> {
    * Data must be provided as a single object which updates the Entity data.
    * @see Entity.update
    *
-   * @param data - A Data object which updates the Entity
+   * @param data    - A Data object which updates the Entity
    * @param options - Additional options which customize the update workflow
    */
   update(data: DeepPartial<D>, options?: Entity.UpdateOptions): Promise<this>;
@@ -377,7 +364,7 @@ declare class Entity<D extends Entity.Data = Entity.Data> {
    * Delete one or multiple existing entities using provided ids.
    * The target ids may be a single string or an Array of strings.
    *
-   * @param data - A single id or Array of ids
+   * @param data    - A single id or Array of ids
    * @param options - Additional options which customize the deletion workflow
    *
    *
@@ -398,8 +385,8 @@ declare class Entity<D extends Entity.Data = Entity.Data> {
   /**
    * Handle a SocketResponse from the server when one or multiple Entities are deleted
    * @param request - The initial request
-   * @param result - An Array of deleted Entity ids
-   * @param userId - The id of the requesting User
+   * @param result  - An Array of deleted Entity ids
+   * @param userId  - The id of the requesting User
    */
   protected static _handleDelete<T extends Entity>(this: ConstructorOf<T>, { request, result, userId }: any): T[];
 
@@ -416,16 +403,12 @@ declare class Entity<D extends Entity.Data = Entity.Data> {
    */
   delete(options?: Entity.DeleteOptions): Promise<this>;
 
-  /* -------------------------------------------- */
-  /*  Embedded Entity Management                  */
-  /* -------------------------------------------- */
-
   /**
    * Get an Embedded Entity by it's id from a named collection in the parent Entity.
    *
    * @param embeddedName - The name of the Embedded Entity type to retrieve
-   * @param id - The numeric ID of the child to retrieve
-   * @param strict - Throw an Error if the requested id does not exist, otherwise return null. Default false.
+   * @param id           - The numeric ID of the child to retrieve
+   * @param strict       - Throw an Error if the requested id does not exist, otherwise return null. Default false.
    */
   getEmbeddedEntity(embeddedName: string, id: string, { strict }?: { strict?: boolean }): any;
 
@@ -435,8 +418,8 @@ declare class Entity<D extends Entity.Data = Entity.Data> {
    * Entities may be temporary (unsaved to the database) by passing the temporary option as true.
    *
    * @param embeddedName - The name of the Embedded Entity class to create
-   * @param data - A Data object or an Array of Data objects to create
-   * @param options - Additional creation options which modify the request
+   * @param data         - A Data object or an Array of Data objects to create
+   * @param options      - Additional creation options which modify the request
    *
    * @example
    * ```typescript
@@ -463,8 +446,8 @@ declare class Entity<D extends Entity.Data = Entity.Data> {
   /**
    * Handle a SocketResponse from the server when one or multiple Embedded Entities are created
    * @param request - The initial request
-   * @param result - An Array of created Entity data
-   * @param userId - The id of the requesting User
+   * @param result  - An Array of created Entity data
+   * @param userId  - The id of the requesting User
    */
   protected static _handleCreateEmbeddedEntity({ request, result, userId }: any): any[];
 
@@ -482,8 +465,8 @@ declare class Entity<D extends Entity.Data = Entity.Data> {
    * Data may be provided as a single object to update one Entity, or as an Array of Objects.
    *
    * @param embeddedName - The name of the Embedded Entity class to create
-   * @param data - A Data object or array of Data. Each element must contain the _id of an existing Entity.
-   * @param options - Additional options which customize the update workflow
+   * @param data         - A Data object or array of Data. Each element must contain the _id of an existing Entity.
+   * @param options      - Additional options which customize the update workflow
    *
    * @example
    * ```typescript
@@ -514,8 +497,8 @@ declare class Entity<D extends Entity.Data = Entity.Data> {
   /**
    * Handle a SocketResponse from the server when one or multiple Embedded Entities are updated
    * @param request - The initial request
-   * @param result - An Array of updated Entity data
-   * @param userId - The id of the requesting User
+   * @param result  - An Array of updated Entity data
+   * @param userId  - The id of the requesting User
    */
   protected static _handleUpdateEmbeddedEntity({ request, result, userId }: any): any[];
 
@@ -539,8 +522,8 @@ declare class Entity<D extends Entity.Data = Entity.Data> {
    * Data may be provided as a single id to delete one object or as an Array of string ids.
    *
    * @param embeddedName - The name of the Embedded Entity class to create
-   * @param data - A Data object or array of Data. Each element must contain the _id of an existing Entity.
-   * @param options - Additional options which customize the update workflow
+   * @param data         - A Data object or array of Data. Each element must contain the _id of an existing Entity.
+   * @param options      - Additional options which customize the update workflow
    *
    * @example
    * ```typescript
@@ -567,8 +550,8 @@ declare class Entity<D extends Entity.Data = Entity.Data> {
   /**
    * Handle a SocketResponse from the server when one or multiple Embedded Entities are deleted
    * @param request - The initial request
-   * @param result - An Array of deleted EmbeddedEntity ids
-   * @param userId - The id of the requesting User
+   * @param result  - An Array of deleted EmbeddedEntity ids
+   * @param userId  - The id of the requesting User
    */
   protected static _handleDeleteEmbeddedEntity({ request, result, userId }: any): any[];
 
@@ -593,18 +576,14 @@ declare class Entity<D extends Entity.Data = Entity.Data> {
     context?: any
   ): void;
 
-  /* -------------------------------------------- */
-  /*  Data Flags                                  */
-  /* -------------------------------------------- */
-
   /**
    * Get the value of a "flag" for this Entity
    * See the setFlag method for more details on flags
    *
    * @param scope - The flag scope which namespaces the key
-   * @param key - The flag key
+   * @param key   - The flag key
    */
-  getFlag(scope: string, key: string): any;
+  getFlag(scope: string, key: string): unknown;
 
   /**
    * Assign a "flag" to this Entity.
@@ -620,22 +599,18 @@ declare class Entity<D extends Entity.Data = Entity.Data> {
    * Flag values can assume almost any data type. Setting a flag value to null will delete that flag.
    *
    * @param scope - The flag scope which namespaces the key
-   * @param key - The flag key
+   * @param key   - The flag key
    * @param value - The flag value
    *
    */
-  setFlag(scope: string, key: string, value: any): Promise<Entity>;
+  setFlag(scope: string, key: string, value: unknown): Promise<this>;
 
   /**
    * Remove a flag assigned to the Entity
    * @param scope - The flag scope which namespaces the key
-   * @param key - The flag key
+   * @param key   - The flag key
    */
-  unsetFlag(scope: string, key: string): Promise<Entity>;
-
-  /* -------------------------------------------- */
-  /*  Sorting                                     */
-  /* -------------------------------------------- */
+  unsetFlag(scope: string, key: string): Promise<this>;
 
   /**
    * Sort this Entity relative a target by providing the target, an Array of siblings and other options.
@@ -656,10 +631,6 @@ declare class Entity<D extends Entity.Data = Entity.Data> {
     updateData?: any;
   }): Promise<void>;
 
-  /* -------------------------------------------- */
-  /*  Saving and Loading                          */
-  /* -------------------------------------------- */
-
   /**
    * Clone an Entity, creating a new Entity using the current data as well as provided creation overrides.
    *
@@ -667,7 +638,7 @@ declare class Entity<D extends Entity.Data = Entity.Data> {
    * @param options - Additional creation options passed to the Entity.create method
    * @returns A Promise which resolves to the created clone Entity
    */
-  clone(createData?: D, options?: Entity.CreateOptions): Promise<Entity>;
+  clone(createData?: DeepPartial<D>, options?: Entity.CreateOptions): Promise<this>;
 
   /**
    * Serializing an Entity should simply serialize it's inner data, not the entire instance
@@ -687,13 +658,15 @@ declare class Entity<D extends Entity.Data = Entity.Data> {
    *
    * @param data - The data object extracted from a DataTransfer event
    */
-  static fromDropData(data: any): Entity;
+  static fromDropData<T extends Entity>(this: ConstructorOf<T>, data: { data: DeepPartial<T['data']> }): Promise<T>;
+  static fromDropData<T extends Entity>(this: ConstructorOf<T>, data: { pack: string }): Promise<T | undefined | null>;
+  static fromDropData<T extends Entity>(this: ConstructorOf<T>, data: { id: string }): Promise<T | null>;
 
   /**
    * Import data and update this entity
    * @param json - JSON data string
    */
-  importFromJSON(json: string): Promise<Entity>;
+  importFromJSON(json: string): Promise<this>;
 
   /**
    * Render an import dialog for updating the data related to this Entity through an exported JSON file
@@ -704,9 +677,8 @@ declare class Entity<D extends Entity.Data = Entity.Data> {
    * Transform the Entity data to be stored in a Compendium pack.
    * Remove any features of the data which are world- specific.
    * This function is asynchronous in case any complex operations are required prior to exporting.
-   *
    */
-  toCompendium(): Promise<D>;
+  toCompendium(): Promise<Duplicated<D>>;
 
   /**
    * Provide a Dialog form to create a new Entity of this type.
@@ -813,17 +785,11 @@ declare namespace Entity {
     options?: CreateOptions
   ) => Promise<T | null>;
 
-  type CreateArrayFunction<E extends Entity> = <T extends E, D extends ReadonlyArray<DeepPartial<T['data']>>>(
+  type CreateArrayFunction<E extends Entity> = <T extends E>(
     this: ConstructorOf<T>,
-    data: D,
+    data: ReadonlyArray<DeepPartial<T['data']>>,
     options?: CreateOptions
-  ) => D extends never[]
-    ? Promise<[]>
-    : IsReadonlyArrayWithKey<D, 0> extends true
-    ? IsReadonlyArrayWithKey<D, 1> extends true
-      ? Promise<T[] | null>
-      : Promise<T | null>
-    : Promise<T | T[] | null>;
+  ) => Promise<T | T[] | null>;
 
   type CreateFunction<E extends Entity> = CreateSingleFunction<E> & CreateArrayFunction<E>;
 
@@ -831,22 +797,13 @@ declare namespace Entity {
     this: ConstructorOf<T>,
     data: DeepPartial<T['data']> & { _id: string },
     options?: UpdateOptions
-  ) => Promise<T | null>;
+  ) => Promise<T | []>;
 
-  type UpdateArrayFunction<E extends Entity> = <
-    T extends E,
-    D extends ReadonlyArray<DeepPartial<T['data']> & { _id: string }>
-  >(
+  type UpdateArrayFunction<E extends Entity> = <T extends E>(
     this: ConstructorOf<T>,
-    data: D,
+    data: ReadonlyArray<DeepPartial<T['data']> & { _id: string }>,
     options?: UpdateOptions
-  ) => D extends never[]
-    ? Promise<[]>
-    : IsReadonlyArrayWithKey<D, 0> extends true
-    ? IsReadonlyArrayWithKey<D, 1> extends true
-      ? Promise<T[] | null>
-      : Promise<T | null>
-    : Promise<T | T[] | null>;
+  ) => Promise<T | T[]>;
 
   type UpdateFunction<E extends Entity> = UpdateSingleFunction<E> & UpdateArrayFunction<E>;
 
@@ -856,17 +813,11 @@ declare namespace Entity {
     options?: DeleteOptions
   ) => Promise<T | null>;
 
-  type DeleteArrayFunction<E extends Entity> = <T extends E, D extends ReadonlyArray<string>>(
+  type DeleteArrayFunction<E extends Entity> = <T extends E>(
     this: ConstructorOf<T>,
-    data: D,
+    data: ReadonlyArray<string>,
     options?: DeleteOptions
-  ) => D extends never[]
-    ? Promise<[]>
-    : IsReadonlyArrayWithKey<D, 0> extends true
-    ? IsReadonlyArrayWithKey<D, 1> extends true
-      ? Promise<T[] | null>
-      : Promise<T | null>
-    : Promise<T | T[] | null>;
+  ) => Promise<T | T[] | null>;
 
   type DeleteFunction<E extends Entity> = DeleteSingleFunction<E> & DeleteArrayFunction<E>;
 }

--- a/types/typesUtils.d.ts
+++ b/types/typesUtils.d.ts
@@ -58,10 +58,3 @@ type OmitAssignableFromType<T extends object, U> = { [k in keyof T as U extends 
  * @internal
  */
 type OmitNotAssignableFromType<T extends object, U> = { [k in keyof T as U extends T[k] ? k : never]: T[k] };
-
-/**
- * `true` if `T` is a `ReadonlyArray` with compile time known length of at least `N + 1`, `false` otherwise.
- * @typeParam T - The `ReadonlyArray` to check.
- * @typeParam N - The key to check for existence in `T`.
- */
-type IsReadonlyArrayWithKey<T extends ReadonlyArray<any>, N extends number> = `${N}` extends keyof T ? true : false;


### PR DESCRIPTION
This PR improves the type definitions of `Entity.create`, `Entity.update`m and `Entity.delete` in the following ways:
- Correctly infer the return type if an array with one element is passed.
- Automatically infer the entity type based on the concrete class the method is called on (i.e. there is no more need to explicitly specify the concrete entity class as type parameter).

There are also some other small improvements to `Entity`