### PR TITLE
Improve embedded entity related methods

### DIFF
--- a/types/framework/entities/combat.d.ts
+++ b/types/framework/entities/combat.d.ts
@@ -44,7 +44,7 @@ declare class CombatEncounters extends EntityCollection<Combat> {
  * The Combat Entity defines a particular combat encounter which can occur within the game session
  * Combat instances belong to the CombatEncounters collection
  */
-declare class Combat extends Entity<Combat.Data> {
+declare class Combat extends Entity<Combat.Data, Combat.EmbeddedEntityConfig> {
   /**
    * Track the sorted turn order of this combat encounter
    */
@@ -263,55 +263,70 @@ declare class Combat extends Entity<Combat.Data> {
    */
   createCombatant<U>(
     data: Expanded<U> extends DeepPartial<Combat.Combatant> ? U : DeepPartial<Combat.Combatant>,
-    options?: any
-  ): Promise<Combat.Combatant>;
+    options?: Entity.CreateOptions
+  ): Promise<Combat.Combatant | null>;
   createCombatant<U>(
     data: Expanded<U> extends DeepPartial<Combat.Combatant> ? U[] : DeepPartial<Combat.Combatant>[],
-    options?: any
-  ): Promise<Combat.Combatant[]>;
+    options?: Entity.CreateOptions
+  ): Promise<Combat.Combatant | Combat.Combatant[] | null>;
 
   /** @override */
   updateCombatant<U>(
-    data: (Expanded<U> extends DeepPartial<Combat.Combatant> ? U : DeepPartial<Combat.Combatant>) & { _id: string },
-    options?: any
-  ): Promise<Combat.Combatant>;
+    data: (Expanded<U> extends DeepPartial<Combat.Combatant> ? U & { _id: string } : DeepPartial<Combat.Combatant>) & {
+      _id: string;
+    },
+    options?: Entity.UpdateOptions
+  ): Promise<Combat.Combatant | []>;
   updateCombatant<U>(
-    data: ((Expanded<U> extends DeepPartial<Combat.Combatant> ? U : DeepPartial<Combat.Combatant>) & { _id: string })[],
-    options?: any
-  ): Promise<Combat.Combatant[]>;
+    data: ((Expanded<U> extends DeepPartial<Combat.Combatant> ? U & { _id: string } : DeepPartial<Combat.Combatant>) & {
+      _id: string;
+    })[],
+    options?: Entity.UpdateOptions
+  ): Promise<Combat.Combatant | Combat.Combatant[]>;
 
   /** @override */
-  deleteCombatant(id: string, options?: any): Promise<Combat.Combatant>;
-  deleteCombatant(id: string[], options?: any): Promise<Combat.Combatant[]>;
+  deleteCombatant(id: string, options?: Entity.DeleteOptions): Promise<Combat.Combatant | []>;
+  deleteCombatant(id: string[], options?: Entity.DeleteOptions): Promise<Combat.Combatant | Combat.Combatant[]>;
 
   /* -------------------------------------------- */
   /*  Socket Events and Handlers                  */
   /* -------------------------------------------- */
 
   /** @override */
-  protected _onCreate(data: Combat.Data, options: any, userId: string): void;
+  protected _onCreate(data: Combat.Data, options: Entity.CreateOptions, userId: string): void;
 
   /** @override */
-  protected _onUpdate(data: DeepPartial<Combat.Data>, options: Entity.UpdateOptions, userId: string): void;
+  protected _onUpdate(
+    data: DeepPartial<Combat.Data> & { _id: string },
+    options: Entity.UpdateOptions,
+    userId: string
+  ): void;
 
   /** @override */
   protected _onDelete(options: Entity.DeleteOptions, userId: string): void;
 
   /** @override */
   protected _onDeleteEmbeddedEntity(
-    embeddedName: string,
+    embeddedName: 'Combatant',
     child: Combat.Combatant,
-    options: Entity.UpdateOptions,
+    options: Entity.DeleteOptions,
     userId: string
   ): void;
 
   /** @override */
   protected _onModifyEmbeddedEntity(
-    embeddedName: string,
-    changes: any[],
-    options: any,
+    embeddedName: 'Combatant',
+    changes: Combat.Combatant[],
+    options: Entity.CreateOptions & { temporary: boolean; renderSheet: boolean },
     userId: string,
-    context?: any
+    context: { action: 'create' }
+  ): void;
+  protected _onModifyEmbeddedEntity(
+    embeddedName: 'Combatant',
+    changes: (DeepPartial<Combat.Combatant> & { _id: string })[] | string[],
+    options: (Entity.UpdateOptions & { diff: boolean }) | Entity.DeleteOptions,
+    userId: string,
+    context: { action: 'update' }
   ): void;
 }
 
@@ -364,4 +379,8 @@ declare namespace Combat {
         tokenId: string;
       }
   );
+
+  type EmbeddedEntityConfig = {
+    Combatant: Combatant;
+  };
 }

--- a/types/framework/entities/item.d.ts
+++ b/types/framework/entities/item.d.ts
@@ -54,7 +54,7 @@ declare class Items extends EntityCollection<Item> {
 
  * @typeParam D - Item.data field. Type should extend Item.Data
  */
-declare class Item<D extends Item.Data = Item.Data<any>> extends Entity<D> {
+declare class Item<D extends Item.Data = Item.Data<any>> extends Entity<D, Item.EmbeddedEntityConfig> {
   /**
    * ActiveEffects are prepared by the Item.prepareEmbeddedEntities() method
    */
@@ -171,4 +171,8 @@ declare namespace Item {
     sort: number;
     type: string;
   }
+
+  type EmbeddedEntityConfig = {
+    ActiveEffect: ActiveEffect.Data;
+  };
 }

--- a/types/framework/entities/playlist.d.ts
+++ b/types/framework/entities/playlist.d.ts
@@ -19,7 +19,7 @@ declare class Playlists extends EntityCollection<Playlist> {
   protected _onUpdateScene(scene: Scene, data: Scene.Data, options: Entity.UpdateOptions): void;
 }
 
-declare class Playlist extends Entity<Playlist.Data> {
+declare class Playlist extends Entity<Playlist.Data, Playlist.EmbeddedEntityConfig> {
   /**
    * Each sound which is played within the Playlist has a created Howl instance.
    * The keys of this object are the sound IDs and the values are the Howl instances.
@@ -125,40 +125,51 @@ declare class Playlist extends Entity<Playlist.Data> {
   /* -------------------------------------------- */
 
   /** @override */
-  protected _onUpdate(data: DeepPartial<Playlist.Data>, options: Entity.UpdateOptions, userId: string): void;
+  protected _onUpdate(
+    data: DeepPartial<Playlist.Data> & { _id: string },
+    options: Entity.UpdateOptions,
+    userId: string
+  ): void;
 
   /** @override */
   protected _onCreateEmbeddedEntity(
-    embeddedName: string,
+    embeddedName: 'PlaylistSound',
     child: Playlist.Sound,
-    options: Entity.UpdateOptions,
+    options: Entity.UpdateOptions & { temporary: boolean; renderSheet: boolean },
     userId: string
   ): void;
 
   /** @override */
   protected _onUpdateEmbeddedEntity(
-    embeddedName: string,
+    embeddedName: 'PlaylistSound',
     child: Playlist.Sound,
-    updateData: any,
-    options: Entity.UpdateOptions,
+    updateData: DeepPartial<Playlist.Sound> & { _id: string },
+    options: Entity.UpdateOptions & { diff: boolean },
     userId: string
   ): void;
 
   /** @override */
   protected _onDeleteEmbeddedEntity(
-    embeddedName: string,
+    embeddedName: 'PlaylistSound',
     child: Playlist.Sound,
-    options: Entity.UpdateOptions,
+    options: Entity.DeleteOptions,
     userId: string
   ): void;
 
   /** @override */
   protected _onModifyEmbeddedEntity(
-    embeddedName: string,
-    changes: any[],
-    options: any,
+    embeddedName: 'PlaylistSound',
+    changes: Playlist.Sound[],
+    options: Entity.CreateOptions & { temporary: boolean; renderSheet: boolean },
     userId: string,
-    context?: any
+    context: { action: 'create' }
+  ): void;
+  protected _onModifyEmbeddedEntity(
+    embeddedName: 'PlaylistSound',
+    changes: (DeepPartial<Playlist.Sound> & { _id: string })[] | string[],
+    options: (Entity.UpdateOptions & { diff: boolean }) | Entity.DeleteOptions,
+    userId: string,
+    context: { action: 'update' }
   ): void;
 
   /* -------------------------------------------- */
@@ -189,4 +200,8 @@ declare namespace Playlist {
     sort: number;
     sounds: Sound[];
   }
+
+  type EmbeddedEntityConfig = {
+    PlaylistSound: Sound;
+  };
 }

--- a/types/framework/entities/rollTable.d.ts
+++ b/types/framework/entities/rollTable.d.ts
@@ -21,7 +21,7 @@ declare class RollTables extends EntityCollection<RollTable> {
   static registerSettings(): void;
 }
 
-declare class RollTable extends Entity<RollTable.Data> {
+declare class RollTable extends Entity<RollTable.Data, RollTable.EmbeddedEntityConfig> {
   /** @override */
   static get config(): Entity.Config<RollTable>;
 
@@ -162,7 +162,7 @@ declare class RollTable extends Entity<RollTable.Data> {
    * @param value - The rolled value
    * @returns An Array of results
    */
-  protected _getResultsForRoll(value: number): any[];
+  protected _getResultsForRoll(value: number): RollTable.Result[];
 
   /**
    * Get a string representation for the result which (if possible) will be a dynamic link or otherwise plain text
@@ -175,13 +175,23 @@ declare class RollTable extends Entity<RollTable.Data> {
   /*  Table Result Management Methods             */
   /* -------------------------------------------- */
 
-  getTableResult(id: string): any; // TODO EmbeddedTableResult
+  getTableResult(id: string): RollTable.Result | null;
 
   /** @override */
-  protected _onCreateEmbeddedEntity(embeddedName: string, child: any, options: any, userId: string): void;
+  protected _onCreateEmbeddedEntity(
+    embeddedName: 'TableResult',
+    child: RollTable.Result,
+    options: Entity.CreateOptions & { temporary: boolean; renderSheet: boolean },
+    userId: string
+  ): void;
 
   /** @override */
-  protected _onDeleteEmbeddedEntity(embeddedName: string, child: any, options: any, userId: string): void;
+  protected _onDeleteEmbeddedEntity(
+    embeddedName: 'TableResult',
+    child: RollTable.Result,
+    options: Entity.DeleteOptions,
+    userId: string
+  ): void;
 
   /* -------------------------------------------- */
   /*  Importing and Exporting                     */
@@ -223,4 +233,8 @@ declare namespace RollTable {
     weight: number;
     _id: string;
   }
+
+  type EmbeddedEntityConfig = {
+    TableResult: Result;
+  };
 }


### PR DESCRIPTION
This PR adjusts `Entity` to take a generic parameter that configures which embedded entities are available in the entity and of which types they are. The related methods are typed accordingly. It also adjusts deriving classes to use this pattern.