### PR TITLE
Add tokens to canvas global

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -136,6 +136,7 @@ import './types/pixi/preciseText';
 import './types/pixi/quadtree';
 import './types/pixi/sightLayer';
 import './types/pixi/textureLoader';
+import './types/pixi/tokenLayer';
 
 import './types/pixi/helpers/controlIcon';
 import './types/pixi/helpers/ray';

--- a/types/game.d.ts
+++ b/types/game.d.ts
@@ -4,7 +4,7 @@
  * - `/stream`: as `{ ready: false }`
  * @defaultValue `null`
  */
-declare let canvas: Canvas | null;
+declare let canvas: Canvas | { ready: false } | null;
 
 declare let game: Game;
 

--- a/types/game.d.ts
+++ b/types/game.d.ts
@@ -4,7 +4,7 @@
  * - `/stream`: as `{ ready: false }`
  * @defaultValue `null`
  */
-declare let canvas: Canvas | { ready: boolean } | null;
+declare let canvas: Canvas | null;
 
 declare let game: Game;
 

--- a/types/pixi/canvas.d.ts
+++ b/types/pixi/canvas.d.ts
@@ -26,6 +26,8 @@ declare class Canvas {
 
   stage: PIXI.Container;
 
+  tokens: TokenLayer;
+
   hud: HeadsUpDisplay;
 
   id: null;

--- a/types/pixi/tokenLayer.d.ts
+++ b/types/pixi/tokenLayer.d.ts
@@ -1,0 +1,1 @@
+declare class TokenLayer extends PlaceablesLayer<Token> {}


### PR DESCRIPTION
Adds the bare minimum types for `canvas.tokens` on the global scope so.

Also removes the `{ ready: boolean }` type from the global `canvas`. Canvas is either a Canvas (which already has ready: boolean) or it is null upon initial declaration. Leave it up to the system/module developer to evaluate ready or not.