### PR TITLE
Roll fixup

### DIFF
--- a/foundry/roll.d.ts
+++ b/foundry/roll.d.ts
@@ -284,15 +284,15 @@ declare class Roll<D extends Record<string, unknown> = {}> {
    */
   toMessage<T extends Record<string, unknown> = {}>(
     messageData?: T,
-    { rollMode, create }?: { rollMode?: keyof typeof CONST.DICE_ROLL_MODES | null; create: true }
+    { rollMode, create }?: { rollMode?: Const.DiceRollModes | null; create: true }
   ): Promise<ChatMessage>;
   toMessage<T extends Record<string, unknown> = {}>(
     messageData?: T,
-    { rollMode, create }?: { rollMode?: keyof typeof CONST.DICE_ROLL_MODES | null; create: false }
+    { rollMode, create }?: { rollMode?: Const.DiceRollModes | null; create: false }
   ): Roll.MessageData<T>;
   toMessage<T extends Record<string, unknown> = {}>(
     messageData?: T,
-    { rollMode, create }?: { rollMode?: keyof typeof CONST.DICE_ROLL_MODES | null; create: boolean }
+    { rollMode, create }?: { rollMode?: Const.DiceRollModes | null; create: boolean }
   ): Promise<ChatMessage> | Roll.MessageData<T>;
 
   /**


### PR DESCRIPTION
Previously, this would have defined `rollMode` to be of type `'PUBLIC' | 'PRIVATE' | 'BLIND' | 'SELF' | null`, which is incorrect. We need the values instead of the keys.