### PR TITLE
Update JournalSheet to 0.7.9

### DIFF
--- a/foundry/applications/formApplications/baseEntitySheets/journalSheet.d.ts
+++ b/foundry/applications/formApplications/baseEntitySheets/journalSheet.d.ts
@@ -11,6 +11,8 @@ declare class JournalSheet<
    */
   constructor(entity: O, options?: JournalSheet.Options);
 
+  protected _sheetMode: JournalSheet.SheetMode | null;
+
   /** @override */
   static get defaultOptions(): JournalSheet.Options;
 
@@ -22,8 +24,6 @@ declare class JournalSheet<
 
   /** @override */
   get title(): string;
-
-  protected _sheetMode: JournalSheet.SheetMode | null;
 
   /** @override */
   getData(options?: Application.RenderOptions): Promise<D> | D;

--- a/foundry/applications/formApplications/baseEntitySheets/journalSheet.d.ts
+++ b/foundry/applications/formApplications/baseEntitySheets/journalSheet.d.ts
@@ -63,8 +63,5 @@ declare namespace JournalSheet {
     folders: Folder[];
   }
 
-  enum SheetMode {
-    text = 'text',
-    image = 'image'
-  }
+  type SheetMode = 'text' | 'image';
 }

--- a/foundry/applications/formApplications/baseEntitySheets/journalSheet.d.ts
+++ b/foundry/applications/formApplications/baseEntitySheets/journalSheet.d.ts
@@ -1,23 +1,70 @@
 /**
  * The JournalEntry Configuration Sheet
- *
- * @param entity - The JournalEntry instance which is being edited
- * @param options - Application options
  */
-declare class JournalSheet extends BaseEntitySheet {
-  /**
-   * Provide a unique CSS ID for Entity Sheets
-   */
+declare class JournalSheet<
+  D extends object = BaseEntitySheet.Data<JournalEntry>,
+  O extends JournalEntry = D extends BaseEntitySheet.Data<infer T> ? T : JournalEntry
+> extends BaseEntitySheet<D, O> {
+  constructor(object: O, options?: JournalSheet.Options);
+
+  /** @override */
+  static get defaultOptions(): JournalSheet.Options;
+
+  /** @override */
   get id(): string;
 
-  /**
-   * Suppress the JournalEntry title when an image is shown to players whom do not have at least limited permission
-   */
+  /** @override */
+  get template(): string;
+
+  /** @override */
   get title(): string;
 
+  /** @override */
+  getData(options?: Application.RenderOptions): Promise<D> | D;
+
   /**
-   * @param options - (unused)
-   * @override
+   * Guess the default view mode for the sheet based on the player's permissions to the Entry
    */
-  getData(options?: any): BaseEntitySheet.Data<Entity>;
+  protected _inferDefaultMode(): JournalSheet.SheetMode;
+
+  /** @override */
+  protected _render(force?: boolean, options?: JournalSheet.RenderOptions): Promise<void>;
+
+  /** @override */
+  protected _getHeaderButtons(): Application.HeaderButton[];
+
+  /** @override */
+  protected _updateObject(event: Event, formData: object): Promise<O>;
+
+  /**
+   * Handle requests to switch the rendered mode of the Journal Entry sheet
+   * Save the form before triggering the show request, in case content has changed
+   */
+  protected _onSwapMode(event: Event, mode: JournalSheet.SheetMode): Promise<void>;
+
+  /**
+   * Handle requests to show the referenced Journal Entry to other Users
+   * Save the form before triggering the show request, in case content has changed
+   */
+  protected _onShowPlayers(event: Event): Promise<void>;
+}
+
+declare namespace JournalSheet {
+  interface RenderOptions extends Application.RenderOptions {
+    sheetMode: SheetMode;
+  }
+
+  interface Options extends BaseEntitySheet.Options {
+    sheetMode: SheetMode;
+  }
+
+  interface Data<O extends JournalEntry = JournalEntry> extends BaseEntitySheet.Data<O> {
+    image: string;
+    folders: Folder[];
+  }
+
+  enum SheetMode {
+    text = 'text',
+    image = 'image'
+  }
 }

--- a/foundry/applications/formApplications/baseEntitySheets/journalSheet.d.ts
+++ b/foundry/applications/formApplications/baseEntitySheets/journalSheet.d.ts
@@ -5,7 +5,11 @@ declare class JournalSheet<
   D extends object = BaseEntitySheet.Data<JournalEntry>,
   O extends JournalEntry = D extends BaseEntitySheet.Data<infer T> ? T : JournalEntry
 > extends BaseEntitySheet<D, O> {
-  constructor(object: O, options?: JournalSheet.Options);
+  /**
+   * @param entity - The JournalEntry instance which is being edited
+   * @param options - JournalSheet options
+   */
+  constructor(entity: O, options?: JournalSheet.Options);
 
   /** @override */
   static get defaultOptions(): JournalSheet.Options;
@@ -19,13 +23,15 @@ declare class JournalSheet<
   /** @override */
   get title(): string;
 
+  protected _sheetMode: JournalSheet.SheetMode | null;
+
   /** @override */
   getData(options?: Application.RenderOptions): Promise<D> | D;
 
   /**
    * Guess the default view mode for the sheet based on the player's permissions to the Entry
    */
-  protected _inferDefaultMode(): JournalSheet.SheetMode;
+  protected _inferDefaultMode(): JournalSheet.SheetMode | null;
 
   /** @override */
   protected _render(force?: boolean, options?: JournalSheet.RenderOptions): Promise<void>;
@@ -51,11 +57,11 @@ declare class JournalSheet<
 
 declare namespace JournalSheet {
   interface RenderOptions extends Application.RenderOptions {
-    sheetMode: SheetMode;
+    sheetMode?: SheetMode | null;
   }
 
   interface Options extends BaseEntitySheet.Options {
-    sheetMode: SheetMode;
+    sheetMode?: SheetMode | null;
   }
 
   interface Data<O extends JournalEntry = JournalEntry> extends BaseEntitySheet.Data<O> {

--- a/foundry/applications/formApplications/baseEntitySheets/journalSheet.d.ts
+++ b/foundry/applications/formApplications/baseEntitySheets/journalSheet.d.ts
@@ -6,7 +6,7 @@ declare class JournalSheet<
   O extends JournalEntry = D extends BaseEntitySheet.Data<infer T> ? T : JournalEntry
 > extends BaseEntitySheet<D, O> {
   /**
-   * @param entity - The JournalEntry instance which is being edited
+   * @param entity  - The JournalEntry instance which is being edited
    * @param options - JournalSheet options
    */
   constructor(entity: O, options?: JournalSheet.Options);


### PR DESCRIPTION
Hey guys, I would like to help you with types for 0.7.9. I'm not sure if there are any guidelines you want me to follow, so feel free to comment my first attempt on JournalSheet types. I've tried to use `ActorSheet` as main example of how it should look.

I'm not really sure if providing the `SheetMode` enum is good idea - according to foundry code there are only two values, but comments in source code treat those as `{string}`. Let me know what is your opinion in that case.

EDIT: I can see another PR in which you've just removed all enums, so I guess I should remove that SheetMode as well.