### PR TITLE
[ImagePopout] Update types to 0.7.9

### DIFF
--- a/foundry/application.d.ts
+++ b/foundry/application.d.ts
@@ -464,9 +464,9 @@ declare namespace Application {
   interface Position {
     width: number;
     height: number | 'auto';
-    left: number;
-    top: number;
-    scale: number;
+    left?: number;
+    top?: number;
+    scale?: number;
   }
 
   interface RenderOptions {

--- a/foundry/application.d.ts
+++ b/foundry/application.d.ts
@@ -49,7 +49,7 @@ declare class Application {
   /**
    * Track the current position and dimensions of the Application UI
    */
-  position: Application.Position;
+  position: Application.Position | Pick<Application.Position, 'width' | 'height'>;
 
   /**
    * DragDrop workflow handlers which are active for this Application
@@ -464,9 +464,9 @@ declare namespace Application {
   interface Position {
     width: number;
     height: number | 'auto';
-    left?: number;
-    top?: number;
-    scale?: number;
+    left: number;
+    top: number;
+    scale: number;
   }
 
   interface RenderOptions {

--- a/foundry/applications/formApplication.d.ts
+++ b/foundry/applications/formApplication.d.ts
@@ -11,7 +11,7 @@
  */
 declare abstract class FormApplication<
   D extends object = FormApplication.Data<{}>,
-  O extends object = D extends FormApplication.Data<infer T> ? T : {}
+  O = D extends FormApplication.Data<infer T> ? T : {}
 > extends Application {
   /**
    * @param object  - Some object or entity which is the target to be updated.

--- a/foundry/applications/formApplications/imagePopout.d.ts
+++ b/foundry/applications/formApplications/imagePopout.d.ts
@@ -4,7 +4,7 @@
  * Furthermore, this application allows for sharing the display of an image with other connected players.
  *
  * @example
- * ```javascript
+ * ```typescript
  * // Construct the Application instance
  * const ip = new ImagePopout("path/to/image.jpg", {
  *   title: "My Featured Image",
@@ -72,7 +72,7 @@ declare class ImagePopout extends FormApplication<ImagePopout.Data, string> {
   /**
    * @override
    * @remarks Not implemented for ImagePopout
-   * */
+   */
   protected _updateObject(event: Event, formData?: object): never;
 }
 

--- a/foundry/applications/formApplications/imagePopout.d.ts
+++ b/foundry/applications/formApplications/imagePopout.d.ts
@@ -1,10 +1,96 @@
 /**
- * An Image Popout Application
- * Provides optional support to edit the image path being viewed
- * @param image - The image being viewed
- * @param options - Standard Application rendering options
- * @param onUpdate - An optional callback function which should be triggered if the Image path is edited
+ * An Image Popout Application which features a single image in a lightbox style frame.
+ * This popout can also be used as a form, allowing the user to edit an image which is being used.
+ * Furthermore, this application allows for sharing the display of an image with other connected players.
+ *
+ * @example
+ * ```javascript
+ * // Construct the Application instance
+ * const ip = new ImagePopout("path/to/image.jpg", {
+ *   title: "My Featured Image",
+ *   shareable: true,
+ *   entity: game.actors.getName("My Hero")
+ * });
+ *
+ * // Display the image popout
+ * ip.render(true);
+ *
+ * // Share the image with other connected players
+ * ip.share();
+ * ```
  */
-declare class ImagePopout extends FormApplication {
-  _updateObject(event?: Event, formData?: object): Promise<any>; // TODO: Add correct return type
+declare class ImagePopout<D extends object = ImagePopout.Data, O extends string = string> extends FormApplication<
+  D,
+  O
+> {
+  constructor(src: O, options?: ImagePopout.Options);
+
+  protected _related: null;
+
+  /** @override */
+  static get defaultOptions(): ImagePopout.Options;
+
+  /** @override */
+  get title(): string;
+
+  /** @override */
+  getData(options?: Application.RenderOptions): D | Promise<D>;
+
+  /**
+   * Test whether the title of the image popout should be visible to the user
+   */
+  isTitleVisible(): boolean;
+
+  /**
+   * Provide a reference to the Entity referenced by this popout, if one exists
+   */
+  getRelatedObject(): Promise<Entity | object | null>;
+
+  /** @override */
+  protected _render(force?: boolean, options?: Application.RenderOptions): Promise<void>;
+
+  /** @override */
+  protected _getHeaderButtons(): Application.HeaderButton[];
+
+  /**
+   * Determine the correct position and dimensions for the displayed image
+   */
+  protected static getPosition(img: string): ImagePopout.Position;
+
+  /**
+   * Determine the Image dimensions given a certain path
+   */
+  static getImageSize(path: string): Promise<[width: number, height: number]>;
+
+  /**
+   * Share the displayed image with other connected Users
+   */
+  shareImage(): void;
+
+  /**
+   * Handle a received request to display an image.
+   */
+  protected static _handleShareImage(params: { image: string; title: string; uuid: string }): ImagePopout;
+
+  /** @override */
+  protected _updateObject(event: Event, formData?: object): never;
+}
+
+declare namespace ImagePopout {
+  interface Options extends FormApplication.Options {
+    shareable: boolean;
+    uuid: string | null;
+  }
+
+  interface Data<T extends string = string> extends FormApplication.Data<T> {
+    image: string;
+    showTitle: boolean;
+  }
+
+  interface Position {
+    width: number;
+    height: number;
+    top: number;
+    left: number;
+  }
 }

--- a/foundry/applications/formApplications/imagePopout.d.ts
+++ b/foundry/applications/formApplications/imagePopout.d.ts
@@ -19,13 +19,10 @@
  * ip.share();
  * ```
  */
-declare class ImagePopout<D extends object = ImagePopout.Data, O extends string = string> extends FormApplication<
-  D,
-  O
-> {
-  constructor(src: O, options?: ImagePopout.Options);
+declare class ImagePopout extends FormApplication<ImagePopout.Data, string> {
+  constructor(src: string, options?: ImagePopout.Options);
 
-  protected _related: null;
+  protected _related: Entity | object | null;
 
   /** @override */
   static get defaultOptions(): ImagePopout.Options;
@@ -34,7 +31,7 @@ declare class ImagePopout<D extends object = ImagePopout.Data, O extends string 
   get title(): string;
 
   /** @override */
-  getData(options?: Application.RenderOptions): D | Promise<D>;
+  getData(options?: Application.RenderOptions): ImagePopout.Data | Promise<ImagePopout.Data>;
 
   /**
    * Test whether the title of the image popout should be visible to the user
@@ -72,7 +69,10 @@ declare class ImagePopout<D extends object = ImagePopout.Data, O extends string 
    */
   protected static _handleShareImage(params: { image: string; title: string; uuid: string }): ImagePopout;
 
-  /** @override */
+  /**
+   * @override
+   * @remarks Not implemented for ImagePopout
+   * */
   protected _updateObject(event: Event, formData?: object): never;
 }
 

--- a/foundry/applications/formApplications/imagePopout.d.ts
+++ b/foundry/applications/formApplications/imagePopout.d.ts
@@ -31,7 +31,7 @@ declare class ImagePopout extends FormApplication<ImagePopout.Data, string> {
   get title(): string;
 
   /** @override */
-  getData(options?: Application.RenderOptions): ImagePopout.Data | Promise<ImagePopout.Data>;
+  getData(options?: Application.RenderOptions): Promise<ImagePopout.Data>;
 
   /**
    * Test whether the title of the image popout should be visible to the user
@@ -52,7 +52,7 @@ declare class ImagePopout extends FormApplication<ImagePopout.Data, string> {
   /**
    * Determine the correct position and dimensions for the displayed image
    */
-  protected static getPosition(img: string): ImagePopout.Position;
+  protected static getPosition(img: string): Application.Position;
 
   /**
    * Determine the Image dimensions given a certain path
@@ -67,7 +67,15 @@ declare class ImagePopout extends FormApplication<ImagePopout.Data, string> {
   /**
    * Handle a received request to display an image.
    */
-  protected static _handleShareImage(params: { image: string; title: string; uuid: string }): ImagePopout;
+  protected static _handleShareImage({
+    image,
+    title,
+    uuid
+  }: {
+    image: string;
+    title: string;
+    uuid: string;
+  }): ImagePopout;
 
   /**
    * @override
@@ -78,19 +86,34 @@ declare class ImagePopout extends FormApplication<ImagePopout.Data, string> {
 
 declare namespace ImagePopout {
   interface Options extends FormApplication.Options {
+    /**
+     * @defaultValue `'templates/apps/image-popout.html'`
+     */
+    template: string;
+    /**
+     * @defaultValue `['image-popout', 'dark']`
+     */
+    classes: string[];
+    /**
+     * @defaultValue `false`
+     */
+    editable: boolean;
+    /**
+     * @defaultValue `true`
+     */
+    resizable: boolean;
+    /**
+     * @defaultValue `false`
+     */
     shareable: boolean;
+    /**
+     * @defaultValue `null`
+     */
     uuid: string | null;
   }
 
   interface Data<T extends string = string> extends FormApplication.Data<T> {
     image: string;
     showTitle: boolean;
-  }
-
-  interface Position {
-    width: number;
-    height: number;
-    top: number;
-    left: number;
   }
 }


### PR DESCRIPTION
Closes #59 

I changed `O` generic in `FormApplication` to allow primitives as constructor parameter (as suggested by BoltsJ in #59).

Please, let me know if the way I handled the first generic (`D`) is a proper way of doing that. As far as I can see, the `D` generic of `FormApplication` is mostly used for returning type of `getData` method, so I've created `ImagePopout.Data` type with additional fields (pulled out from `ImagePopout.getData` source code). 

Maybe I should make `D` a little bit more strict for `ImagePopoutData` and change it to `D extends ImagePopout.Data = ImagePopout.Data`?

Also note that, according to source code, `_updateObject` is not overridden in `ImagePopout`. Unfortunately, `FormApplication._updateObject` is abstract, so it forces us to `implement it` in some way. In foundry code, it's just method with single exception thrown, so I made `_updateObject` with `never` return type. If you have a pattern for that, let me know.

(I did `npm run lint` before push and there were no errors in changed files)