### PR TITLE
[JournalSheet] Adjust JournalSheet types definitions

### DIFF
--- a/foundry/applications/formApplications/baseEntitySheet.d.ts
+++ b/foundry/applications/formApplications/baseEntitySheet.d.ts
@@ -88,7 +88,7 @@ declare namespace BaseEntitySheet {
     template: string;
 
     /**
-     * @defaultValue {@link Const.EntityPermissions.Limited}
+     * @defaultValue {@link ENTITY_PERMISSIONS.LIMITED}
      */
     viewPermission: Const.EntityPermission;
   }

--- a/foundry/applications/formApplications/baseEntitySheets/journalSheet.d.ts
+++ b/foundry/applications/formApplications/baseEntitySheets/journalSheet.d.ts
@@ -26,7 +26,7 @@ declare class JournalSheet<
   get title(): string;
 
   /** @override */
-  getData(options?: Application.RenderOptions): D;
+  getData(options?: Application.RenderOptions): Promise<D> | D;
 
   /**
    * Guess the default view mode for the sheet based on the player's permissions to the Entry
@@ -86,7 +86,7 @@ declare namespace JournalSheet {
      */
     submitOnClose: boolean;
     /**
-     * @defaultValue {@link Const.EntityPermission.None}
+     * @defaultValue {@link ENTITY_PERMISSIONS.NONE}
      */
     viewPermission: Const.EntityPermission;
     sheetMode?: SheetMode | null;

--- a/foundry/applications/formApplications/baseEntitySheets/journalSheet.d.ts
+++ b/foundry/applications/formApplications/baseEntitySheets/journalSheet.d.ts
@@ -9,7 +9,7 @@ declare class JournalSheet<
    * @param entity  - The JournalEntry instance which is being edited
    * @param options - JournalSheet options
    */
-  constructor(entity: O, options?: JournalSheet.Options);
+  constructor(entity: O, options?: Partial<JournalSheet.Options>);
 
   protected _sheetMode: JournalSheet.SheetMode | null;
 
@@ -26,7 +26,7 @@ declare class JournalSheet<
   get title(): string;
 
   /** @override */
-  getData(options?: Application.RenderOptions): Promise<D> | D;
+  getData(options?: Application.RenderOptions): D;
 
   /**
    * Guess the default view mode for the sheet based on the player's permissions to the Entry
@@ -61,6 +61,34 @@ declare namespace JournalSheet {
   }
 
   interface Options extends BaseEntitySheet.Options {
+    /**
+     * @defaultValue `['sheet', 'journal-sheet']`
+     */
+    classes: string[];
+    /**
+     * @defaultValue `720`
+     */
+    width: number;
+    /**
+     * @defaultValue `800`
+     */
+    height: number;
+    /**
+     * @defaultValue `true`
+     */
+    resizable: boolean;
+    /**
+     * @defaultValue `false`
+     */
+    closeOnSubmit: boolean;
+    /**
+     * @defaultValue `true`
+     */
+    submitOnClose: boolean;
+    /**
+     * @defaultValue {@link Const.EntityPermission.None}
+     */
+    viewPermission: Const.EntityPermission;
     sheetMode?: SheetMode | null;
   }
 

--- a/foundry/applications/formApplications/imagePopout.d.ts
+++ b/foundry/applications/formApplications/imagePopout.d.ts
@@ -20,7 +20,7 @@
  * ```
  */
 declare class ImagePopout extends FormApplication<ImagePopout.Data, string> {
-  constructor(src: string, options?: ImagePopout.Options);
+  constructor(src: string, options?: Partial<ImagePopout.Options>);
 
   protected _related: Entity | object | null;
 


### PR DESCRIPTION
I made a few adjustments:
1. `options` parameter should be Partial, but it wasn't.
2. Added defaultValues for JournalSheet.Options.
3. Narrow down returning type of getData (it is never a promise)

One thing I noticed - I've made default value of `viewPermission` in the same way as it is done in BaseEntitySheet, but in BaseEntitySheet there is a typo (`Const.EntityPermissions`). Also, it references `type EntityPermission = ValueOf<typeof ENTITY_PERMISSIONS>;`, which is computed to `0 | 1 | 2 | 3`, so `.None` references nothing. 

Maybe I should stick to `ENTITY_PERMISSIONS.NONE` as default value instead, and also change the `BaseEntitySheet.Options.viewPermission` to `ENTITY_PERMISSIONS.LIMITED`. What do you think?