### PR TITLE
Add publish workflow

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,7 +1,12 @@
 name: checks
+
 on:
   - push
   - pull_request
+
+env:
+  node_version: 14
+
 jobs:
   typecheck:
     name: type check code base
@@ -12,40 +17,55 @@ jobs:
       - name: install node
         uses: actions/setup-node@v2
         with:
-          node-version: '14'
-      - name: npm install
-        run: npm install
+          node-version: ${{ env.node_version }}
+      - name: Cache Node.js modules
+        uses: actions/cache@v2
+        with:
+          path: .npm
+          key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.OS }}-node-
+            ${{ runner.OS }}-
+      - run: npm ci --cache .npm --prefer-offline
       - name: compile typescript
         run: tsc
   lint:
     name: lint code base
     runs-on: ubuntu-latest
     steps:
-      - name: checkout code
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@v2
       - name: install node
         uses: actions/setup-node@v2
         with:
-          node-version: '14'
-      - name: npm install
-        run: npm install
+          node-version: ${{ env.node_version }}
+      - name: Cache Node.js modules
+        uses: actions/cache@v2
+        with:
+          path: .npm
+          key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.OS }}-node-
+            ${{ runner.OS }}-
+      - run: npm ci --cache .npm --prefer-offline
       - name: run eslint
         run: npm run lint:ci
   test:
     name: test code base
     runs-on: ubuntu-latest
     steps:
-      - name: checkout code
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@v2
       - name: install node
         uses: actions/setup-node@v2
         with:
-          node-version: '14'
-      - name: npm install
-        run: npm install
+          node-version: ${{ env.node_version }}
+      - name: Cache Node.js modules
+        uses: actions/cache@v2
+        with:
+          path: .npm
+          key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.OS }}-node-
+            ${{ runner.OS }}-
+      - run: npm ci --cache .npm --prefer-offline
       - name: execute tests
         run: npm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,8 @@ jobs:
       - name: Publish
         run: |
           npm publish --ignore-scripts
-          npm dist-tag add @league-of-foundry-developers/foundry-vtt-types@$(jq -r '.version' package.json) $(echo ${GITHUB_REF##*/} | sed -r 's/foundry/fvtt/g')
+          export PUBLISHED_VERSION=$(jq -r '.version' package.json)
+          npm dist-tag add @league-of-foundry-developers/foundry-vtt-types@${PUBLISHED_VERSION} fvtt-${PUBLISHED_VERSION//-[0-9]*/}
+        shell: bash
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+name: publish
+
+on:
+  release:
+    types: [created]
+
+env:
+  node_version: 14
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ env.node_version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.node_version }}
+      - name: Cache Node.js modules
+        uses: actions/cache@v2
+        with:
+          path: .npm
+          key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.OS }}-node-
+            ${{ runner.OS }}-
+      - run: npm ci --cache .npm --prefer-offline
+      - run: tsc
+      - run: npm run lint:ci
+      - run: npm test
+      - run: npm run prepublishOnly
+      - name: Archive package.json
+        uses: actions/upload-artifact@v2
+        with:
+          name: package.json
+          path: package.json
+
+  publish:
+    needs: verify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ env.node_version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.node_version }}
+          registry-url: 'https://registry.npmjs.org'
+      - run: rm package.json
+      - name: Download prepared package.json
+        uses: actions/download-artifact@v2
+        with:
+          name: package.json
+      - name: Publish
+        run: |
+          npm publish --ignore-scripts
+          npm dist-tag add @league-of-foundry-developers/foundry-vtt-types@$(jq -r '.version' package.json) $(echo ${GITHUB_REF##*/} | sed -r 's/foundry/fvtt/g')
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,8 @@
 name: publish
 
 on:
-  - push
+  release:
+    types: [created]
 
 env:
   node_version: 14
@@ -51,9 +52,9 @@ jobs:
           name: package.json
       - name: Publish
         run: |
-          echo npm publish --ignore-scripts
+          npm publish --ignore-scripts
           export PUBLISHED_VERSION=$(jq -r '.version' package.json)
-          echo npm dist-tag add @league-of-foundry-developers/foundry-vtt-types@${PUBLISHED_VERSION} fvtt-${PUBLISHED_VERSION//-[0-9]*/}
+          npm dist-tag add @league-of-foundry-developers/foundry-vtt-types@${PUBLISHED_VERSION} fvtt-${PUBLISHED_VERSION//-[0-9]*/}
         shell: bash
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,7 @@
 name: publish
 
 on:
-  release:
-    types: [created]
+  - push
 
 env:
   node_version: 14
@@ -52,9 +51,9 @@ jobs:
           name: package.json
       - name: Publish
         run: |
-          npm publish --ignore-scripts
+          echo npm publish --ignore-scripts
           export PUBLISHED_VERSION=$(jq -r '.version' package.json)
-          npm dist-tag add @league-of-foundry-developers/foundry-vtt-types@${PUBLISHED_VERSION} fvtt-${PUBLISHED_VERSION//-[0-9]*/}
+          echo npm dist-tag add @league-of-foundry-developers/foundry-vtt-types@${PUBLISHED_VERSION} fvtt-${PUBLISHED_VERSION//-[0-9]*/}
         shell: bash
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This adds a workflow that publishes to npm when a release is created. The basic workflow to publish a new version then becomes this:

- Locally, run
  ```
  npm version prerelease
  ```
  This increases the prerelease version number (i.e. the number behind the "-") and creates a tag for the new version.
- Push the created tag and the branch:
  ```
  git push --follow-tags
  ```
  If you don't have admin priviledges, you need to create a PR instead.
- Create a new release for the tag in GitHub. This triggers the workflow and automatically publishes the version to npm.