### PR TITLE
FormApplication Editor Changes - Foundry 0.7.9

### DIFF
--- a/foundry/applications/formApplication.d.ts
+++ b/foundry/applications/formApplication.d.ts
@@ -45,7 +45,7 @@ declare abstract class FormApplication<
    * The values of this Array are inner-objects with references to the MCE editor and other metadata
    * @defaultValue `{}`
    */
-  editors: Partial<Record<string, FormApplication.Editor>>;
+  editors: Partial<Record<string, FormApplication.FormApplicationEditor>>;
 
   /**
    * Assign the default options which are supported by the entity edit sheet.
@@ -211,13 +211,14 @@ declare namespace FormApplication {
     title: string;
   }
 
-  interface Editor {
+  interface FormApplicationEditor {
+    active: boolean;
     activate: boolean;
     button: HTMLElement;
     changed: boolean;
     hasButton: boolean;
     initial: string;
-    mce: Editor;
+    mce: Editor | null;
     options: TextEditor.Options;
     target: string;
   }


### PR DESCRIPTION
I noticed a few discrepancies with the types for the FormApplication Editor.

- There was a property missing from the [FormApplication Editor Interface](https://github.com/League-of-Foundry-Developers/foundry-vtt-types/blob/foundry-0.7.9/foundry/applications/formApplication.d.ts#L214). There is an active property missing, can see it being [set in the foundry.js](https://foundryvtt.com/api/foundry.js.html#line5368) (line 5368)
- The mce property from the [FormApplication Editor Interface](https://github.com/League-of-Foundry-Developers/foundry-vtt-types/blob/foundry-0.7.9/foundry/applications/formApplication.d.ts#L214) can be null in addition to the tinyMCE editor type. Referencing the [foundry.js again](https://foundryvtt.com/api/foundry.js.html#line5368) (line 5367)
- The bigger change is the [FormApplication Editor Interface](https://github.com/League-of-Foundry-Developers/foundry-vtt-types/blob/foundry-0.7.9/foundry/applications/formApplication.d.ts#L214) was interfering with the [tinyMCE Editor global type](https://github.com/League-of-Foundry-Developers/foundry-vtt-types/blob/foundry-0.7.9/types/augments/tinyMCE.d.ts#L4). So I renamed the FormApplication Editor Interface to FromApplicationEditor to reduce the confusion.