### PR TITLE
InvitationLinks - Foundry 0.7.9

### DIFF
--- a/foundry/applications/invitationLinks.d.ts
+++ b/foundry/applications/invitationLinks.d.ts
@@ -18,7 +18,7 @@ declare class InvitationLinks extends Application {
   static get defaultOptions(): Application.Options;
 
   /** @override */
-  getData(): { local?: string; remote?: string } | Promise<{ local?: string; remote?: string }>;
+  getData(): { local?: string; remote?: string };
 
   /** @override */
   activateListeners(html: JQuery): void;

--- a/foundry/applications/invitationLinks.d.ts
+++ b/foundry/applications/invitationLinks.d.ts
@@ -1,0 +1,25 @@
+/**
+ * Game Invitation Links Reference
+ */
+
+declare class InvitationLinks extends Application {
+  /**
+   * @defaultValue
+   * ```typescript
+   * {
+   *   ...super.defaultOptions,
+   *   id: 'invitation-links',
+   *   template: 'templates/sidebar/apps/invitation-links.html',
+   *   title: game.i18n.localize("INVITATIONS.Title"),
+   *   width: 400,
+   * }
+   * ```
+   */
+  static get defaultOptions(): Application.Options;
+
+  /** @override */
+  getData(): { local?: string; remote?: string } | Promise<{ local?: string; remote?: string }>;
+
+  /** @override */
+  activateListeners(html: JQuery): void;
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -64,6 +64,7 @@ import './foundry/applications/filePicker';
 import './foundry/applications/formApplication';
 import './foundry/applications/headsUpDisplay';
 import './foundry/applications/hotbar';
+import './foundry/applications/invitationLinks';
 import './foundry/applications/mainMenu';
 import './foundry/applications/notifications';
 import './foundry/applications/pause';


### PR DESCRIPTION
Added the class for Invitation links based on the code in the [foundry.js](https://foundryvtt.com/api/foundry.js.html#line24676)

Placed under the applications folder as it extends the base application class.

For issue #102