### PR TITLE
Scene Navigation - Foundry 0.7.9

### DIFF
--- a/foundry/applications/sceneNavigation.d.ts
+++ b/foundry/applications/sceneNavigation.d.ts
@@ -1,11 +1,19 @@
-// @TODO:
-
 /**
  * Top menu scene navigation
  */
 declare class SceneNavigation extends Application {
   /**
    * Assign the default options which are supported by the SceneNavigation UI
+   * @defaultValue
+   * ```typescript
+   * {
+   *   ...super.defaultOptions,
+   *   id: 'navigation',
+   *   template: 'templates/hud/navigation.html',
+   *   popOut: false,
+   *   dragDrop: [{dragSelector: ".scene"}]
+   * }
+   * ```
    */
   static get defaultOptions(): Application.Options;
 
@@ -14,10 +22,14 @@ declare class SceneNavigation extends Application {
    */
   get scenes(): Scene[];
 
-  /**
-   * Collapse the SceneNavigation menu, sliding it up if it is currently expanded
-   */
-  collapse(): Promise<boolean>;
+  /** @override */
+  render(force?: boolean, options?: Application.RenderOptions): Application;
+
+  /** @override */
+  protected _render(force?: boolean, options?: Application.RenderOptions): Promise<void>;
+
+  /** @override */
+  getData(options?: Application.RenderOptions): SceneNavigation.Data | Promise<SceneNavigation.Data>;
 
   /**
    * Expand the SceneNavigation menu, sliding it down if it is currently collapsed
@@ -25,13 +37,24 @@ declare class SceneNavigation extends Application {
   expand(): Promise<boolean>;
 
   /**
-   * Prepare the default data which is required to render the SceneNavigation menu
+   * Collapse the SceneNavigation menu, sliding it up if it is currently expanded
    */
-  getData(): object;
+  collapse(): Promise<boolean>;
 
   /**
-   * Extend the Application.render logic to first check the rendering context to see what was changed
-   * If a specific context was provided, make sure an update to the navigation is necessary before rendering
+   * Activate Scene Navigation event listeners
    */
-  render(force?: boolean, options?: Application.RenderOptions): this;
+  activateListeners(html: JQuery): void;
+
+  /**
+   * Get the set of ContextMenu options which should be applied for Scenes in the menu
+   */
+  private _getContextMenuOptions(): ContextMenu.Item[];
+}
+
+declare namespace SceneNavigation {
+  interface Data {
+    collapsed: boolean;
+    scenes: Scene[];
+  }
 }

--- a/foundry/applications/sceneNavigation.d.ts
+++ b/foundry/applications/sceneNavigation.d.ts
@@ -23,7 +23,7 @@ declare class SceneNavigation extends Application {
   get scenes(): Scene[];
 
   /** @override */
-  render(force?: boolean, options?: Application.RenderOptions): this;
+  render(force?: boolean, options?: Application.RenderOptions): this | undefined;
 
   /** @override */
   protected _render(force?: boolean, options?: Application.RenderOptions): Promise<void>;
@@ -54,7 +54,7 @@ declare class SceneNavigation extends Application {
   /**
    * Handle left-click events on the scenes in the navigation menu
    */
-  private _onClickScene(event: Event): void;
+  private _onClickScene(event: JQuery.ClickEvent): void;
 
   /** @override */
   protected _onDragStart(event: DragEvent): void;
@@ -63,12 +63,12 @@ declare class SceneNavigation extends Application {
   protected _onDrop(event: DragEvent): Promise<boolean | undefined | void>;
 
   /** @override */
-  private _onToggleNav(event: Event): void;
+  private _onToggleNav(event: JQuery.ClickEvent): void;
 
   /**
    * Updated the loading progress bar
-   * @param context- The message to display in the progress back
-   * @param pct- The percentage the progress bar has completed
+   * @param context - The message to display in the progress back
+   * @param pct     - The percentage the progress bar has completed
    */
   static _onLoadProgress(context: string, pct: number): void;
 }
@@ -76,6 +76,10 @@ declare class SceneNavigation extends Application {
 declare namespace SceneNavigation {
   interface Data {
     collapsed: boolean;
-    scenes: Scene[];
+    scenes: (Duplicated<Scene['data']> & {
+      users: { letter: string; color: User['data']['color'] };
+      visible: boolean;
+      css: [string | null];
+    })[];
   }
 }

--- a/foundry/applications/sceneNavigation.d.ts
+++ b/foundry/applications/sceneNavigation.d.ts
@@ -23,7 +23,7 @@ declare class SceneNavigation extends Application {
   get scenes(): Scene[];
 
   /** @override */
-  render(force?: boolean, options?: Application.RenderOptions): Application;
+  render(force?: boolean, options?: Application.RenderOptions): this;
 
   /** @override */
   protected _render(force?: boolean, options?: Application.RenderOptions): Promise<void>;
@@ -50,6 +50,27 @@ declare class SceneNavigation extends Application {
    * Get the set of ContextMenu options which should be applied for Scenes in the menu
    */
   private _getContextMenuOptions(): ContextMenu.Item[];
+
+  /**
+   * Handle left-click events on the scenes in the navigation menu
+   */
+  private _onClickScene(event: Event): void;
+
+  /** @override */
+  protected _onDragStart(event: DragEvent): void;
+
+  /** @override */
+  protected _onDrop(event: DragEvent): Promise<boolean | undefined | void>;
+
+  /** @override */
+  private _onToggleNav(event: Event): void;
+
+  /**
+   * Updated the loading progress bar
+   * @param context- The message to display in the progress back
+   * @param pct- The percentage the progress bar has completed
+   */
+  static _onLoadProgress(context: string, pct: number): void;
 }
 
 declare namespace SceneNavigation {


### PR DESCRIPTION
Updated the Scene Navigation class to work with foundry 0.7.9 as found in the [foundry.js](https://foundryvtt.com/api/foundry.js.html#line20703)

Resolves #77 