### PR TITLE
CameraPopoutAppWrapper - Foundry 0.7.9

### DIFF
--- a/foundry/cameraPopoutAppWrapper.ts
+++ b/foundry/cameraPopoutAppWrapper.ts
@@ -32,7 +32,7 @@ declare class CameraPopoutAppWrapper {
   get position(): Application.Position;
 
   /** @override */
-  setPosition({ left, top, width, height, scale }: Partial<Application.Position>): void;
+  setPosition({ left, top, width, height, scale }?: Partial<Application.Position>): void;
 
   private _onResize(event: Event): void;
 

--- a/foundry/cameraPopoutAppWrapper.ts
+++ b/foundry/cameraPopoutAppWrapper.ts
@@ -5,6 +5,13 @@
 declare class CameraPopoutAppWrapper {
 
   /**
+   * @param view- The CameraViews application that this popout belongs to
+   * @param userId- ID of the user this popout belongs to
+   * @param element- The div element of this specific popout window
+   */
+  constructor(view: CameraViews, userId: string, element: JQuery);
+
+  /**
    * The CameraViews application that this popout belongs to
    */
   view: CameraViews;
@@ -20,13 +27,6 @@ declare class CameraPopoutAppWrapper {
   userId: string;
 
   /**
-   * @param view- The CameraViews application that this popout belongs to
-   * @param userId- ID of the user this popout belongs to
-   * @param element- The div element of this specific popout window
-   */
-  constructor(view: CameraViews, userId: string, element: JQuery);
-
-  /**
    * Get the current position of this popout window
    */
   get position(): Application.Position;
@@ -34,10 +34,10 @@ declare class CameraPopoutAppWrapper {
   /**
    * Sets the position of this popout window
    */
-  setPosition(position: Application.Position): void;
+  setPosition(position?: { left?: number; top?: number; width?: number; height?: number; scale?: number }): void;
 
   /**
-   * The resize event, currently unused
+   * The resize event
    */
   private _onResize(event: Event): void;
 

--- a/foundry/cameraPopoutAppWrapper.ts
+++ b/foundry/cameraPopoutAppWrapper.ts
@@ -31,18 +31,11 @@ declare class CameraPopoutAppWrapper {
    */
   get position(): Application.Position;
 
-  /**
-   * Sets the position of this popout window
-   */
-  setPosition(position?: { left?: number; top?: number; width?: number; height?: number; scale?: number }): void;
+  /** @override */
+  setPosition({ left, top, width, height, scale }: Partial<Application.Position>): void;
 
-  /**
-   * The resize event
-   */
   private _onResize(event: Event): void;
 
-  /**
-   * Brings this popout window to the top of all popout windows
-   */
+  /** @override */
   bringToTop(): void;
 }

--- a/foundry/cameraPopoutAppWrapper.ts
+++ b/foundry/cameraPopoutAppWrapper.ts
@@ -1,0 +1,48 @@
+/**
+ * Abstraction of the Application interface to be used with the Draggable class as a substitute for the app
+ * This class will represent one popout feed window and handle its positioning and draggability
+ */
+declare class CameraPopoutAppWrapper {
+
+  /**
+   * The CameraViews application that this popout belongs to
+   */
+  view: CameraViews;
+
+  /**
+   * The div element of this specific popout window
+   */
+  element: JQuery;
+
+  /**
+   * ID of the user this popout belongs to
+   */
+  userId: string;
+
+  /**
+   * @param view- The CameraViews application that this popout belongs to
+   * @param userId- ID of the user this popout belongs to
+   * @param element- The div element of this specific popout window
+   */
+  constructor(view: CameraViews, userId: string, element: JQuery);
+
+  /**
+   * Get the current position of this popout window
+   */
+  get position(): Application.Position;
+
+  /**
+   * Sets the position of this popout window
+   */
+  setPosition(position: Application.Position): void;
+
+  /**
+   * The resize event, currently unused
+   */
+  private _onResize(event: Event): void;
+
+  /**
+   * Brings this popout window to the top of all popout windows
+   */
+  bringToTop(): void;
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,6 +10,7 @@ import './foundry/audioHelper';
 import './foundry/avClient';
 import './foundry/avMaster';
 import './foundry/avSettings';
+import './foundry/cameraPopoutAppWrapper';
 import './foundry/canvas';
 import './foundry/chatBubbles';
 import './foundry/clientSettings';


### PR DESCRIPTION
Added the class for the CameraPopoutAppWrapper from the 0.7.9 [foundry.js](https://foundryvtt.com/api/foundry.js.html#line21425).

Oddity is this class looks like it should extended the Application class but it does not.

resolves issue #81