### PR TITLE
Fix Roll.render and roll.getTooltip return types

### DIFF
--- a/foundry/entities/user.d.ts
+++ b/foundry/entities/user.d.ts
@@ -145,7 +145,7 @@ declare class User extends Entity<User.Data> {
    * @param fromSlot - An optional origin slot from which the Macro is being shifted
    * @returns A Promise which resolves once the User update is complete
    */
-  assignHotbarMacro(macro: Macro | null, slot: number, { fromSlot }?: { fromSlot?: number }): Promise<User>;
+  assignHotbarMacro(macro: Macro | null, slot?: number | string, { fromSlot }?: { fromSlot?: number }): Promise<User>;
 
   /**
    * Get an Array of Macro Entities on this User's Hotbar by page

--- a/foundry/roll.d.ts
+++ b/foundry/roll.d.ts
@@ -252,7 +252,7 @@ declare class Roll<D extends object = {}> {
   /**
    * Render the tooltip HTML for a Roll instance
    */
-  getTooltip(): Promise<HTMLElement>;
+  getTooltip(): Promise<string>;
 
   /* -------------------------------------------- */
 
@@ -262,7 +262,7 @@ declare class Roll<D extends object = {}> {
    *                      (default: `{}`)
    * @returns A Promise which resolves to the rendered HTML
    */
-  render(chatOptions?: Roll.ChatOptions): Promise<HTMLElement>;
+  render(chatOptions?: Roll.ChatOptions): Promise<string>;
 
   /* -------------------------------------------- */
 


### PR DESCRIPTION
See https://gitlab.com/foundrynet/foundryvtt/-/issues/4758 and https://gitlab.com/foundrynet/foundryvtt/-/issues/4759