### PR TITLE
Use an alternate approach to defining types for ClientSettings

### DIFF
--- a/foundry/applications/sidebarTabs/combatTracker.d.ts
+++ b/foundry/applications/sidebarTabs/combatTracker.d.ts
@@ -121,7 +121,7 @@ declare namespace CombatTracker {
   type Data = {
     user: User;
     started: boolean;
-    settings: Combat.CompleteConfigSetting;
+    settings: Combat.ConfigValue;
   } & (
     | {
         combats: [];

--- a/foundry/clientSettings.d.ts
+++ b/foundry/clientSettings.d.ts
@@ -41,6 +41,7 @@ declare class ClientSettings {
    * @param data   - Configuration for setting data
    * @typeParam M  - The module name to register the setting for
    * @typeParam K  - The key to register the setting for
+   * @typeParam T  - The type of the setting value
    *
    * @example
    * ```typescript
@@ -86,7 +87,7 @@ declare class ClientSettings {
   register<M extends string, K extends string, T>(
     module: M,
     key: K,
-    data: ClientSettings.Values[`${M}.${K}`] extends boolean | number | string | object
+    data: ClientSettings.Values[`${M}.${K}`] extends boolean | number | bigint | string | symbol | object
       ? ClientSettings.PartialSetting<ClientSettings.Values[`${M}.${K}`]>
       : ClientSettings.PartialSetting<T>
   ): void;
@@ -200,13 +201,15 @@ declare namespace ClientSettings {
     };
     scope: string;
     type?: T extends boolean
-      ? ConstructorOf<Boolean>
+      ? typeof Boolean
       : T extends number
-      ? ConstructorOf<Number>
+      ? typeof Number
+      : T extends bigint
+      ? typeof BigInt
       : T extends string
-      ? ConstructorOf<String>
-      : T extends object
-      ? ConstructorOf<Object>
+      ? typeof String
+      : T extends symbol
+      ? typeof Symbol
       : ConstructorOf<T>;
   }
 

--- a/foundry/clientSettings.d.ts
+++ b/foundry/clientSettings.d.ts
@@ -83,10 +83,12 @@ declare class ClientSettings {
    * });
    * ```
    */
-  register<M extends string, K extends string>(
+  register<M extends string, K extends string, T>(
     module: M,
     key: K,
-    data: ClientSettings.RegisteredSettings[`${M}.${K}`]
+    data: ClientSettings.Values[`${M}.${K}`] extends boolean | number | string | object
+      ? ClientSettings.PartialSetting<ClientSettings.Values[`${M}.${K}`]>
+      : ClientSettings.PartialSetting<T>
   ): void;
 
   /**
@@ -159,7 +161,9 @@ declare class ClientSettings {
    * Locally update a setting given a provided key and value
    */
   protected _update<M extends string, K extends string, V extends ClientSettings.Values[`${M}.${K}`]>(
-    setting: ClientSettings.RegisteredSettings[`${M}.${K}`] | ClientSettings.RegisteredMenuSettings[`${M}.${K}`],
+    setting:
+      | ClientSettings.PartialSetting<ClientSettings.Values[`${M}.${K}`]>
+      | ClientSettings.RegisteredMenuSettings[`${M}.${K}`],
     key: `${M}.${K}`,
     value: V
   ): V;
@@ -195,7 +199,15 @@ declare namespace ClientSettings {
       step: number;
     };
     scope: string;
-    type?: ConstructorOf<T>;
+    type?: T extends boolean
+      ? ConstructorOf<Boolean>
+      : T extends number
+      ? ConstructorOf<Number>
+      : T extends string
+      ? ConstructorOf<String>
+      : T extends object
+      ? ConstructorOf<Object>
+      : ConstructorOf<T>;
   }
 
   interface PartialMenuSetting {
@@ -209,11 +221,6 @@ declare namespace ClientSettings {
 
   interface RegisteredMenuSettings {
     [key: string]: PartialMenuSetting;
-  }
-
-  interface RegisteredSettings {
-    'core.combatTrackerConfig': Combat.PartialConfigSetting;
-    [key: string]: PartialSetting;
   }
 
   interface Values {

--- a/foundry/entities/combat.d.ts
+++ b/foundry/entities/combat.d.ts
@@ -283,20 +283,6 @@ declare class Combat extends Entity<Combat.Data> {
 }
 
 declare namespace Combat {
-  interface CompleteConfigSetting extends PartialConfigSetting {
-    key: typeof Combat['CONFIG_SETTING'];
-    module: 'core';
-  }
-
-  interface PartialConfigSetting extends ClientSettings.PartialSetting<ConfigValue> {
-    name: 'Combat Tracker Configuration';
-    scope: 'world';
-    config: false;
-    default: {};
-    type: ConstructorOf<Object>;
-    onChange: () => void;
-  }
-
   interface ConfigValue {
     resource?: string;
     skipDefeated?: boolean;

--- a/test-d/foundry/clientSettings.test-d.ts
+++ b/test-d/foundry/clientSettings.test-d.ts
@@ -1,4 +1,4 @@
-import { expectType } from 'tsd';
+import { expectError, expectType } from 'tsd';
 import '../../index';
 
 const clientSettings = new ClientSettings([]);
@@ -17,3 +17,30 @@ clientSettings.register('core', Combat.CONFIG_SETTING, combatSetting);
 clientSettings.set('core', Combat.CONFIG_SETTING, {});
 clientSettings.set('core', Combat.CONFIG_SETTING, { resource: 'foo', skipDefeated: false });
 expectType<Combat.ConfigValue>(clientSettings.get('core', 'combatTrackerConfig'));
+
+declare global {
+  namespace ClientSettings { // eslint-disable-line
+    interface Values {
+      'foo.bar': boolean;
+    }
+  }
+}
+
+expectError(
+  clientSettings.register('foo', 'bar', {
+    scope: 'world',
+    type: String
+  })
+);
+expectError(clientSettings.set('foo', 'bar', 'true'));
+
+clientSettings.register('foo', 'bar', {
+  scope: 'world',
+  type: Boolean,
+  config: true,
+  default: true
+});
+clientSettings.set('foo', 'bar', false);
+expectType<boolean>(clientSettings.get('foo', 'bar'));
+
+expectType<unknown>(clientSettings.get('foo', 'baz'));

--- a/test-d/foundry/clientSettings.test-d.ts
+++ b/test-d/foundry/clientSettings.test-d.ts
@@ -3,7 +3,7 @@ import '../../index';
 
 const clientSettings = new ClientSettings([]);
 
-const combatSetting: Combat.PartialConfigSetting = {
+const combatSetting = {
   name: 'Combat Tracker Configuration',
   scope: 'world',
   config: false,


### PR DESCRIPTION
Determines the type to use for ClientSettings.register by checking if it
is defined in ClientSettings.Values. If it is, pass the type as a type
param to ClientSettings.PartialSetting<T> and type check according to
that. If it is not defined in Values, derive the type param for
PartialSetting based on the supplied data object.

Updates PartialSetting to be a little more robust about what type is
passed in. For example, PartialSetting<boolean> has a type of
ConstructorOf<Boolean> for the type field.

Adds testing to verify that augmentation of ClientSettings.Values
results in an authoritative typing of the fields.