### PR TITLE
Make CONFIG a namespace to allow declaration merging

### DIFF
--- a/foundry/config.d.ts
+++ b/foundry/config.d.ts
@@ -5,7 +5,7 @@
  * Unlike the CONST analog which is frozen and immutable, the CONFIG object may be updated during the course of a
  * session or modified by system and module developers to adjust how the application behaves.
  */
-declare const CONFIG: {
+interface CONFIG extends Record<string, unknown> {
   /**
    * Configure debugging flags to display additional information
    */
@@ -1454,7 +1454,9 @@ declare const CONFIG: {
      */
     speakingHistoryLength: number;
   };
-} & Record<string, unknown>;
+}
+
+declare const CONFIG: CONFIG;
 
 declare namespace Config {
   interface Permission {


### PR DESCRIPTION
As discussed on discord in the tools-and-workflow channel, to allow modules to define system specific overrides to CONFIG via declaration merging. After doing this change, I'm able to add the following to my module to add the PF2E namespace, allowing me to avoid having to typecast CONFIG to the any type (since you can't access properties on the `unknown` type).

Example override in a local definition file after the change:
```typescript
interface CONFIG {
    PF2E: {
        damageTypes: Record<string, string>;
    }
}
```
