### PR TITLE
Make the second argument of 1i8n.format optional in 0.7.9

### DIFF
--- a/foundry/localization.d.ts
+++ b/foundry/localization.d.ts
@@ -119,5 +119,5 @@ declare class Localization {
    * game.i18n.format("MYMODULE.GREETING", {name: "Andrew"}); // Hello Andrew, this is my module!
    * ```
    */
-  format(stringId: string, data: Record<string, any>): string;
+  format(stringId: string, data?: Record<string, any>): string;
 }


### PR DESCRIPTION
Some code I'm updating to Typescript was throwing an error about a missing argument so I looked into it and it's not a required argument
![a screenshot of the chrome devtools](https://user-images.githubusercontent.com/847422/116827581-926a9c00-ab91-11eb-8393-48c54e4f6e56.png)

