### PR TITLE
0.8.3/PoolTerm/Roll updates

### DIFF
--- a/src/foundry/roll.d.ts
+++ b/src/foundry/roll.d.ts
@@ -273,6 +273,7 @@ declare class Roll<D extends object = {}> {
    */
   evaluate({ minimize, maximize, async }?: Partial<Roll.Options & { async: false }>): this;
   evaluate({ minimize, maximize, async }?: Partial<Roll.Options & { async: true }>): Promise<this>;
+  evaluate({ minimize, maximize, async }?: Partial<Roll.Options>): this | Promise<this>;
 
   /**
    * Evaluate the roll asynchronously.
@@ -317,9 +318,9 @@ declare class Roll<D extends object = {}> {
    * @param options - Evaluation options passed to Roll#evaluate
    * @returns A new Roll object, rolled using the same formula and data
    */
-
   reroll(options?: Partial<Roll.Options & { async: false }>): this;
   reroll(options?: Partial<Roll.Options & { async: true }>): Promise<this>;
+  reroll(options?: Partial<Roll.Options>): this | Promise<this>;
 
   /**
    * Simulate a roll and evaluate the distribution of returned results

--- a/src/foundry/roll.d.ts
+++ b/src/foundry/roll.d.ts
@@ -271,7 +271,8 @@ declare class Roll<D extends object = {}> {
    * console.log(r.total);  // 11
    * ```
    */
-  evaluate({ minimize, maximize, async }?: Partial<Roll.Options>): this | Promise<this>;
+  evaluate({ minimize, maximize, async }?: Partial<Roll.Options & { async: false }>): this;
+  evaluate({ minimize, maximize, async }?: Partial<Roll.Options & { async: true }>): Promise<this>;
 
   /**
    * Evaluate the roll asynchronously.
@@ -316,7 +317,9 @@ declare class Roll<D extends object = {}> {
    * @param options - Evaluation options passed to Roll#evaluate
    * @returns A new Roll object, rolled using the same formula and data
    */
-  reroll(options?: Partial<Roll.Options>): ReturnType<Roll['evaluate']>;
+
+  reroll(options?: Partial<Roll.Options & { async: false }>): this;
+  reroll(options?: Partial<Roll.Options & { async: true }>): Promise<this>;
 
   /**
    * Simulate a roll and evaluate the distribution of returned results

--- a/src/foundry/rollTerms/poolTerm.d.ts
+++ b/src/foundry/rollTerms/poolTerm.d.ts
@@ -30,7 +30,7 @@ declare class PoolTerm extends RollTerm {
   modifiers: PoolTerm.TermData['modifiers'];
 
   /** The elements of a Dice Pool must be Roll objects or numbers */
-  rolls: (PoolTerm.TermData['rolls'] | number)[];
+  rolls: PoolTerm.TermData['rolls'];
 
   /** The array of dice pool results which have been rolled */
   results: PoolTerm.TermData['results'];


### PR DESCRIPTION
# Changelog

## Added 

- Added overloads for `Roll.evaluate()` since it can return a promise if `async = true` is passed as an argument
- Added overloads for `Roll.reroll()`, see above

### Changed

Changed type of `PoolTerm#rolls` as it should only contain roll, see https://discord.com/channels/170995199584108546/841367638180364348/844610476150227005