### PR TITLE
Add two new eslint rules and fix some errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,8 +10,70 @@ module.exports = {
   },
   plugins: ['@typescript-eslint', 'eslint-plugin-tsdoc'],
   rules: {
+    'eslint/lines-between-class-members': 'off',
     'tsdoc/syntax': 'warn',
     '@typescript-eslint/ban-types': 'off',
+    '@typescript-eslint/lines-between-class-members': ['error'],
+    '@typescript-eslint/member-ordering': [
+      'warn',
+      {
+        default: {
+          memberTypes: [
+            'public-static-field',
+            'protected-static-field',
+            'private-static-field',
+            'static-field',
+
+            // static accessors go here
+
+            'public-static-method',
+            'protected-static-method',
+            'private-static-method',
+            'static-method',
+
+            'public-constructor',
+            'protected-constructor',
+            'private-constructor',
+            'constructor',
+
+            'signature',
+
+            'public-instance-field',
+            'protected-instance-field',
+            'private-instance-field',
+            'instance-field',
+
+            // instance accessors go here
+
+            'public-abstract-field',
+            'protected-abstract-field',
+            'private-abstract-field',
+            'abstract-field',
+
+            'public-instance-method',
+            'protected-instance-method',
+            'private-instance-method',
+            'instance-method',
+
+            'public-abstract-method',
+            'protected-abstract-method',
+            'private-abstract-method',
+            'abstract-method',
+
+            'public-field',
+            'protected-field',
+            'private-field',
+            'field',
+
+            'public-method',
+            'protected-method',
+            'private-method',
+            'method'
+          ],
+          order: 'alphabetically'
+        }
+      }
+    ],
     '@typescript-eslint/no-explicit-any': 'off'
   }
 };

--- a/src/foundry/avMaster.d.ts
+++ b/src/foundry/avMaster.d.ts
@@ -38,10 +38,12 @@ declare class AVMaster {
    * @defaultValue `{}`
    */
   protected _speakingData: AVMaster.SpeakingData;
+
   /**
    * @defaultValue `{}`
    */
   protected _pttHandlers: AVMaster.PTTHandlers;
+
   /**
    * @defaultValue `0`
    */

--- a/src/foundry/pixi/containers/canvasLayers/placeablesLayers/lightingLayer.d.ts
+++ b/src/foundry/pixi/containers/canvasLayers/placeablesLayers/lightingLayer.d.ts
@@ -26,6 +26,7 @@ declare class LightingLayer extends PlaceablesLayer<AmbientLight> {
    * A mapping of different light level channels
    */
   channels: Record<'background' | 'black' | 'bright' | 'canvas' | 'dark' | 'dim', LightChannel>;
+
   /**
    * The currently displayed darkness level, which may override the saved Scene value
    */

--- a/src/foundry/pixi/containers/placeableObjects/drawing.d.ts
+++ b/src/foundry/pixi/containers/placeableObjects/drawing.d.ts
@@ -56,6 +56,7 @@ declare class Drawing extends PlaceableObject<Drawing.Data> {
    * Internal timestamp for the previous freehand draw time, to limit sampling
    */
   protected _drawTime: number;
+
   protected _sampleTime: number;
 
   /**

--- a/src/foundry/pixi/containers/placeableObjects/measuredTemplate.d.ts
+++ b/src/foundry/pixi/containers/placeableObjects/measuredTemplate.d.ts
@@ -21,7 +21,9 @@
 declare class MeasuredTemplate extends PlaceableObject<MeasuredTemplate.Data> {
   // Draw portions of the content
   controlIcon: ControlIcon | null;
+
   template: PIXI.Graphics | null;
+
   ruler: PreciseText | null;
 
   /**

--- a/src/foundry/pixi/containers/placeableObjects/wall.d.ts
+++ b/src/foundry/pixi/containers/placeableObjects/wall.d.ts
@@ -23,6 +23,7 @@ declare class Wall extends PlaceableObject<Wall.Data> {
    * @remarks Not used for `Wall`
    */
   controlIcon: null;
+
   /**
    * @remarks Type is `MouseInteractionManager<this, this['endpoints']>`
    */

--- a/src/foundry/pixi/texts/preciseText.d.ts
+++ b/src/foundry/pixi/texts/preciseText.d.ts
@@ -4,5 +4,6 @@
  */
 declare class PreciseText extends PIXI.Text {
   _autoResolution: false;
+
   _resolution: 2;
 }

--- a/src/foundry/ray.d.ts
+++ b/src/foundry/ray.d.ts
@@ -18,14 +18,17 @@ declare class Ray {
 
   // Points
   A: Point;
+
   B: Point;
 
   // Origins
   x0: number;
+
   y0: number;
 
   // Slopes
   dx: number;
+
   dy: number;
 
   /**

--- a/test-d/foundry/pixi/containers/placeableObject.test-d.ts
+++ b/test-d/foundry/pixi/containers/placeableObject.test-d.ts
@@ -3,12 +3,15 @@ import '../../../../index';
 
 class NoIcon extends PlaceableObject {
   controlIcon!: null;
+
   get bounds(): NormalizedRectangle {
     throw new Error('Not implemented');
   }
+
   async draw() {
     return this;
   }
+
   refresh() {
     return this;
   }
@@ -19,9 +22,11 @@ class HasIcon extends PlaceableObject {
   get bounds(): NormalizedRectangle {
     throw new Error('Not implemented');
   }
+
   async draw() {
     return this;
   }
+
   refresh() {
     return this;
   }


### PR DESCRIPTION
This adds the member-ordering and lines-between-class-members rules.
Accessors have to be sorted by hand, because the member-ordering rule
does not support those.

Ordering for accessors for future reference:
- static before constructor, instance after constructor
- after fields, before methods
- normal public, protected, private order
- getters before setters (grouped in pairs)
- sorted alphabetically