### PR TITLE
Fix running husky when installed as a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "@league-of-foundry-developers/foundry-vtt-types",
       "version": "0.7.9-6",
-      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@types/howler": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint:ci": "eslint --ext .d.ts,.test-d.ts .",
     "eslint:report": "eslint --output-file eslint_report.json --format json --ext .d.ts,.test-d.ts .",
     "test": "tsd",
-    "postinstall": "husky install",
+    "prepare": "husky install",
     "prepublishOnly": "pinst --disable",
     "postpublish": "pinst --enable"
   },


### PR DESCRIPTION
This will let us use branches directly as work is done on them. Prepare only runs for local installs not as a dependency. Does not work on Yarn 2, since they removed prepare from Yarn 1.

If you want to test it `git config --local --get core.hookspath` should show the hooks directory and `git config --local --unset core.hookspath` will remove it. Check it, unset it, check again (errors, exit code 1), `npm i`, check and it's set again.

If you want a repo to test with, I've started my 0.8.x update branch for SNWR, and use [this very branch for it](https://github.com/Spice-King/foundry-swnr/blob/65a2205b04816babee90b221f641fa346383317f/package.json#L21).