### PR TITLE
Mark the third parameter of testUserPermission as optional

### DIFF
--- a/src/foundry/common/abstract/document.mjs.d.ts
+++ b/src/foundry/common/abstract/document.mjs.d.ts
@@ -171,7 +171,7 @@ declare abstract class Document<
   testUserPermission(
     user: BaseUser,
     permission: keyof typeof foundry.CONST.ENTITY_PERMISSIONS | foundry.CONST.EntityPermission,
-    { exact }: { exact?: boolean }
+    { exact }?: { exact?: boolean }
   ): boolean;
 
   /**

--- a/test-d/foundry/common/abstract/document.mjs.test-d.ts
+++ b/test-d/foundry/common/abstract/document.mjs.test-d.ts
@@ -24,3 +24,10 @@ expectType<Promise<Macro>>(foundry.documents.BaseMacro.create());
 expectType<Promise<Macro[]>>(foundry.documents.BaseMacro.createDocuments([]));
 expectType<Promise<Macro[]>>(foundry.documents.BaseMacro.updateDocuments([]));
 expectType<Promise<Macro[]>>(foundry.documents.BaseMacro.deleteDocuments([]));
+
+const user = await User.create();
+
+expectType<boolean>(user.testUserPermission(user, 'NONE'));
+expectType<boolean>(user.testUserPermission(user, 'OBSERVER', {}));
+expectType<boolean>(user.testUserPermission(user, 'LIMITED', { exact: true }));
+expectType<boolean>(user.testUserPermission(user, 'OWNER', { exact: false }));


### PR DESCRIPTION
Signature of the method is `testUserPermission(user, permission, {exact=false}={})`