### PR TITLE
Add tests for ActorData and ItemData

### DIFF
--- a/src/foundry/common/data/data.mjs/actorData.d.ts
+++ b/src/foundry/common/data/data.mjs/actorData.d.ts
@@ -105,7 +105,7 @@ type ActorDataBaseSource = PropertiesToSource<ActorDataBaseProperties>;
 type ActorDataProperties = ActorDataBaseProperties & ConfiguredData<'Actor'>;
 type ActorDataSource = ActorDataBaseSource & ConfiguredSource<'Actor'>;
 
-type DocumentDataConstructor = typeof DocumentData;
+type DocumentDataConstructor = Pick<typeof DocumentData, keyof typeof DocumentData>;
 
 interface ActorDataConstructor extends DocumentDataConstructor {
   new (data?: DeepPartial<ActorDataSource>, document?: documents.BaseActor | null): ActorData;

--- a/src/foundry/common/data/data.mjs/itemData.d.ts
+++ b/src/foundry/common/data/data.mjs/itemData.d.ts
@@ -88,7 +88,7 @@ type ItemDataBaseSource = PropertiesToSource<ItemDataBaseProperties>;
 type ItemDataProperties = ItemDataBaseProperties & ConfiguredData<'Item'>;
 type ItemDataSource = ItemDataBaseSource & ConfiguredSource<'Item'>;
 
-type DocumentDataConstructor = typeof DocumentData;
+type DocumentDataConstructor = Pick<typeof DocumentData, keyof typeof DocumentData>;
 
 interface ItemDataConstructor extends DocumentDataConstructor {
   new (data?: DeepPartial<ItemDataSource>, document?: documents.BaseItem | null): ItemData;

--- a/test-d/foundry/common/data/data.mjs/actorData.test-d.ts
+++ b/test-d/foundry/common/data/data.mjs/actorData.test-d.ts
@@ -1,0 +1,76 @@
+import { expectError, expectType } from 'tsd';
+import '../../../../../index';
+
+interface CharacterDataSourceData {
+  health: number;
+}
+
+interface CharacterDataSource {
+  type: 'character';
+  data: CharacterDataSourceData;
+}
+
+interface CharacterDataPropertiesData extends CharacterDataSourceData {
+  movement: number;
+}
+
+interface CharacterDataProperties {
+  type: 'character';
+  data: CharacterDataPropertiesData;
+}
+
+interface NPCDataSourceData {
+  challenge: number;
+  faction: string;
+}
+
+interface NPCDataSource {
+  type: 'npc';
+  data: NPCDataSourceData;
+}
+
+interface NPCDataPropertiesData extends NPCDataSourceData {
+  damage: number;
+}
+
+interface NPCDataProperties {
+  type: 'npc';
+  data: NPCDataPropertiesData;
+}
+
+type MyActorDataSource = CharacterDataSource | NPCDataSource;
+type MyActorDataProperties = CharacterDataProperties | NPCDataProperties;
+
+declare global {
+  interface DataConfig {
+    Actor: MyActorDataProperties;
+  }
+
+  interface SourceConfig {
+    Actor: MyActorDataSource;
+  }
+}
+
+expectError(new foundry.data.ActorData({ name: 'Some Actor With Wrong Type', type: 'foo' }));
+
+const actorData = new foundry.data.ActorData({ name: 'Some Actor', type: 'character' });
+
+expectType<foundry.data.ActorData>(actorData);
+expectType<'character' | 'npc'>(actorData.type);
+if (actorData._source.type === 'character') {
+  expectType<number>(actorData._source.data.health);
+  expectError(actorData._source.data.movement);
+} else {
+  expectType<string>(actorData._source.data.faction);
+  expectType<number>(actorData._source.data.challenge);
+  expectError(actorData._source.data.damage);
+}
+
+if (actorData.type === 'character') {
+  expectType<number>(actorData.data.health);
+  expectType<number>(actorData.data.movement);
+} else {
+  expectType<string>(actorData.data.faction);
+  expectType<number>(actorData.data.challenge);
+  expectType<number>(actorData.data.damage);
+}

--- a/test-d/foundry/common/data/data.mjs/itemData.test-d.ts
+++ b/test-d/foundry/common/data/data.mjs/itemData.test-d.ts
@@ -1,0 +1,76 @@
+import { expectError, expectType } from 'tsd';
+import '../../../../../index';
+
+interface ArmorDataSourceData {
+  armorValue: number;
+}
+
+interface ArmorDataSource {
+  type: 'armor';
+  data: ArmorDataSourceData;
+}
+
+interface WeaponDataSourceData {
+  damagePerHit: number;
+  attackSpeed: number;
+}
+
+interface WeaponDataSource {
+  type: 'weapon';
+  data: WeaponDataSourceData;
+}
+
+interface ArmorDataPropertiesData extends ArmorDataSourceData {
+  weight: number;
+}
+
+interface ArmorDataProperties {
+  type: 'armor';
+  data: ArmorDataPropertiesData;
+}
+
+interface WeaponDataPropertiesData extends WeaponDataSourceData {
+  damage: number;
+}
+
+interface WeaponDataProperties {
+  type: 'weapon';
+  data: WeaponDataPropertiesData;
+}
+
+type MyItemDataSource = ArmorDataSource | WeaponDataSource;
+type MyItemDataProperties = ArmorDataProperties | WeaponDataProperties;
+
+declare global {
+  interface DataConfig {
+    Item: MyItemDataProperties;
+  }
+
+  interface SourceConfig {
+    Item: MyItemDataSource;
+  }
+}
+
+expectError(new foundry.data.ItemData({ name: 'Some Item With Wrong Type', type: 'foo' }));
+
+const itemData = new foundry.data.ItemData({ name: 'Some Item', type: 'weapon' });
+
+expectType<foundry.data.ItemData>(itemData);
+expectType<'weapon' | 'armor'>(itemData.type);
+if (itemData._source.type === 'armor') {
+  expectType<number>(itemData._source.data.armorValue);
+  expectError(itemData._source.data.weight);
+} else {
+  expectType<number>(itemData._source.data.attackSpeed);
+  expectType<number>(itemData._source.data.damagePerHit);
+  expectError(itemData._source.data.damage);
+}
+
+if (itemData.type === 'armor') {
+  expectType<number>(itemData.data.armorValue);
+  expectType<number>(itemData.data.weight);
+} else {
+  expectType<number>(itemData.data.attackSpeed);
+  expectType<number>(itemData.data.damagePerHit);
+  expectType<number>(itemData.data.damage);
+}


### PR DESCRIPTION
Additionally, remove the generic DocumentData constructor function from the ItemData and ActorData constructors.