### PR TITLE
Update PIXI

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,3 @@
 import 'jquery';
 import 'handlebars';
-import 'pixi.js';
 import './src';

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@types/simple-peer": "~9.11.0",
         "handlebars": "4.7.7",
         "pixi-particles": "4.3.1",
-        "pixi.js": "5.3.4",
+        "pixi.js": "6.0.4",
         "socket.io-client": "4.1.2",
         "tinymce": "5.8.1",
         "typescript": "^4.1.4"
@@ -193,40 +193,64 @@
       }
     },
     "node_modules/@pixi/accessibility": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-5.3.4.tgz",
-      "integrity": "sha512-g8hQnnVSYJ+gLrdQyCsDDSu+VehhVL9Pcr2fkQSC9VBhxiMIN+Paky8kOxC2LL5nsKRIUGGaTa6iHtiopPQQMw==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-6.0.4.tgz",
+      "integrity": "sha512-S0Co6M+BIx+Yk3INCwGp5Xif0jIv/uj5JPMbctpMV7fSsE3x0nYvcOOAfBjkGhYcXG7fNOGrYLgs5XQOBIWGtA==",
       "dependencies": {
-        "@pixi/core": "5.3.4",
-        "@pixi/display": "5.3.4",
-        "@pixi/utils": "5.3.4"
+        "@pixi/canvas-renderer": "6.0.4",
+        "@pixi/core": "6.0.4",
+        "@pixi/display": "6.0.4",
+        "@pixi/utils": "6.0.4"
       }
     },
     "node_modules/@pixi/app": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-5.3.4.tgz",
-      "integrity": "sha512-XT/EFyGslFdvdHY9ZS7yDAdLOj0U1UHeLxFr1kwiawuwIt/WsxNeH4jq2IijvZuQ3L5ON7Y7zQf54JEPv5fK0Q==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-6.0.4.tgz",
+      "integrity": "sha512-+BiuaQtnOBR5/Q8+nXnHE2tuZyuBnqy/cwbIR1ImPnKAs7UaCcRLf1R0RvnRFu4KMP4ozTd810p0k84TzIguTA==",
       "dependencies": {
-        "@pixi/core": "5.3.4",
-        "@pixi/display": "5.3.4"
+        "@pixi/core": "6.0.4",
+        "@pixi/display": "6.0.4"
+      }
+    },
+    "node_modules/@pixi/canvas-renderer": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/canvas-renderer/-/canvas-renderer-6.0.4.tgz",
+      "integrity": "sha512-z2r1nzYsAp9+gipvlFCj0rd0yfjVq1hTQkyWuMbo5TrePdEo3NLRrCUGo1dHJNbeSERpgGNN05OAiGQbAI+AUg==",
+      "dependencies": {
+        "@pixi/constants": "6.0.4",
+        "@pixi/core": "6.0.4",
+        "@pixi/math": "6.0.4",
+        "@pixi/settings": "6.0.4",
+        "@pixi/utils": "6.0.4"
+      }
+    },
+    "node_modules/@pixi/compressed-textures": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-6.0.4.tgz",
+      "integrity": "sha512-AqQPuuXcNrR28YT69SZhRxRRwzqQcQ/QrlexAR9Fohpe+jfDnvlNaIvQQoXU7HxD7huRiQ/dm3nwsLiKPqVoTg==",
+      "dependencies": {
+        "@pixi/constants": "6.0.4",
+        "@pixi/core": "6.0.4",
+        "@pixi/loaders": "6.0.4",
+        "@pixi/utils": "6.0.4"
       }
     },
     "node_modules/@pixi/constants": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.4.tgz",
-      "integrity": "sha512-YsWjdMVMoJA8kG/0D4s9/DWWa2lPlexk0qNZOcV3tICaPG0IYfIhepfveMeMhIb0QrdSAsPbhYdcaxxgoaNF1A=="
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-6.0.4.tgz",
+      "integrity": "sha512-khwRMfuHVdFk93L+bf0mmCwtSloYlfBfjdseIAbJL+VSpeMG1S2DzCYlMCPdp4mvDLU9LvkH2U2leZGEIx5j7g=="
     },
     "node_modules/@pixi/core": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.4.tgz",
-      "integrity": "sha512-k6SRniy4pH7ZKAKC2HkbLSKPm+j7bF17fTO5+6xLSiVqLnfa7ChV51wNuoa30olVF3/d8ME2uraf7dsvXwomzw==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-6.0.4.tgz",
+      "integrity": "sha512-r1ceyAz0z3usUs0uj4u2986vVT2tQixGNin2o9FNhPFDXbN5EaoKHLtrjGBt1iylK/EUH/nfL5zq0SGa/loW0A==",
       "dependencies": {
-        "@pixi/constants": "5.3.4",
-        "@pixi/math": "5.3.4",
-        "@pixi/runner": "5.3.4",
-        "@pixi/settings": "5.3.4",
-        "@pixi/ticker": "5.3.4",
-        "@pixi/utils": "5.3.4"
+        "@pixi/constants": "6.0.4",
+        "@pixi/math": "6.0.4",
+        "@pixi/runner": "6.0.4",
+        "@pixi/settings": "6.0.4",
+        "@pixi/ticker": "6.0.4",
+        "@pixi/utils": "6.0.4"
       },
       "funding": {
         "type": "opencollective",
@@ -234,307 +258,310 @@
       }
     },
     "node_modules/@pixi/display": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-5.3.4.tgz",
-      "integrity": "sha512-RCi39Qi1L8mlIu1YvWvPI45WpKHRbpYlvSIT/414wmoaAoFZnaJ+qoVuqDCfzfNhWWirGAWpXniQjNRzkUZjcA==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-6.0.4.tgz",
+      "integrity": "sha512-v6hjx5Gm5aIlLQ7xrsZ2lstI1cv/MtbWXJOhU8LXckkrHHUvAuJgml3+0pcHw8YLuOlepZngUuiqy/XjceVk8A==",
       "dependencies": {
-        "@pixi/math": "5.3.4",
-        "@pixi/settings": "5.3.4",
-        "@pixi/utils": "5.3.4"
+        "@pixi/math": "6.0.4",
+        "@pixi/settings": "6.0.4",
+        "@pixi/utils": "6.0.4"
       }
     },
     "node_modules/@pixi/extract": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-5.3.4.tgz",
-      "integrity": "sha512-HTGF5WKts4kF0v1rOU4YcLMUpb18FzcxKhaCwjXpqm3vANgjuGAUL9PxpmC4ecS03mkRa0+9vAXEUkJLQeNLPg==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-6.0.4.tgz",
+      "integrity": "sha512-xf/pnc5od7YJ8zCVIrv1km7i+P+rxYcSrrBI/hqX+qoVsI5EySKInf2GhCKHz4UjOHdSL5aPDnNYvzssNdIpdQ==",
       "dependencies": {
-        "@pixi/core": "5.3.4",
-        "@pixi/math": "5.3.4",
-        "@pixi/utils": "5.3.4"
+        "@pixi/core": "6.0.4",
+        "@pixi/math": "6.0.4",
+        "@pixi/utils": "6.0.4"
       }
     },
     "node_modules/@pixi/filter-alpha": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-5.3.4.tgz",
-      "integrity": "sha512-lgRCN8bDeHlMpRtQv/P5gCJ+9e3AufJVC2H0TdkCRmJqm1dB+rhKwxIeNINsjjz+kiuumOe88CxRbRd3CpEydg==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-6.0.4.tgz",
+      "integrity": "sha512-MZEfvNPfH2NfrwgqKhwwzurnbLujphx4KNQmS63MEZTvXuQJy16DEOs459APYF6PmeGAGuDPKd5Onk/VbLRUwQ==",
       "dependencies": {
-        "@pixi/core": "5.3.4"
+        "@pixi/core": "6.0.4"
       }
     },
     "node_modules/@pixi/filter-blur": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-5.3.4.tgz",
-      "integrity": "sha512-PYPHc8MEsZWfmVQkm0UKO70dmZpcWyu/Bs0xJa5apsmCm6zXNzXfMh02lsXu82HrNQ+9iJT/mAKrrDABGn9vtg==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-6.0.4.tgz",
+      "integrity": "sha512-Hb14geh8ZKc8jZ4lfKyeWThLMqIvha6DdRUTfiSdKe3L7Q6qwqsb7LPtIrZHAPEQCyFLWbcOvRMy6ZFy0YkpLA==",
       "dependencies": {
-        "@pixi/core": "5.3.4",
-        "@pixi/settings": "5.3.4"
+        "@pixi/core": "6.0.4",
+        "@pixi/settings": "6.0.4"
       }
     },
     "node_modules/@pixi/filter-color-matrix": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-5.3.4.tgz",
-      "integrity": "sha512-9Iflvr1moc7ns5A/73lWVwLUbe+wb678NLA4X9SYXAJTiij4M1isDrULhk95TGUaWo4bbSBaov1vm8XbUZNG8w==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-6.0.4.tgz",
+      "integrity": "sha512-31Rf9VBo2gqoxiAbD/Z1i+mu1C7uehecoelYQqCIzLjsWisICDTZZjUkMB5GrGzjeSpSqLfB34tlutBSh/r1wg==",
       "dependencies": {
-        "@pixi/core": "5.3.4"
+        "@pixi/core": "6.0.4"
       }
     },
     "node_modules/@pixi/filter-displacement": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-5.3.4.tgz",
-      "integrity": "sha512-CldemXpcKr1GRT1Ll33TTFWtU6KDl4sYTvAwWTAEu8OhKedobBB/mRCIK9p1h7iZYtaj5MRYQjewmFKRrqyXrQ==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-6.0.4.tgz",
+      "integrity": "sha512-Oyk/WbzxlN46d/uB5NtPLfEW2G6ob5XRP+mPVd8yhK38m9Y9rKlcH4jJoWB2niQ+ewkdRfZhuIB+JRdhc9eevg==",
       "dependencies": {
-        "@pixi/core": "5.3.4",
-        "@pixi/math": "5.3.4"
+        "@pixi/core": "6.0.4",
+        "@pixi/math": "6.0.4"
       }
     },
     "node_modules/@pixi/filter-fxaa": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-5.3.4.tgz",
-      "integrity": "sha512-GtIfaOsqQlsK+F1795V/JJIq5Uu15nasiCwGr+wVwHNGMBanAXt7AnSy8JHcgup3Eqx8FXRuM/AyD/4IYUquuA==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-6.0.4.tgz",
+      "integrity": "sha512-cO5XuEIq//Wsk4MjrCYuXff+1/Gfc4bkFkMTO5JKvUaDlZzHNykZd5CeAouD2fz7/6/1z0gdWKbBY9IoameBew==",
       "dependencies": {
-        "@pixi/core": "5.3.4"
+        "@pixi/core": "6.0.4"
       }
     },
     "node_modules/@pixi/filter-noise": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-5.3.4.tgz",
-      "integrity": "sha512-pNq4T4LC2naWz0pZXF3RT9aA7XdLL4TuBjJsYrrBaJZraupbOo6Mp8VwxVJs8GThmMl7/U13GalOzVSb/HjzDg==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-6.0.4.tgz",
+      "integrity": "sha512-Fpex0tpKCwZIsN03zAmN7hAOCocFF/w4XVVIkuNgYR5A90OkK+omR6p/fDtlJtlAjWarsWq0y+c5wvvUMfqsmg==",
       "dependencies": {
-        "@pixi/core": "5.3.4"
+        "@pixi/core": "6.0.4"
       }
     },
     "node_modules/@pixi/graphics": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-5.3.4.tgz",
-      "integrity": "sha512-W6cuFfzwgfx3zVFICu98cENgwjy+d2e6xNJ/yJI0q8QiwlZmpuSXHBCfZrtIWpp9VSJZe2KDIo1LUnLhCpp3Yg==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-6.0.4.tgz",
+      "integrity": "sha512-CybR+DBkGB5llypPeib2A0J13mnPQwlQDqLRhlhXKkYxXQKXlPk5MWA7ZEg+4wKeqUUlrC+k70e5ZFYLC3AgEQ==",
       "dependencies": {
-        "@pixi/constants": "5.3.4",
-        "@pixi/core": "5.3.4",
-        "@pixi/display": "5.3.4",
-        "@pixi/math": "5.3.4",
-        "@pixi/sprite": "5.3.4",
-        "@pixi/utils": "5.3.4"
+        "@pixi/constants": "6.0.4",
+        "@pixi/core": "6.0.4",
+        "@pixi/display": "6.0.4",
+        "@pixi/math": "6.0.4",
+        "@pixi/sprite": "6.0.4",
+        "@pixi/utils": "6.0.4"
       }
     },
     "node_modules/@pixi/interaction": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-5.3.4.tgz",
-      "integrity": "sha512-7/JN7AtCuYmmWczrQROKSI9Z42p6C6p7B2wDVqNYYgROSaeGbGsZ8H0sa6nYLnIj4F3CaGSRoRnAMPz+CO70bw==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-6.0.4.tgz",
+      "integrity": "sha512-4+FOKDpiF/+F9r3+y81xTBElcLqI3OpeeI9bkIw9pPHA41riXRQv+m0HWz76bGQK7zDAimAV9K2xff7Wa5nSeg==",
       "dependencies": {
-        "@pixi/core": "5.3.4",
-        "@pixi/display": "5.3.4",
-        "@pixi/math": "5.3.4",
-        "@pixi/ticker": "5.3.4",
-        "@pixi/utils": "5.3.4"
+        "@pixi/core": "6.0.4",
+        "@pixi/display": "6.0.4",
+        "@pixi/math": "6.0.4",
+        "@pixi/ticker": "6.0.4",
+        "@pixi/utils": "6.0.4"
       }
     },
     "node_modules/@pixi/loaders": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-5.3.4.tgz",
-      "integrity": "sha512-/dFznZnsivzq/MW7n/PPhMeznWFMMDYrac958OlxzSwrEAgtq6ZVLZbz7pCf9uhiifMnqwBGefphOFubj3Qorw==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-6.0.4.tgz",
+      "integrity": "sha512-cw8QSkn8l8P06fINfwCZW+vUdhtOJ5G+T2qQm3HIDgI/J1tAsiRj3ufHop8xkHwYXrUeTf1LTqw+QdlZEVpJfg==",
       "dependencies": {
-        "@pixi/core": "5.3.4",
-        "@pixi/utils": "5.3.4",
+        "@pixi/constants": "6.0.4",
+        "@pixi/core": "6.0.4",
+        "@pixi/utils": "6.0.4",
         "resource-loader": "^3.0.1"
       }
     },
     "node_modules/@pixi/math": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.4.tgz",
-      "integrity": "sha512-UQ2jhdlCHIvAVf8EcHB3QuR5GhB49VdTccWmer96RZCeGkcZsPSUk1ldO1GZnIctcf0Iuvmq74G02dYbtC7JxQ=="
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-6.0.4.tgz",
+      "integrity": "sha512-UwZ72CeZ2KsS4IlcEXgNiuD88omPk42Dct74+1G+R2+yPI+XRZq+hGQRTle/BbFYjxh9ccdQVyX9ToGv1XTd6Q=="
     },
     "node_modules/@pixi/mesh": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-5.3.4.tgz",
-      "integrity": "sha512-y0Y52cwsqETc/35DMGVCzQmhPCrQ3ZhjWcW9JwQoHMy3PoNSN9QUqYjVjF2oEj5hxcJnGNo3GAXFZz2Uh/UReQ==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-6.0.4.tgz",
+      "integrity": "sha512-uE1Qs4mXy0QVV3yjxlNeqthkXGS6Hkt5uR1fwrvdqxlQRkX69nRq+GZfInuRYDWqwAsl8eZWs7f+pLRDT+HFbA==",
       "dependencies": {
-        "@pixi/constants": "5.3.4",
-        "@pixi/core": "5.3.4",
-        "@pixi/display": "5.3.4",
-        "@pixi/math": "5.3.4",
-        "@pixi/settings": "5.3.4",
-        "@pixi/utils": "5.3.4"
+        "@pixi/constants": "6.0.4",
+        "@pixi/core": "6.0.4",
+        "@pixi/display": "6.0.4",
+        "@pixi/math": "6.0.4",
+        "@pixi/settings": "6.0.4",
+        "@pixi/utils": "6.0.4"
       }
     },
     "node_modules/@pixi/mesh-extras": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-5.3.4.tgz",
-      "integrity": "sha512-mjc3RlgLGYUv2FUKrVv/Dfaj2KW5qhX9c6Ev+yJ4lg/sMblet5gtYuyKsmJMS/K6B8V8+oMlTfX9ozFCzq1oJQ==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-6.0.4.tgz",
+      "integrity": "sha512-2fGM8j2NBwPV71SSmMfke1N1oEQ34+J19rdaAb+p1fXex0FafqtXVO49Q8rPMvungKDplMKElzQoaC1G6JGKqA==",
       "dependencies": {
-        "@pixi/constants": "5.3.4",
-        "@pixi/core": "5.3.4",
-        "@pixi/math": "5.3.4",
-        "@pixi/mesh": "5.3.4",
-        "@pixi/utils": "5.3.4"
+        "@pixi/constants": "6.0.4",
+        "@pixi/core": "6.0.4",
+        "@pixi/math": "6.0.4",
+        "@pixi/mesh": "6.0.4",
+        "@pixi/utils": "6.0.4"
       }
     },
     "node_modules/@pixi/mixin-cache-as-bitmap": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-5.3.4.tgz",
-      "integrity": "sha512-8ZAmzDK1fHXIzYFHFH72LUMRZerY1Pt71XI3UgsWExABS1aREe20oPLuVByLP94W7X/kTXz+zK+nt51O5MGKsA==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-6.0.4.tgz",
+      "integrity": "sha512-b1G5AWsxnw3CxNyaxCWJ1cWPnRECknJQ9B4D8Dy7u/gI2gABVjqz17nNFYnVpcggLlgMTkjX8+/HWnD/vZQkTg==",
       "dependencies": {
-        "@pixi/core": "5.3.4",
-        "@pixi/display": "5.3.4",
-        "@pixi/math": "5.3.4",
-        "@pixi/settings": "5.3.4",
-        "@pixi/sprite": "5.3.4",
-        "@pixi/utils": "5.3.4"
+        "@pixi/canvas-renderer": "6.0.4",
+        "@pixi/core": "6.0.4",
+        "@pixi/display": "6.0.4",
+        "@pixi/math": "6.0.4",
+        "@pixi/settings": "6.0.4",
+        "@pixi/sprite": "6.0.4",
+        "@pixi/utils": "6.0.4"
       }
     },
     "node_modules/@pixi/mixin-get-child-by-name": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-5.3.4.tgz",
-      "integrity": "sha512-PY1Qe6CKYu+UNSRAFIfRyhRfkrpsTMwh9sI6iXVVi712bM3JkZIwDfDF31TA4nYX8z7H49w+KCWY4PejZ8l2WA==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-6.0.4.tgz",
+      "integrity": "sha512-scUMBHlOmW0hpjltn4UCihJZvz3ysDYIW35ma9p9Lso2D9qKjsZpojQ6mc75FVWz53T0BjUmLW8LHA86Jic6MQ==",
       "dependencies": {
-        "@pixi/display": "5.3.4"
+        "@pixi/display": "6.0.4"
       }
     },
     "node_modules/@pixi/mixin-get-global-position": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-5.3.4.tgz",
-      "integrity": "sha512-yv+huwUAOfyXDEHbQp6W5/3RjQpwG6AhpgMY4b3XBMtvrp9R/5Wgw/YC/nea9kZ3Gb2u4Aqeco8U+tPIRNjeIA==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-6.0.4.tgz",
+      "integrity": "sha512-HzaFTMZEZTr6+WYuT9crTjjBYl7/Y/VDB7pWmjnntEdQsa1m0+by7Mnl67L6OSUPsAgW3MMlWirb5tL2zGFC7g==",
       "dependencies": {
-        "@pixi/display": "5.3.4",
-        "@pixi/math": "5.3.4"
+        "@pixi/display": "6.0.4",
+        "@pixi/math": "6.0.4"
       }
     },
     "node_modules/@pixi/particles": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/particles/-/particles-5.3.4.tgz",
-      "integrity": "sha512-sX0BGGbS7yCwlam1mC5awW2BjU7QFmZv82E8ON/r9aAZS6InT25zOpMdvy0ImIIqBvF0Z1Qz1IT6pKEBxqMo9Q==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/particles/-/particles-6.0.4.tgz",
+      "integrity": "sha512-/57nd+icuPFMNc+SxeUqGoO8ZXEKu9u8h+UI856XF1Rc1jlXzGanGAbp43Llq2LphYqBI8YVftP0QXhewCVjjA==",
       "dependencies": {
-        "@pixi/constants": "5.3.4",
-        "@pixi/core": "5.3.4",
-        "@pixi/display": "5.3.4",
-        "@pixi/math": "5.3.4",
-        "@pixi/utils": "5.3.4"
+        "@pixi/constants": "6.0.4",
+        "@pixi/core": "6.0.4",
+        "@pixi/display": "6.0.4",
+        "@pixi/math": "6.0.4",
+        "@pixi/utils": "6.0.4"
       }
     },
     "node_modules/@pixi/polyfill": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-5.3.4.tgz",
-      "integrity": "sha512-bxk8bhrfQ9Y2rU/L0ss2gIeXwmMlOciw+B5yVUDVLqzjE4y8Fm2619L4qu9v51Z9a+8JbyVE5c1eT7HJgx0g0w==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-6.0.4.tgz",
+      "integrity": "sha512-HM27pSl8iduFqUC4Waa9mt/gRKHi8Pr679it84+U4CwXmJ2lw9DL5dZuyU+QzCp2nPEVGMqx8Ig8c7WLUMvnWA==",
       "dependencies": {
-        "es6-promise-polyfill": "^1.2.0",
-        "object-assign": "^4.1.1"
+        "object-assign": "^4.1.1",
+        "promise-polyfill": "^8.2.0"
       }
     },
     "node_modules/@pixi/prepare": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-5.3.4.tgz",
-      "integrity": "sha512-MVMvNTrNYQidWXd4LSkgv+eqTzHtSViADA+Tvnemy9QMuWqbTfxFn4UMhrBjQIfG9+hwdIFS14pfFKt/BLHNrw==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-6.0.4.tgz",
+      "integrity": "sha512-BrOeKC6eZ+sdiqpefUMGXIt/VDiYDqPDP7XUCRmaI8rGTFT6ZAg/XJQENb9TsVen/4dUp+9/1u7HCFO1TEhaWQ==",
       "dependencies": {
-        "@pixi/core": "5.3.4",
-        "@pixi/display": "5.3.4",
-        "@pixi/graphics": "5.3.4",
-        "@pixi/settings": "5.3.4",
-        "@pixi/text": "5.3.4",
-        "@pixi/ticker": "5.3.4"
+        "@pixi/core": "6.0.4",
+        "@pixi/display": "6.0.4",
+        "@pixi/graphics": "6.0.4",
+        "@pixi/settings": "6.0.4",
+        "@pixi/text": "6.0.4",
+        "@pixi/ticker": "6.0.4"
       }
     },
     "node_modules/@pixi/runner": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.4.tgz",
-      "integrity": "sha512-iPWHVhv2js+NhDQNmePkHfic8SilBT7H/pzRjMqHqvafTdl8Y+4g+hdQDalZJNr3Ixl77QPAYlOKhegBujn2mQ=="
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-6.0.4.tgz",
+      "integrity": "sha512-ta6r36r2vC+fPB27URpSacPGQDtbJbdUoeGCJWAEwX+QI4vx4C9NYAcB0bIg8TLXiigCfA6by/RMnJ0dBiemFA=="
     },
     "node_modules/@pixi/settings": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.4.tgz",
-      "integrity": "sha512-Jqj1NLtYODCqK8ZKVccUBAaBDkn7SQ6b7N15FwxbiSgfbvwpynSKr6WQTxqMq29h42MKsic6BJcQrlGEbDNz5w==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-6.0.4.tgz",
+      "integrity": "sha512-djiIsmULDwcHWNmEiZKm4zyVopu1NL+fClnbBmtDkGZw7nm37y6dOcdpYawJcxvE4/KLm6pspBiRTnrzdlqW7Q==",
       "dependencies": {
         "ismobilejs": "^1.1.0"
       }
     },
     "node_modules/@pixi/sprite": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-5.3.4.tgz",
-      "integrity": "sha512-vO+GMJWnumnVzc2R7jGcLlUeIXIek+SDqVQyPDPJ5T8sWTgFhanHCrgpKfplZIu08X/zvIZQxPfd332R0waeog==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-6.0.4.tgz",
+      "integrity": "sha512-6yMoHmfFhSRERLM1PUXceq9e6e1UH0YJkLoPVLv6gxMunfk6jPXeO8p9dDS2FQ8ZMSkO/16BKq27HIMKvF6Cvg==",
       "dependencies": {
-        "@pixi/constants": "5.3.4",
-        "@pixi/core": "5.3.4",
-        "@pixi/display": "5.3.4",
-        "@pixi/math": "5.3.4",
-        "@pixi/settings": "5.3.4",
-        "@pixi/utils": "5.3.4"
+        "@pixi/constants": "6.0.4",
+        "@pixi/core": "6.0.4",
+        "@pixi/display": "6.0.4",
+        "@pixi/math": "6.0.4",
+        "@pixi/settings": "6.0.4",
+        "@pixi/utils": "6.0.4"
       }
     },
     "node_modules/@pixi/sprite-animated": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-5.3.4.tgz",
-      "integrity": "sha512-HaTelbvm2xekw9b9GdYbupM2RZ/muRZvstkmSqMZhiIViZekzKPa5WQJwnqZzVBjCg735j09G8aF4H2NpNqF9g==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-6.0.4.tgz",
+      "integrity": "sha512-uzNeJiZqcnuRc7HH/HdWxrkU7S3/D57rEGK+AuoaWEE2e2HlBWILGkf78mtqmeIrEChxe2qkOVkf4y3BZkzJVw==",
       "dependencies": {
-        "@pixi/core": "5.3.4",
-        "@pixi/sprite": "5.3.4",
-        "@pixi/ticker": "5.3.4"
+        "@pixi/core": "6.0.4",
+        "@pixi/sprite": "6.0.4",
+        "@pixi/ticker": "6.0.4"
       }
     },
     "node_modules/@pixi/sprite-tiling": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-5.3.4.tgz",
-      "integrity": "sha512-NMqpNuWEIic2n5EL/TrGmn1+bab4TwxcILnco4myvw9Sd/wLsaJx3XboegY7YCWCKhnl+Ax6cl8DMkk7OJkpJQ==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-6.0.4.tgz",
+      "integrity": "sha512-4TBsKMeGhwmfsVELorSs+zWWBih37Kd0lPQu0uhcHVV1RKtZxZpkgNoyzKS4d+WInNek5F0E592bYsXkbE6Gag==",
       "dependencies": {
-        "@pixi/constants": "5.3.4",
-        "@pixi/core": "5.3.4",
-        "@pixi/display": "5.3.4",
-        "@pixi/math": "5.3.4",
-        "@pixi/sprite": "5.3.4",
-        "@pixi/utils": "5.3.4"
+        "@pixi/constants": "6.0.4",
+        "@pixi/core": "6.0.4",
+        "@pixi/display": "6.0.4",
+        "@pixi/math": "6.0.4",
+        "@pixi/sprite": "6.0.4",
+        "@pixi/utils": "6.0.4"
       }
     },
     "node_modules/@pixi/spritesheet": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-5.3.4.tgz",
-      "integrity": "sha512-gfCqOMD2XJHw1bMXxXbuYPnBbCBUvbzMN7Pw2po7U5R6bsk7WEoG7Hp3HjAPyPQvg36v2Db6dcz0//ZNNqm+EQ==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-6.0.4.tgz",
+      "integrity": "sha512-WgOBoi9KvLkHtfSyKSEzjIq6BkLwC+Ckllh+vWgfjfFDhtm7NdOfxW5WVIoCLfyfv5/NSwEMEEffZrcw4zYA/A==",
       "dependencies": {
-        "@pixi/core": "5.3.4",
-        "@pixi/loaders": "5.3.4",
-        "@pixi/math": "5.3.4",
-        "@pixi/utils": "5.3.4"
+        "@pixi/core": "6.0.4",
+        "@pixi/loaders": "6.0.4",
+        "@pixi/math": "6.0.4",
+        "@pixi/utils": "6.0.4"
       }
     },
     "node_modules/@pixi/text": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-5.3.4.tgz",
-      "integrity": "sha512-kmdK1KLrWY8PHGIIXKVRQmik3gWquiYz6DB0jqabi3j0gVp6h+CVDje01N6Nl75ZCQ/PjaWafzQvURypfX73ng==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-6.0.4.tgz",
+      "integrity": "sha512-r9UJg8ivWvvS7nNyBaZBKX5zg5UCU37dIYbKXcHyiXnOvXO22tiQBfkPBrZCueeLXRouC9sHmDFya8rb5TE9HA==",
       "dependencies": {
-        "@pixi/core": "5.3.4",
-        "@pixi/math": "5.3.4",
-        "@pixi/settings": "5.3.4",
-        "@pixi/sprite": "5.3.4",
-        "@pixi/utils": "5.3.4"
+        "@pixi/core": "6.0.4",
+        "@pixi/math": "6.0.4",
+        "@pixi/settings": "6.0.4",
+        "@pixi/sprite": "6.0.4",
+        "@pixi/utils": "6.0.4"
       }
     },
     "node_modules/@pixi/text-bitmap": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-5.3.4.tgz",
-      "integrity": "sha512-uNJOYvy3sn0S5Bp6H113ZAmaQm68ojCXSuOBJzIMEV2cUuYLngW+7DqKOsHMMhNmcONs/OBq57SRrzDcr8WYdw==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-6.0.4.tgz",
+      "integrity": "sha512-Nh2PXixqF0LFJ0xwmTib2HVWdhgsHn+dSYMVIec8LndDFQMTBw+X2XP1iHjVm0xhqOVdZI+Qfb2Trc0j2lINrw==",
       "dependencies": {
-        "@pixi/core": "5.3.4",
-        "@pixi/display": "5.3.4",
-        "@pixi/loaders": "5.3.4",
-        "@pixi/math": "5.3.4",
-        "@pixi/mesh": "5.3.4",
-        "@pixi/settings": "5.3.4",
-        "@pixi/text": "5.3.4",
-        "@pixi/utils": "5.3.4"
+        "@pixi/core": "6.0.4",
+        "@pixi/display": "6.0.4",
+        "@pixi/loaders": "6.0.4",
+        "@pixi/math": "6.0.4",
+        "@pixi/mesh": "6.0.4",
+        "@pixi/settings": "6.0.4",
+        "@pixi/text": "6.0.4",
+        "@pixi/utils": "6.0.4"
       }
     },
     "node_modules/@pixi/ticker": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.4.tgz",
-      "integrity": "sha512-PmCAstgyI6vLPXKZVFlo4Zornry21BwFiTOp1dBUW3sIMky9Wx2fajjyVHIridCY6yaazt6Xu37khZf5qRgASw==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-6.0.4.tgz",
+      "integrity": "sha512-PkFfPP5vHlgnApLks0Ia0okmFu6KPqBdIyquDqHJAcBdgljedm32KS6K2EH37xelBOzYHScjZ2SQGiiebVfClw==",
       "dependencies": {
-        "@pixi/settings": "5.3.4"
+        "@pixi/settings": "6.0.4"
       }
     },
     "node_modules/@pixi/utils": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.4.tgz",
-      "integrity": "sha512-HjUWFfAmPPKX0BSq20GWY//Vm+gC9O+wcn9sXMqOItCuf0DDFwxoBrUVaHNNnEVhM1Djpz/+YijCijmGdZeddA==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-6.0.4.tgz",
+      "integrity": "sha512-35JTWsAJ8Va0vvtUSQvyOr3kGedGKVuJnHDO89B8C8tSFtMpJYrR44vp1b1p1vOjNak+ulGehZc8LzlCqymViQ==",
       "dependencies": {
-        "@pixi/constants": "5.3.4",
-        "@pixi/settings": "5.3.4",
-        "earcut": "^2.1.5",
+        "@pixi/constants": "6.0.4",
+        "@pixi/settings": "6.0.4",
+        "@types/earcut": "^2.1.0",
+        "earcut": "^2.2.2",
         "eventemitter3": "^3.1.0",
         "url": "^0.11.0"
       }
@@ -553,6 +580,11 @@
       "version": "1.2.10",
       "resolved": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.10.tgz",
       "integrity": "sha512-bsjleuRKWmGqajMerkzox19aGbscQX5rmmvvXl3wlIp5gMG1HgkiwPxsN5p070fBDKTNSPgojVbuY1+HWMbFhg=="
+    },
+    "node_modules/@types/earcut": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@types/earcut/-/earcut-2.1.1.tgz",
+      "integrity": "sha512-w8oigUCDjElRHRRrMvn/spybSMyX8MTkKA5Dv+tS1IE/TgmNZPqUYtvYBXGY8cieSE66gm+szeK+bnbxC2xHTQ=="
     },
     "node_modules/@types/jquery": {
       "version": "3.5.5",
@@ -1250,11 +1282,6 @@
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
-    },
-    "node_modules/es6-promise-polyfill": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/es6-promise-polyfill/-/es6-promise-polyfill-1.2.0.tgz",
-      "integrity": "sha1-84kl8jyz4+jObNqP93T867sJDN4="
     },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
@@ -2705,44 +2732,45 @@
       }
     },
     "node_modules/pixi.js": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-5.3.4.tgz",
-      "integrity": "sha512-CrAaQQRw+iTA75IEu57CEk6stFs587iWE3HwQG0rZL2ESW2uJvdsF/ieeS/hFk35QmlEsPRqmH1sf7t7FGtsyw==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-6.0.4.tgz",
+      "integrity": "sha512-zAlwr5x9xytaflmZiZWl/ZhlSf+lZzeJG+Hexa7Buf7cvEhHPfSITy4NNk0+qnMXKooQidikBmypShDsj2jAdg==",
       "dependencies": {
-        "@pixi/accessibility": "5.3.4",
-        "@pixi/app": "5.3.4",
-        "@pixi/constants": "5.3.4",
-        "@pixi/core": "5.3.4",
-        "@pixi/display": "5.3.4",
-        "@pixi/extract": "5.3.4",
-        "@pixi/filter-alpha": "5.3.4",
-        "@pixi/filter-blur": "5.3.4",
-        "@pixi/filter-color-matrix": "5.3.4",
-        "@pixi/filter-displacement": "5.3.4",
-        "@pixi/filter-fxaa": "5.3.4",
-        "@pixi/filter-noise": "5.3.4",
-        "@pixi/graphics": "5.3.4",
-        "@pixi/interaction": "5.3.4",
-        "@pixi/loaders": "5.3.4",
-        "@pixi/math": "5.3.4",
-        "@pixi/mesh": "5.3.4",
-        "@pixi/mesh-extras": "5.3.4",
-        "@pixi/mixin-cache-as-bitmap": "5.3.4",
-        "@pixi/mixin-get-child-by-name": "5.3.4",
-        "@pixi/mixin-get-global-position": "5.3.4",
-        "@pixi/particles": "5.3.4",
-        "@pixi/polyfill": "5.3.4",
-        "@pixi/prepare": "5.3.4",
-        "@pixi/runner": "5.3.4",
-        "@pixi/settings": "5.3.4",
-        "@pixi/sprite": "5.3.4",
-        "@pixi/sprite-animated": "5.3.4",
-        "@pixi/sprite-tiling": "5.3.4",
-        "@pixi/spritesheet": "5.3.4",
-        "@pixi/text": "5.3.4",
-        "@pixi/text-bitmap": "5.3.4",
-        "@pixi/ticker": "5.3.4",
-        "@pixi/utils": "5.3.4"
+        "@pixi/accessibility": "6.0.4",
+        "@pixi/app": "6.0.4",
+        "@pixi/compressed-textures": "6.0.4",
+        "@pixi/constants": "6.0.4",
+        "@pixi/core": "6.0.4",
+        "@pixi/display": "6.0.4",
+        "@pixi/extract": "6.0.4",
+        "@pixi/filter-alpha": "6.0.4",
+        "@pixi/filter-blur": "6.0.4",
+        "@pixi/filter-color-matrix": "6.0.4",
+        "@pixi/filter-displacement": "6.0.4",
+        "@pixi/filter-fxaa": "6.0.4",
+        "@pixi/filter-noise": "6.0.4",
+        "@pixi/graphics": "6.0.4",
+        "@pixi/interaction": "6.0.4",
+        "@pixi/loaders": "6.0.4",
+        "@pixi/math": "6.0.4",
+        "@pixi/mesh": "6.0.4",
+        "@pixi/mesh-extras": "6.0.4",
+        "@pixi/mixin-cache-as-bitmap": "6.0.4",
+        "@pixi/mixin-get-child-by-name": "6.0.4",
+        "@pixi/mixin-get-global-position": "6.0.4",
+        "@pixi/particles": "6.0.4",
+        "@pixi/polyfill": "6.0.4",
+        "@pixi/prepare": "6.0.4",
+        "@pixi/runner": "6.0.4",
+        "@pixi/settings": "6.0.4",
+        "@pixi/sprite": "6.0.4",
+        "@pixi/sprite-animated": "6.0.4",
+        "@pixi/sprite-tiling": "6.0.4",
+        "@pixi/spritesheet": "6.0.4",
+        "@pixi/text": "6.0.4",
+        "@pixi/text-bitmap": "6.0.4",
+        "@pixi/ticker": "6.0.4",
+        "@pixi/utils": "6.0.4"
       },
       "funding": {
         "type": "opencollective",
@@ -2811,6 +2839,11 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/promise-polyfill": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.2.0.tgz",
+      "integrity": "sha512-k/TC0mIcPVF6yHhUvwAp7cvL6I2fFV7TzF1DuGPI8mBh4QQazf36xCKEHKTZKRysEoTQoQdKyP25J8MPJp7j5g=="
     },
     "node_modules/punycode": {
       "version": "2.1.1",
@@ -3746,344 +3779,371 @@
       }
     },
     "@pixi/accessibility": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-5.3.4.tgz",
-      "integrity": "sha512-g8hQnnVSYJ+gLrdQyCsDDSu+VehhVL9Pcr2fkQSC9VBhxiMIN+Paky8kOxC2LL5nsKRIUGGaTa6iHtiopPQQMw==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-6.0.4.tgz",
+      "integrity": "sha512-S0Co6M+BIx+Yk3INCwGp5Xif0jIv/uj5JPMbctpMV7fSsE3x0nYvcOOAfBjkGhYcXG7fNOGrYLgs5XQOBIWGtA==",
       "requires": {
-        "@pixi/core": "5.3.4",
-        "@pixi/display": "5.3.4",
-        "@pixi/utils": "5.3.4"
+        "@pixi/canvas-renderer": "6.0.4",
+        "@pixi/core": "6.0.4",
+        "@pixi/display": "6.0.4",
+        "@pixi/utils": "6.0.4"
       }
     },
     "@pixi/app": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-5.3.4.tgz",
-      "integrity": "sha512-XT/EFyGslFdvdHY9ZS7yDAdLOj0U1UHeLxFr1kwiawuwIt/WsxNeH4jq2IijvZuQ3L5ON7Y7zQf54JEPv5fK0Q==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-6.0.4.tgz",
+      "integrity": "sha512-+BiuaQtnOBR5/Q8+nXnHE2tuZyuBnqy/cwbIR1ImPnKAs7UaCcRLf1R0RvnRFu4KMP4ozTd810p0k84TzIguTA==",
       "requires": {
-        "@pixi/core": "5.3.4",
-        "@pixi/display": "5.3.4"
+        "@pixi/core": "6.0.4",
+        "@pixi/display": "6.0.4"
+      }
+    },
+    "@pixi/canvas-renderer": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/canvas-renderer/-/canvas-renderer-6.0.4.tgz",
+      "integrity": "sha512-z2r1nzYsAp9+gipvlFCj0rd0yfjVq1hTQkyWuMbo5TrePdEo3NLRrCUGo1dHJNbeSERpgGNN05OAiGQbAI+AUg==",
+      "requires": {
+        "@pixi/constants": "6.0.4",
+        "@pixi/core": "6.0.4",
+        "@pixi/math": "6.0.4",
+        "@pixi/settings": "6.0.4",
+        "@pixi/utils": "6.0.4"
+      }
+    },
+    "@pixi/compressed-textures": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-6.0.4.tgz",
+      "integrity": "sha512-AqQPuuXcNrR28YT69SZhRxRRwzqQcQ/QrlexAR9Fohpe+jfDnvlNaIvQQoXU7HxD7huRiQ/dm3nwsLiKPqVoTg==",
+      "requires": {
+        "@pixi/constants": "6.0.4",
+        "@pixi/core": "6.0.4",
+        "@pixi/loaders": "6.0.4",
+        "@pixi/utils": "6.0.4"
       }
     },
     "@pixi/constants": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.4.tgz",
-      "integrity": "sha512-YsWjdMVMoJA8kG/0D4s9/DWWa2lPlexk0qNZOcV3tICaPG0IYfIhepfveMeMhIb0QrdSAsPbhYdcaxxgoaNF1A=="
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-6.0.4.tgz",
+      "integrity": "sha512-khwRMfuHVdFk93L+bf0mmCwtSloYlfBfjdseIAbJL+VSpeMG1S2DzCYlMCPdp4mvDLU9LvkH2U2leZGEIx5j7g=="
     },
     "@pixi/core": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.4.tgz",
-      "integrity": "sha512-k6SRniy4pH7ZKAKC2HkbLSKPm+j7bF17fTO5+6xLSiVqLnfa7ChV51wNuoa30olVF3/d8ME2uraf7dsvXwomzw==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-6.0.4.tgz",
+      "integrity": "sha512-r1ceyAz0z3usUs0uj4u2986vVT2tQixGNin2o9FNhPFDXbN5EaoKHLtrjGBt1iylK/EUH/nfL5zq0SGa/loW0A==",
       "requires": {
-        "@pixi/constants": "5.3.4",
-        "@pixi/math": "5.3.4",
-        "@pixi/runner": "5.3.4",
-        "@pixi/settings": "5.3.4",
-        "@pixi/ticker": "5.3.4",
-        "@pixi/utils": "5.3.4"
+        "@pixi/constants": "6.0.4",
+        "@pixi/math": "6.0.4",
+        "@pixi/runner": "6.0.4",
+        "@pixi/settings": "6.0.4",
+        "@pixi/ticker": "6.0.4",
+        "@pixi/utils": "6.0.4"
       }
     },
     "@pixi/display": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-5.3.4.tgz",
-      "integrity": "sha512-RCi39Qi1L8mlIu1YvWvPI45WpKHRbpYlvSIT/414wmoaAoFZnaJ+qoVuqDCfzfNhWWirGAWpXniQjNRzkUZjcA==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-6.0.4.tgz",
+      "integrity": "sha512-v6hjx5Gm5aIlLQ7xrsZ2lstI1cv/MtbWXJOhU8LXckkrHHUvAuJgml3+0pcHw8YLuOlepZngUuiqy/XjceVk8A==",
       "requires": {
-        "@pixi/math": "5.3.4",
-        "@pixi/settings": "5.3.4",
-        "@pixi/utils": "5.3.4"
+        "@pixi/math": "6.0.4",
+        "@pixi/settings": "6.0.4",
+        "@pixi/utils": "6.0.4"
       }
     },
     "@pixi/extract": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-5.3.4.tgz",
-      "integrity": "sha512-HTGF5WKts4kF0v1rOU4YcLMUpb18FzcxKhaCwjXpqm3vANgjuGAUL9PxpmC4ecS03mkRa0+9vAXEUkJLQeNLPg==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-6.0.4.tgz",
+      "integrity": "sha512-xf/pnc5od7YJ8zCVIrv1km7i+P+rxYcSrrBI/hqX+qoVsI5EySKInf2GhCKHz4UjOHdSL5aPDnNYvzssNdIpdQ==",
       "requires": {
-        "@pixi/core": "5.3.4",
-        "@pixi/math": "5.3.4",
-        "@pixi/utils": "5.3.4"
+        "@pixi/core": "6.0.4",
+        "@pixi/math": "6.0.4",
+        "@pixi/utils": "6.0.4"
       }
     },
     "@pixi/filter-alpha": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-5.3.4.tgz",
-      "integrity": "sha512-lgRCN8bDeHlMpRtQv/P5gCJ+9e3AufJVC2H0TdkCRmJqm1dB+rhKwxIeNINsjjz+kiuumOe88CxRbRd3CpEydg==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-6.0.4.tgz",
+      "integrity": "sha512-MZEfvNPfH2NfrwgqKhwwzurnbLujphx4KNQmS63MEZTvXuQJy16DEOs459APYF6PmeGAGuDPKd5Onk/VbLRUwQ==",
       "requires": {
-        "@pixi/core": "5.3.4"
+        "@pixi/core": "6.0.4"
       }
     },
     "@pixi/filter-blur": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-5.3.4.tgz",
-      "integrity": "sha512-PYPHc8MEsZWfmVQkm0UKO70dmZpcWyu/Bs0xJa5apsmCm6zXNzXfMh02lsXu82HrNQ+9iJT/mAKrrDABGn9vtg==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-6.0.4.tgz",
+      "integrity": "sha512-Hb14geh8ZKc8jZ4lfKyeWThLMqIvha6DdRUTfiSdKe3L7Q6qwqsb7LPtIrZHAPEQCyFLWbcOvRMy6ZFy0YkpLA==",
       "requires": {
-        "@pixi/core": "5.3.4",
-        "@pixi/settings": "5.3.4"
+        "@pixi/core": "6.0.4",
+        "@pixi/settings": "6.0.4"
       }
     },
     "@pixi/filter-color-matrix": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-5.3.4.tgz",
-      "integrity": "sha512-9Iflvr1moc7ns5A/73lWVwLUbe+wb678NLA4X9SYXAJTiij4M1isDrULhk95TGUaWo4bbSBaov1vm8XbUZNG8w==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-6.0.4.tgz",
+      "integrity": "sha512-31Rf9VBo2gqoxiAbD/Z1i+mu1C7uehecoelYQqCIzLjsWisICDTZZjUkMB5GrGzjeSpSqLfB34tlutBSh/r1wg==",
       "requires": {
-        "@pixi/core": "5.3.4"
+        "@pixi/core": "6.0.4"
       }
     },
     "@pixi/filter-displacement": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-5.3.4.tgz",
-      "integrity": "sha512-CldemXpcKr1GRT1Ll33TTFWtU6KDl4sYTvAwWTAEu8OhKedobBB/mRCIK9p1h7iZYtaj5MRYQjewmFKRrqyXrQ==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-6.0.4.tgz",
+      "integrity": "sha512-Oyk/WbzxlN46d/uB5NtPLfEW2G6ob5XRP+mPVd8yhK38m9Y9rKlcH4jJoWB2niQ+ewkdRfZhuIB+JRdhc9eevg==",
       "requires": {
-        "@pixi/core": "5.3.4",
-        "@pixi/math": "5.3.4"
+        "@pixi/core": "6.0.4",
+        "@pixi/math": "6.0.4"
       }
     },
     "@pixi/filter-fxaa": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-5.3.4.tgz",
-      "integrity": "sha512-GtIfaOsqQlsK+F1795V/JJIq5Uu15nasiCwGr+wVwHNGMBanAXt7AnSy8JHcgup3Eqx8FXRuM/AyD/4IYUquuA==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-6.0.4.tgz",
+      "integrity": "sha512-cO5XuEIq//Wsk4MjrCYuXff+1/Gfc4bkFkMTO5JKvUaDlZzHNykZd5CeAouD2fz7/6/1z0gdWKbBY9IoameBew==",
       "requires": {
-        "@pixi/core": "5.3.4"
+        "@pixi/core": "6.0.4"
       }
     },
     "@pixi/filter-noise": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-5.3.4.tgz",
-      "integrity": "sha512-pNq4T4LC2naWz0pZXF3RT9aA7XdLL4TuBjJsYrrBaJZraupbOo6Mp8VwxVJs8GThmMl7/U13GalOzVSb/HjzDg==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-6.0.4.tgz",
+      "integrity": "sha512-Fpex0tpKCwZIsN03zAmN7hAOCocFF/w4XVVIkuNgYR5A90OkK+omR6p/fDtlJtlAjWarsWq0y+c5wvvUMfqsmg==",
       "requires": {
-        "@pixi/core": "5.3.4"
+        "@pixi/core": "6.0.4"
       }
     },
     "@pixi/graphics": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-5.3.4.tgz",
-      "integrity": "sha512-W6cuFfzwgfx3zVFICu98cENgwjy+d2e6xNJ/yJI0q8QiwlZmpuSXHBCfZrtIWpp9VSJZe2KDIo1LUnLhCpp3Yg==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-6.0.4.tgz",
+      "integrity": "sha512-CybR+DBkGB5llypPeib2A0J13mnPQwlQDqLRhlhXKkYxXQKXlPk5MWA7ZEg+4wKeqUUlrC+k70e5ZFYLC3AgEQ==",
       "requires": {
-        "@pixi/constants": "5.3.4",
-        "@pixi/core": "5.3.4",
-        "@pixi/display": "5.3.4",
-        "@pixi/math": "5.3.4",
-        "@pixi/sprite": "5.3.4",
-        "@pixi/utils": "5.3.4"
+        "@pixi/constants": "6.0.4",
+        "@pixi/core": "6.0.4",
+        "@pixi/display": "6.0.4",
+        "@pixi/math": "6.0.4",
+        "@pixi/sprite": "6.0.4",
+        "@pixi/utils": "6.0.4"
       }
     },
     "@pixi/interaction": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-5.3.4.tgz",
-      "integrity": "sha512-7/JN7AtCuYmmWczrQROKSI9Z42p6C6p7B2wDVqNYYgROSaeGbGsZ8H0sa6nYLnIj4F3CaGSRoRnAMPz+CO70bw==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-6.0.4.tgz",
+      "integrity": "sha512-4+FOKDpiF/+F9r3+y81xTBElcLqI3OpeeI9bkIw9pPHA41riXRQv+m0HWz76bGQK7zDAimAV9K2xff7Wa5nSeg==",
       "requires": {
-        "@pixi/core": "5.3.4",
-        "@pixi/display": "5.3.4",
-        "@pixi/math": "5.3.4",
-        "@pixi/ticker": "5.3.4",
-        "@pixi/utils": "5.3.4"
+        "@pixi/core": "6.0.4",
+        "@pixi/display": "6.0.4",
+        "@pixi/math": "6.0.4",
+        "@pixi/ticker": "6.0.4",
+        "@pixi/utils": "6.0.4"
       }
     },
     "@pixi/loaders": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-5.3.4.tgz",
-      "integrity": "sha512-/dFznZnsivzq/MW7n/PPhMeznWFMMDYrac958OlxzSwrEAgtq6ZVLZbz7pCf9uhiifMnqwBGefphOFubj3Qorw==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-6.0.4.tgz",
+      "integrity": "sha512-cw8QSkn8l8P06fINfwCZW+vUdhtOJ5G+T2qQm3HIDgI/J1tAsiRj3ufHop8xkHwYXrUeTf1LTqw+QdlZEVpJfg==",
       "requires": {
-        "@pixi/core": "5.3.4",
-        "@pixi/utils": "5.3.4",
+        "@pixi/constants": "6.0.4",
+        "@pixi/core": "6.0.4",
+        "@pixi/utils": "6.0.4",
         "resource-loader": "^3.0.1"
       }
     },
     "@pixi/math": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.4.tgz",
-      "integrity": "sha512-UQ2jhdlCHIvAVf8EcHB3QuR5GhB49VdTccWmer96RZCeGkcZsPSUk1ldO1GZnIctcf0Iuvmq74G02dYbtC7JxQ=="
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-6.0.4.tgz",
+      "integrity": "sha512-UwZ72CeZ2KsS4IlcEXgNiuD88omPk42Dct74+1G+R2+yPI+XRZq+hGQRTle/BbFYjxh9ccdQVyX9ToGv1XTd6Q=="
     },
     "@pixi/mesh": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-5.3.4.tgz",
-      "integrity": "sha512-y0Y52cwsqETc/35DMGVCzQmhPCrQ3ZhjWcW9JwQoHMy3PoNSN9QUqYjVjF2oEj5hxcJnGNo3GAXFZz2Uh/UReQ==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-6.0.4.tgz",
+      "integrity": "sha512-uE1Qs4mXy0QVV3yjxlNeqthkXGS6Hkt5uR1fwrvdqxlQRkX69nRq+GZfInuRYDWqwAsl8eZWs7f+pLRDT+HFbA==",
       "requires": {
-        "@pixi/constants": "5.3.4",
-        "@pixi/core": "5.3.4",
-        "@pixi/display": "5.3.4",
-        "@pixi/math": "5.3.4",
-        "@pixi/settings": "5.3.4",
-        "@pixi/utils": "5.3.4"
+        "@pixi/constants": "6.0.4",
+        "@pixi/core": "6.0.4",
+        "@pixi/display": "6.0.4",
+        "@pixi/math": "6.0.4",
+        "@pixi/settings": "6.0.4",
+        "@pixi/utils": "6.0.4"
       }
     },
     "@pixi/mesh-extras": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-5.3.4.tgz",
-      "integrity": "sha512-mjc3RlgLGYUv2FUKrVv/Dfaj2KW5qhX9c6Ev+yJ4lg/sMblet5gtYuyKsmJMS/K6B8V8+oMlTfX9ozFCzq1oJQ==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-6.0.4.tgz",
+      "integrity": "sha512-2fGM8j2NBwPV71SSmMfke1N1oEQ34+J19rdaAb+p1fXex0FafqtXVO49Q8rPMvungKDplMKElzQoaC1G6JGKqA==",
       "requires": {
-        "@pixi/constants": "5.3.4",
-        "@pixi/core": "5.3.4",
-        "@pixi/math": "5.3.4",
-        "@pixi/mesh": "5.3.4",
-        "@pixi/utils": "5.3.4"
+        "@pixi/constants": "6.0.4",
+        "@pixi/core": "6.0.4",
+        "@pixi/math": "6.0.4",
+        "@pixi/mesh": "6.0.4",
+        "@pixi/utils": "6.0.4"
       }
     },
     "@pixi/mixin-cache-as-bitmap": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-5.3.4.tgz",
-      "integrity": "sha512-8ZAmzDK1fHXIzYFHFH72LUMRZerY1Pt71XI3UgsWExABS1aREe20oPLuVByLP94W7X/kTXz+zK+nt51O5MGKsA==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-6.0.4.tgz",
+      "integrity": "sha512-b1G5AWsxnw3CxNyaxCWJ1cWPnRECknJQ9B4D8Dy7u/gI2gABVjqz17nNFYnVpcggLlgMTkjX8+/HWnD/vZQkTg==",
       "requires": {
-        "@pixi/core": "5.3.4",
-        "@pixi/display": "5.3.4",
-        "@pixi/math": "5.3.4",
-        "@pixi/settings": "5.3.4",
-        "@pixi/sprite": "5.3.4",
-        "@pixi/utils": "5.3.4"
+        "@pixi/canvas-renderer": "6.0.4",
+        "@pixi/core": "6.0.4",
+        "@pixi/display": "6.0.4",
+        "@pixi/math": "6.0.4",
+        "@pixi/settings": "6.0.4",
+        "@pixi/sprite": "6.0.4",
+        "@pixi/utils": "6.0.4"
       }
     },
     "@pixi/mixin-get-child-by-name": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-5.3.4.tgz",
-      "integrity": "sha512-PY1Qe6CKYu+UNSRAFIfRyhRfkrpsTMwh9sI6iXVVi712bM3JkZIwDfDF31TA4nYX8z7H49w+KCWY4PejZ8l2WA==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-6.0.4.tgz",
+      "integrity": "sha512-scUMBHlOmW0hpjltn4UCihJZvz3ysDYIW35ma9p9Lso2D9qKjsZpojQ6mc75FVWz53T0BjUmLW8LHA86Jic6MQ==",
       "requires": {
-        "@pixi/display": "5.3.4"
+        "@pixi/display": "6.0.4"
       }
     },
     "@pixi/mixin-get-global-position": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-5.3.4.tgz",
-      "integrity": "sha512-yv+huwUAOfyXDEHbQp6W5/3RjQpwG6AhpgMY4b3XBMtvrp9R/5Wgw/YC/nea9kZ3Gb2u4Aqeco8U+tPIRNjeIA==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-6.0.4.tgz",
+      "integrity": "sha512-HzaFTMZEZTr6+WYuT9crTjjBYl7/Y/VDB7pWmjnntEdQsa1m0+by7Mnl67L6OSUPsAgW3MMlWirb5tL2zGFC7g==",
       "requires": {
-        "@pixi/display": "5.3.4",
-        "@pixi/math": "5.3.4"
+        "@pixi/display": "6.0.4",
+        "@pixi/math": "6.0.4"
       }
     },
     "@pixi/particles": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/particles/-/particles-5.3.4.tgz",
-      "integrity": "sha512-sX0BGGbS7yCwlam1mC5awW2BjU7QFmZv82E8ON/r9aAZS6InT25zOpMdvy0ImIIqBvF0Z1Qz1IT6pKEBxqMo9Q==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/particles/-/particles-6.0.4.tgz",
+      "integrity": "sha512-/57nd+icuPFMNc+SxeUqGoO8ZXEKu9u8h+UI856XF1Rc1jlXzGanGAbp43Llq2LphYqBI8YVftP0QXhewCVjjA==",
       "requires": {
-        "@pixi/constants": "5.3.4",
-        "@pixi/core": "5.3.4",
-        "@pixi/display": "5.3.4",
-        "@pixi/math": "5.3.4",
-        "@pixi/utils": "5.3.4"
+        "@pixi/constants": "6.0.4",
+        "@pixi/core": "6.0.4",
+        "@pixi/display": "6.0.4",
+        "@pixi/math": "6.0.4",
+        "@pixi/utils": "6.0.4"
       }
     },
     "@pixi/polyfill": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-5.3.4.tgz",
-      "integrity": "sha512-bxk8bhrfQ9Y2rU/L0ss2gIeXwmMlOciw+B5yVUDVLqzjE4y8Fm2619L4qu9v51Z9a+8JbyVE5c1eT7HJgx0g0w==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-6.0.4.tgz",
+      "integrity": "sha512-HM27pSl8iduFqUC4Waa9mt/gRKHi8Pr679it84+U4CwXmJ2lw9DL5dZuyU+QzCp2nPEVGMqx8Ig8c7WLUMvnWA==",
       "requires": {
-        "es6-promise-polyfill": "^1.2.0",
-        "object-assign": "^4.1.1"
+        "object-assign": "^4.1.1",
+        "promise-polyfill": "^8.2.0"
       }
     },
     "@pixi/prepare": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-5.3.4.tgz",
-      "integrity": "sha512-MVMvNTrNYQidWXd4LSkgv+eqTzHtSViADA+Tvnemy9QMuWqbTfxFn4UMhrBjQIfG9+hwdIFS14pfFKt/BLHNrw==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-6.0.4.tgz",
+      "integrity": "sha512-BrOeKC6eZ+sdiqpefUMGXIt/VDiYDqPDP7XUCRmaI8rGTFT6ZAg/XJQENb9TsVen/4dUp+9/1u7HCFO1TEhaWQ==",
       "requires": {
-        "@pixi/core": "5.3.4",
-        "@pixi/display": "5.3.4",
-        "@pixi/graphics": "5.3.4",
-        "@pixi/settings": "5.3.4",
-        "@pixi/text": "5.3.4",
-        "@pixi/ticker": "5.3.4"
+        "@pixi/core": "6.0.4",
+        "@pixi/display": "6.0.4",
+        "@pixi/graphics": "6.0.4",
+        "@pixi/settings": "6.0.4",
+        "@pixi/text": "6.0.4",
+        "@pixi/ticker": "6.0.4"
       }
     },
     "@pixi/runner": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.4.tgz",
-      "integrity": "sha512-iPWHVhv2js+NhDQNmePkHfic8SilBT7H/pzRjMqHqvafTdl8Y+4g+hdQDalZJNr3Ixl77QPAYlOKhegBujn2mQ=="
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-6.0.4.tgz",
+      "integrity": "sha512-ta6r36r2vC+fPB27URpSacPGQDtbJbdUoeGCJWAEwX+QI4vx4C9NYAcB0bIg8TLXiigCfA6by/RMnJ0dBiemFA=="
     },
     "@pixi/settings": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.4.tgz",
-      "integrity": "sha512-Jqj1NLtYODCqK8ZKVccUBAaBDkn7SQ6b7N15FwxbiSgfbvwpynSKr6WQTxqMq29h42MKsic6BJcQrlGEbDNz5w==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-6.0.4.tgz",
+      "integrity": "sha512-djiIsmULDwcHWNmEiZKm4zyVopu1NL+fClnbBmtDkGZw7nm37y6dOcdpYawJcxvE4/KLm6pspBiRTnrzdlqW7Q==",
       "requires": {
         "ismobilejs": "^1.1.0"
       }
     },
     "@pixi/sprite": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-5.3.4.tgz",
-      "integrity": "sha512-vO+GMJWnumnVzc2R7jGcLlUeIXIek+SDqVQyPDPJ5T8sWTgFhanHCrgpKfplZIu08X/zvIZQxPfd332R0waeog==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-6.0.4.tgz",
+      "integrity": "sha512-6yMoHmfFhSRERLM1PUXceq9e6e1UH0YJkLoPVLv6gxMunfk6jPXeO8p9dDS2FQ8ZMSkO/16BKq27HIMKvF6Cvg==",
       "requires": {
-        "@pixi/constants": "5.3.4",
-        "@pixi/core": "5.3.4",
-        "@pixi/display": "5.3.4",
-        "@pixi/math": "5.3.4",
-        "@pixi/settings": "5.3.4",
-        "@pixi/utils": "5.3.4"
+        "@pixi/constants": "6.0.4",
+        "@pixi/core": "6.0.4",
+        "@pixi/display": "6.0.4",
+        "@pixi/math": "6.0.4",
+        "@pixi/settings": "6.0.4",
+        "@pixi/utils": "6.0.4"
       }
     },
     "@pixi/sprite-animated": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-5.3.4.tgz",
-      "integrity": "sha512-HaTelbvm2xekw9b9GdYbupM2RZ/muRZvstkmSqMZhiIViZekzKPa5WQJwnqZzVBjCg735j09G8aF4H2NpNqF9g==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-6.0.4.tgz",
+      "integrity": "sha512-uzNeJiZqcnuRc7HH/HdWxrkU7S3/D57rEGK+AuoaWEE2e2HlBWILGkf78mtqmeIrEChxe2qkOVkf4y3BZkzJVw==",
       "requires": {
-        "@pixi/core": "5.3.4",
-        "@pixi/sprite": "5.3.4",
-        "@pixi/ticker": "5.3.4"
+        "@pixi/core": "6.0.4",
+        "@pixi/sprite": "6.0.4",
+        "@pixi/ticker": "6.0.4"
       }
     },
     "@pixi/sprite-tiling": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-5.3.4.tgz",
-      "integrity": "sha512-NMqpNuWEIic2n5EL/TrGmn1+bab4TwxcILnco4myvw9Sd/wLsaJx3XboegY7YCWCKhnl+Ax6cl8DMkk7OJkpJQ==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-6.0.4.tgz",
+      "integrity": "sha512-4TBsKMeGhwmfsVELorSs+zWWBih37Kd0lPQu0uhcHVV1RKtZxZpkgNoyzKS4d+WInNek5F0E592bYsXkbE6Gag==",
       "requires": {
-        "@pixi/constants": "5.3.4",
-        "@pixi/core": "5.3.4",
-        "@pixi/display": "5.3.4",
-        "@pixi/math": "5.3.4",
-        "@pixi/sprite": "5.3.4",
-        "@pixi/utils": "5.3.4"
+        "@pixi/constants": "6.0.4",
+        "@pixi/core": "6.0.4",
+        "@pixi/display": "6.0.4",
+        "@pixi/math": "6.0.4",
+        "@pixi/sprite": "6.0.4",
+        "@pixi/utils": "6.0.4"
       }
     },
     "@pixi/spritesheet": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-5.3.4.tgz",
-      "integrity": "sha512-gfCqOMD2XJHw1bMXxXbuYPnBbCBUvbzMN7Pw2po7U5R6bsk7WEoG7Hp3HjAPyPQvg36v2Db6dcz0//ZNNqm+EQ==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-6.0.4.tgz",
+      "integrity": "sha512-WgOBoi9KvLkHtfSyKSEzjIq6BkLwC+Ckllh+vWgfjfFDhtm7NdOfxW5WVIoCLfyfv5/NSwEMEEffZrcw4zYA/A==",
       "requires": {
-        "@pixi/core": "5.3.4",
-        "@pixi/loaders": "5.3.4",
-        "@pixi/math": "5.3.4",
-        "@pixi/utils": "5.3.4"
+        "@pixi/core": "6.0.4",
+        "@pixi/loaders": "6.0.4",
+        "@pixi/math": "6.0.4",
+        "@pixi/utils": "6.0.4"
       }
     },
     "@pixi/text": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-5.3.4.tgz",
-      "integrity": "sha512-kmdK1KLrWY8PHGIIXKVRQmik3gWquiYz6DB0jqabi3j0gVp6h+CVDje01N6Nl75ZCQ/PjaWafzQvURypfX73ng==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-6.0.4.tgz",
+      "integrity": "sha512-r9UJg8ivWvvS7nNyBaZBKX5zg5UCU37dIYbKXcHyiXnOvXO22tiQBfkPBrZCueeLXRouC9sHmDFya8rb5TE9HA==",
       "requires": {
-        "@pixi/core": "5.3.4",
-        "@pixi/math": "5.3.4",
-        "@pixi/settings": "5.3.4",
-        "@pixi/sprite": "5.3.4",
-        "@pixi/utils": "5.3.4"
+        "@pixi/core": "6.0.4",
+        "@pixi/math": "6.0.4",
+        "@pixi/settings": "6.0.4",
+        "@pixi/sprite": "6.0.4",
+        "@pixi/utils": "6.0.4"
       }
     },
     "@pixi/text-bitmap": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-5.3.4.tgz",
-      "integrity": "sha512-uNJOYvy3sn0S5Bp6H113ZAmaQm68ojCXSuOBJzIMEV2cUuYLngW+7DqKOsHMMhNmcONs/OBq57SRrzDcr8WYdw==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-6.0.4.tgz",
+      "integrity": "sha512-Nh2PXixqF0LFJ0xwmTib2HVWdhgsHn+dSYMVIec8LndDFQMTBw+X2XP1iHjVm0xhqOVdZI+Qfb2Trc0j2lINrw==",
       "requires": {
-        "@pixi/core": "5.3.4",
-        "@pixi/display": "5.3.4",
-        "@pixi/loaders": "5.3.4",
-        "@pixi/math": "5.3.4",
-        "@pixi/mesh": "5.3.4",
-        "@pixi/settings": "5.3.4",
-        "@pixi/text": "5.3.4",
-        "@pixi/utils": "5.3.4"
+        "@pixi/core": "6.0.4",
+        "@pixi/display": "6.0.4",
+        "@pixi/loaders": "6.0.4",
+        "@pixi/math": "6.0.4",
+        "@pixi/mesh": "6.0.4",
+        "@pixi/settings": "6.0.4",
+        "@pixi/text": "6.0.4",
+        "@pixi/utils": "6.0.4"
       }
     },
     "@pixi/ticker": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.4.tgz",
-      "integrity": "sha512-PmCAstgyI6vLPXKZVFlo4Zornry21BwFiTOp1dBUW3sIMky9Wx2fajjyVHIridCY6yaazt6Xu37khZf5qRgASw==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-6.0.4.tgz",
+      "integrity": "sha512-PkFfPP5vHlgnApLks0Ia0okmFu6KPqBdIyquDqHJAcBdgljedm32KS6K2EH37xelBOzYHScjZ2SQGiiebVfClw==",
       "requires": {
-        "@pixi/settings": "5.3.4"
+        "@pixi/settings": "6.0.4"
       }
     },
     "@pixi/utils": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.4.tgz",
-      "integrity": "sha512-HjUWFfAmPPKX0BSq20GWY//Vm+gC9O+wcn9sXMqOItCuf0DDFwxoBrUVaHNNnEVhM1Djpz/+YijCijmGdZeddA==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-6.0.4.tgz",
+      "integrity": "sha512-35JTWsAJ8Va0vvtUSQvyOr3kGedGKVuJnHDO89B8C8tSFtMpJYrR44vp1b1p1vOjNak+ulGehZc8LzlCqymViQ==",
       "requires": {
-        "@pixi/constants": "5.3.4",
-        "@pixi/settings": "5.3.4",
-        "earcut": "^2.1.5",
+        "@pixi/constants": "6.0.4",
+        "@pixi/settings": "6.0.4",
+        "@types/earcut": "^2.1.0",
+        "earcut": "^2.2.2",
         "eventemitter3": "^3.1.0",
         "url": "^0.11.0"
       }
@@ -4098,6 +4158,11 @@
       "version": "1.2.10",
       "resolved": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.10.tgz",
       "integrity": "sha512-bsjleuRKWmGqajMerkzox19aGbscQX5rmmvvXl3wlIp5gMG1HgkiwPxsN5p070fBDKTNSPgojVbuY1+HWMbFhg=="
+    },
+    "@types/earcut": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@types/earcut/-/earcut-2.1.1.tgz",
+      "integrity": "sha512-w8oigUCDjElRHRRrMvn/spybSMyX8MTkKA5Dv+tS1IE/TgmNZPqUYtvYBXGY8cieSE66gm+szeK+bnbxC2xHTQ=="
     },
     "@types/jquery": {
       "version": "3.5.5",
@@ -4611,11 +4676,6 @@
       "requires": {
         "is-arrayish": "^0.2.1"
       }
-    },
-    "es6-promise-polyfill": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/es6-promise-polyfill/-/es6-promise-polyfill-1.2.0.tgz",
-      "integrity": "sha1-84kl8jyz4+jObNqP93T867sJDN4="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -5719,44 +5779,45 @@
       "requires": {}
     },
     "pixi.js": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-5.3.4.tgz",
-      "integrity": "sha512-CrAaQQRw+iTA75IEu57CEk6stFs587iWE3HwQG0rZL2ESW2uJvdsF/ieeS/hFk35QmlEsPRqmH1sf7t7FGtsyw==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-6.0.4.tgz",
+      "integrity": "sha512-zAlwr5x9xytaflmZiZWl/ZhlSf+lZzeJG+Hexa7Buf7cvEhHPfSITy4NNk0+qnMXKooQidikBmypShDsj2jAdg==",
       "requires": {
-        "@pixi/accessibility": "5.3.4",
-        "@pixi/app": "5.3.4",
-        "@pixi/constants": "5.3.4",
-        "@pixi/core": "5.3.4",
-        "@pixi/display": "5.3.4",
-        "@pixi/extract": "5.3.4",
-        "@pixi/filter-alpha": "5.3.4",
-        "@pixi/filter-blur": "5.3.4",
-        "@pixi/filter-color-matrix": "5.3.4",
-        "@pixi/filter-displacement": "5.3.4",
-        "@pixi/filter-fxaa": "5.3.4",
-        "@pixi/filter-noise": "5.3.4",
-        "@pixi/graphics": "5.3.4",
-        "@pixi/interaction": "5.3.4",
-        "@pixi/loaders": "5.3.4",
-        "@pixi/math": "5.3.4",
-        "@pixi/mesh": "5.3.4",
-        "@pixi/mesh-extras": "5.3.4",
-        "@pixi/mixin-cache-as-bitmap": "5.3.4",
-        "@pixi/mixin-get-child-by-name": "5.3.4",
-        "@pixi/mixin-get-global-position": "5.3.4",
-        "@pixi/particles": "5.3.4",
-        "@pixi/polyfill": "5.3.4",
-        "@pixi/prepare": "5.3.4",
-        "@pixi/runner": "5.3.4",
-        "@pixi/settings": "5.3.4",
-        "@pixi/sprite": "5.3.4",
-        "@pixi/sprite-animated": "5.3.4",
-        "@pixi/sprite-tiling": "5.3.4",
-        "@pixi/spritesheet": "5.3.4",
-        "@pixi/text": "5.3.4",
-        "@pixi/text-bitmap": "5.3.4",
-        "@pixi/ticker": "5.3.4",
-        "@pixi/utils": "5.3.4"
+        "@pixi/accessibility": "6.0.4",
+        "@pixi/app": "6.0.4",
+        "@pixi/compressed-textures": "6.0.4",
+        "@pixi/constants": "6.0.4",
+        "@pixi/core": "6.0.4",
+        "@pixi/display": "6.0.4",
+        "@pixi/extract": "6.0.4",
+        "@pixi/filter-alpha": "6.0.4",
+        "@pixi/filter-blur": "6.0.4",
+        "@pixi/filter-color-matrix": "6.0.4",
+        "@pixi/filter-displacement": "6.0.4",
+        "@pixi/filter-fxaa": "6.0.4",
+        "@pixi/filter-noise": "6.0.4",
+        "@pixi/graphics": "6.0.4",
+        "@pixi/interaction": "6.0.4",
+        "@pixi/loaders": "6.0.4",
+        "@pixi/math": "6.0.4",
+        "@pixi/mesh": "6.0.4",
+        "@pixi/mesh-extras": "6.0.4",
+        "@pixi/mixin-cache-as-bitmap": "6.0.4",
+        "@pixi/mixin-get-child-by-name": "6.0.4",
+        "@pixi/mixin-get-global-position": "6.0.4",
+        "@pixi/particles": "6.0.4",
+        "@pixi/polyfill": "6.0.4",
+        "@pixi/prepare": "6.0.4",
+        "@pixi/runner": "6.0.4",
+        "@pixi/settings": "6.0.4",
+        "@pixi/sprite": "6.0.4",
+        "@pixi/sprite-animated": "6.0.4",
+        "@pixi/sprite-tiling": "6.0.4",
+        "@pixi/spritesheet": "6.0.4",
+        "@pixi/text": "6.0.4",
+        "@pixi/text-bitmap": "6.0.4",
+        "@pixi/ticker": "6.0.4",
+        "@pixi/utils": "6.0.4"
       }
     },
     "please-upgrade-node": {
@@ -5803,6 +5864,11 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
+    },
+    "promise-polyfill": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.2.0.tgz",
+      "integrity": "sha512-k/TC0mIcPVF6yHhUvwAp7cvL6I2fFV7TzF1DuGPI8mBh4QQazf36xCKEHKTZKRysEoTQoQdKyP25J8MPJp7j5g=="
     },
     "punycode": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@types/simple-peer": "~9.11.0",
     "handlebars": "4.7.7",
     "pixi-particles": "4.3.1",
-    "pixi.js": "5.3.4",
+    "pixi.js": "6.0.4",
     "socket.io-client": "4.1.2",
     "tinymce": "5.8.1",
     "typescript": "^4.1.4"

--- a/src/types/augments/index.d.ts
+++ b/src/types/augments/index.d.ts
@@ -2,3 +2,4 @@ import './pixiParticles';
 import './simple-peer';
 import './socket.io-client';
 import './tinyMCE';
+import './pixi';

--- a/src/types/augments/pixi.d.ts
+++ b/src/types/augments/pixi.d.ts
@@ -1,0 +1,4 @@
+import * as PIXI from 'pixi.js';
+
+export = PIXI;
+export as namespace PIXI;

--- a/src/types/fixes/index.d.ts
+++ b/src/types/fixes/index.d.ts
@@ -1,0 +1,1 @@
+import './mini-signals';

--- a/src/types/fixes/mini-signals.d.ts
+++ b/src/types/fixes/mini-signals.d.ts
@@ -1,0 +1,18 @@
+declare module 'mini-signals' {
+  namespace MiniSignal {
+    interface MiniSignalBinding {
+      detach(): boolean;
+    }
+  }
+
+  class MiniSignal {
+    constructor();
+    handlers(exists?: boolean): MiniSignal.MiniSignalBinding[] | boolean;
+    has(node: MiniSignal.MiniSignalBinding): boolean;
+    dispatch(...args: any[]): boolean;
+    add(fn: Function, thisArg?: any): MiniSignal.MiniSignalBinding;
+    once(fn: Function, thisArg?: any): MiniSignal.MiniSignalBinding;
+    detach(node: MiniSignal.MiniSignalBinding): MiniSignal;
+    detachAll(): MiniSignal;
+  }
+}

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,2 +1,3 @@
 import './augments';
+import './fixes';
 import './utils';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,11 @@
     "moduleResolution": "Node",
     "noEmit": true,
     "strict": true,
-    "target": "ES2020"
+    "target": "ES2020",
+    "allowSyntheticDefaultImports": true,
+    "paths": {
+      "mini-signals": ["./src/types/fixes/mini-signals.d.ts"]
+    }
   },
   "include": ["index.d.ts"]
 }


### PR DESCRIPTION
This updates PIXI to 6.0.4, the version used by foundry 0.8.8. Some fixes seems to be necessary, see https://github.com/Hypercubed/mini-signals/issues/20, https://github.com/pixijs/pixijs/pull/7045, and https://github.com/pixijs/pixijs/issues/7305. With these changes, the type definitions seem to build fine, but a quick check revealed that these changes seem to break builds in systems / modules that use the types... :(

EDIT: And apparently it also breaks the tests, with the same error that I got in my module :(

I suggest that for now, we stick with the older version of pixi until we find a solution.