### PR TITLE
Ad a more readable way to extract constructor data from DocumentData.

### DIFF
--- a/src/foundry/common/data/data.mjs/combatData.d.ts
+++ b/src/foundry/common/data/data.mjs/combatData.d.ts
@@ -1,8 +1,14 @@
-import { ConfiguredDocumentClass, FieldReturnType, PropertiesToSource } from '../../../../types/helperTypes';
+import {
+  ConfiguredDocumentClass,
+  ConstructorDataType,
+  FieldReturnType,
+  PropertiesToSource
+} from '../../../../types/helperTypes';
 import EmbeddedCollection from '../../abstract/embedded-collection.mjs';
 import { DocumentData } from '../../abstract/module.mjs';
 import * as documents from '../../documents.mjs';
 import * as fields from '../fields.mjs';
+import { CombatantData } from './combatantData';
 
 interface CombatDataSchema extends DocumentSchema {
   _id: typeof fields.DOCUMENT_ID;
@@ -64,7 +70,7 @@ interface CombatDataConstructorData {
   scene?: string | null;
 
   /** A Collection of Combatant embedded Documents */
-  combatants?: Parameters<foundry.data.CombatantData['_initializeSource']>[0][] | null;
+  combatants?: ConstructorDataType<CombatantData>[] | null;
 
   /**
    * Is the Combat encounter currently active?

--- a/src/foundry/common/documents.mjs/baseActiveEffect.d.ts
+++ b/src/foundry/common/documents.mjs/baseActiveEffect.d.ts
@@ -1,5 +1,5 @@
 import { DocumentMetadata, DocumentModificationOptions } from '../abstract/document.mjs';
-import { ConfiguredDocumentClass } from '../../../types/helperTypes';
+import { ConfiguredDocumentClass, ConstructorDataType } from '../../../types/helperTypes';
 import { Document } from '../abstract/module.mjs';
 import * as data from '../data/data.mjs';
 import { BaseActor } from './baseActor';
@@ -26,7 +26,7 @@ export declare class BaseActiveEffect extends Document<
   >;
 
   protected _preCreate(
-    data: Parameters<data.ActiveEffectData['_initializeSource']>[0],
+    data: ConstructorDataType<data.ActiveEffectData>,
     options: DocumentModificationOptions,
     user: BaseUser
   ): Promise<void>;

--- a/src/foundry/common/documents.mjs/baseActor.d.ts
+++ b/src/foundry/common/documents.mjs/baseActor.d.ts
@@ -4,6 +4,7 @@ import { BaseActiveEffect } from './baseActiveEffect';
 import { BaseItem } from './baseItem';
 import * as data from '../data/data.mjs';
 import { BaseUser } from './baseUser';
+import { ConstructorDataType } from '../../../types/helperTypes';
 
 //TODO Add Token as parent class once it is available
 /**
@@ -56,7 +57,7 @@ export declare class BaseActor extends Document<data.ActorData, Document<any, an
    * @param user    - The User requesting the document creation
    */
   protected _preCreate(
-    data: Parameters<data.ActorData['_initializeSource']>[0],
+    data: ConstructorDataType<data.ActorData>,
     options: DocumentModificationOptions,
     user: BaseUser
   ): Promise<void>;
@@ -69,7 +70,7 @@ export declare class BaseActor extends Document<data.ActorData, Document<any, an
    * @param user    - The User requesting the document update
    */
   protected _preUpdate(
-    changed: DeepPartial<Parameters<data.ActorData['_initializeSource']>[0]> & Record<string, unknown>,
+    changed: DeepPartial<ConstructorDataType<data.ActorData>>,
     options: DocumentModificationOptions,
     user: BaseUser
   ): Promise<void>;

--- a/src/foundry/common/documents.mjs/baseChatMessage.d.ts
+++ b/src/foundry/common/documents.mjs/baseChatMessage.d.ts
@@ -1,6 +1,5 @@
 import { DocumentMetadata } from '../abstract/document.mjs';
 import { Document } from '../abstract/module.mjs';
-import { ChatMessageData } from '../data/data.mjs';
 import { BaseUser } from './baseUser';
 import * as data from '../data/data.mjs';
 
@@ -19,7 +18,7 @@ export declare class BaseChatMessage extends Document<data.ChatMessageData, null
       isPrimary: true;
       permissions: {
         create: (user: BaseUser, doc: BaseChatMessage) => boolean;
-        update: (user: BaseUser, doc: BaseChatMessage, data: ChatMessageData['_source']) => boolean;
+        update: (user: BaseUser, doc: BaseChatMessage, data?: object) => boolean;
         delete: (user: BaseUser, doc: BaseChatMessage) => boolean;
       };
     }
@@ -33,7 +32,7 @@ export declare class BaseChatMessage extends Document<data.ChatMessageData, null
   /**
    * Is a user able to update an existing chat message?
    */
-  protected static _canUpdate(user: BaseUser, doc: BaseChatMessage, data: ChatMessageData['_source']): boolean;
+  protected static _canUpdate(user: BaseUser, doc: BaseChatMessage, data?: object): boolean;
 
   /**
    * Is a user able to delete an existing chat message?

--- a/src/foundry/common/documents.mjs/baseCombat.d.ts
+++ b/src/foundry/common/documents.mjs/baseCombat.d.ts
@@ -1,3 +1,4 @@
+import { ConstructorDataType } from '../../../types/helperTypes';
 import { DocumentMetadata } from '../abstract/document.mjs';
 import { Document } from '../abstract/module.mjs';
 import { data } from '../module.mjs';
@@ -33,9 +34,5 @@ export declare class BaseCombat extends Document<data.CombatData> {
    * Is a user able to update an existing Combat?
    * @param doc - (unused)
    */
-  protected static _canUpdate(
-    user: BaseUser,
-    doc: unknown,
-    data: Parameters<data.CombatantData['_initializeSource']>[0]
-  ): boolean;
+  protected static _canUpdate(user: BaseUser, doc: unknown, data?: ConstructorDataType<data.CombatData>): boolean;
 }

--- a/src/foundry/common/documents.mjs/baseCombatant.d.ts
+++ b/src/foundry/common/documents.mjs/baseCombatant.d.ts
@@ -32,5 +32,5 @@ export declare class BaseCombatant extends Document<
    * Is a user able to update an existing Combatant?
    * @remarks doc seems unused
    */
-  protected static _canUpdate(user: BaseUser, doc: unknown, data: data.CombatantData): boolean;
+  protected static _canUpdate(user: BaseUser, doc: unknown, data?: object): boolean;
 }

--- a/src/foundry/common/documents.mjs/baseDrawing.d.ts
+++ b/src/foundry/common/documents.mjs/baseDrawing.d.ts
@@ -15,8 +15,8 @@ export declare class BaseDrawing extends Document<any, any> {
       isEmbedded: true;
       permissions: {
         create: 'DRAWING_CREATE';
-        update: (user: BaseUser, doc: any, data: any) => boolean;
-        delete: (user: BaseUser, doc: any, data: any) => boolean;
+        update: (user: BaseUser, doc: any, data?: object) => boolean;
+        delete: (user: BaseUser, doc: any, data?: object) => boolean;
       };
     }
   >;

--- a/src/foundry/common/documents.mjs/baseFogExploration.d.ts
+++ b/src/foundry/common/documents.mjs/baseFogExploration.d.ts
@@ -15,8 +15,8 @@ export declare class BaseFogExploration extends Document<any, any> {
       isPrimary: true;
       permissions: {
         create: 'PLAYER';
-        update: (user: BaseUser, doc: any, data: any) => boolean;
-        delete: (user: BaseUser, doc: any, data: any) => boolean;
+        update: (user: BaseUser, doc: any, data?: object) => boolean;
+        delete: (user: BaseUser, doc: any, data?: object) => boolean;
       };
     }
   >;

--- a/src/foundry/common/documents.mjs/baseItem.d.ts
+++ b/src/foundry/common/documents.mjs/baseItem.d.ts
@@ -35,7 +35,7 @@ export declare class BaseItem extends Document<data.ItemData, InstanceType<Confi
    */
   get effects(): this['data']['effects'];
 
-  canUserModify(user: BaseUser, action: string, data?: object): boolean;
+  canUserModify(user: BaseUser, action: 'create' | 'update' | 'delete', data?: object): boolean;
 
   testUserPermission(
     user: BaseUser,

--- a/src/foundry/common/documents.mjs/baseMacro.d.ts
+++ b/src/foundry/common/documents.mjs/baseMacro.d.ts
@@ -2,6 +2,7 @@ import * as data from '../data/data.mjs';
 import { Document } from '../abstract/module.mjs';
 import { DocumentMetadata, DocumentModificationOptions } from '../abstract/document.mjs';
 import { BaseUser } from './baseUser';
+import { ConstructorDataType } from '../../../types/helperTypes';
 
 /**
  * The base Macro model definition which defines common behavior of an Macro document between both client and server.
@@ -19,14 +20,14 @@ export declare class BaseMacro extends Document<data.MacroData> {
       types: ['script', 'chat']; // TODO: Automatically infer from CONST.MACRO_TYPES
       permissions: {
         create: 'PLAYER';
-        update: (user: BaseUser, doc: BaseMacro, data: any) => boolean;
+        update: (user: BaseUser, doc: BaseMacro, data?: object) => boolean;
         delete: (user: BaseUser, doc: BaseMacro) => boolean;
       };
     }
   >;
 
   protected _preCreate(
-    data: Parameters<data.MacroData['_initializeSource']>[0],
+    data: ConstructorDataType<data.MacroData>,
     options: DocumentModificationOptions,
     user: BaseUser
   ): Promise<void>;
@@ -34,7 +35,7 @@ export declare class BaseMacro extends Document<data.MacroData> {
   /**
    * Is a user able to update an existing Macro document?
    */
-  protected static _canUpdate(user: BaseUser, doc: BaseMacro, data: unknown): boolean;
+  protected static _canUpdate(user: BaseUser, doc: BaseMacro, data?: object): boolean;
 
   /**
    * Is a user able to delete an existing Macro document?

--- a/src/foundry/common/documents.mjs/baseTableResult.d.ts
+++ b/src/foundry/common/documents.mjs/baseTableResult.d.ts
@@ -14,7 +14,7 @@ export declare class BaseTableResult extends Document<any, any> {
       label: 'DOCUMENT.TableResult';
       types: typeof CONST.TABLE_RESULT_TYPES;
       permissions: {
-        update: (user: BaseUser, doc: any, data: any) => boolean;
+        update: (user: BaseUser, doc: any, data?: object) => boolean;
       };
     }
   >;

--- a/src/foundry/common/documents.mjs/baseWall.d.ts
+++ b/src/foundry/common/documents.mjs/baseWall.d.ts
@@ -16,7 +16,7 @@ export declare class BaseWall extends Document<any, InstanceType<ConfiguredDocum
       label: 'DOCUMENT.Wall';
       isEmbedded: true;
       permissions: {
-        update: (user: BaseUser, doc: any, data: any) => boolean;
+        update: (user: BaseUser, doc: any, data?: object) => boolean;
       };
     }
   >;

--- a/src/foundry/common/packages.mjs/packageData.d.ts
+++ b/src/foundry/common/packages.mjs/packageData.d.ts
@@ -1,4 +1,4 @@
-import { FieldReturnType, PropertiesToSource } from '../../../types/helperTypes';
+import { ConstructorDataType, FieldReturnType, PropertiesToSource } from '../../../types/helperTypes';
 import { DocumentData } from '../abstract/module.mjs';
 import * as fields from '../data/fields.mjs';
 import { PackageAuthorData } from './packageAuthorData';
@@ -187,7 +187,7 @@ export interface PackageDataConstructorData {
    * An array of author objects who are co-authors of this package. Preferred to the singular author field.
    * @defaultValue `[]`
    */
-  authors?: Parameters<PackageAuthorData['_initializeSource']>[0][] | null;
+  authors?: ConstructorDataType<PackageAuthorData>[] | null;
 
   /** A web url where more details about the package may be found */
   url?: string | null;
@@ -241,13 +241,13 @@ export interface PackageDataConstructorData {
    * An array of language data objects which are included by this package
    * @defaultValue `[]`
    */
-  languages?: Parameters<PackageLanguageData['_initializeSource']>[0][] | null;
+  languages?: ConstructorDataType<PackageLanguageData>[] | null;
 
   /**
    * An array of compendium packs which are included by this package
    * @defaultValue `[]`
    */
-  packs?: Parameters<PackageCompendiumData['_initializeSource']>[0][] | null;
+  packs?: ConstructorDataType<PackageCompendiumData>[] | null;
 
   /**
    * An array of game system names which this module supports
@@ -259,7 +259,7 @@ export interface PackageDataConstructorData {
    * An array of dependency objects which define required dependencies for using this package
    * @defaultValue `[]`
    */
-  dependencies?: Parameters<PackageDependencyData['_initializeSource']>[0][] | null;
+  dependencies?: ConstructorDataType<PackageDependencyData>[] | null;
 
   /**
    * Whether to require a package-specific socket namespace for this package

--- a/src/foundry/foundry.js/canvasDocumentMixin.d.ts
+++ b/src/foundry/foundry.js/canvasDocumentMixin.d.ts
@@ -1,3 +1,4 @@
+import { ConstructorDataType } from '../../types/helperTypes';
 import { ContextType, DocumentModificationOptions } from '../common/abstract/document.mjs';
 import { ClientDocumentMixin } from './clientDocumentMixin';
 
@@ -18,23 +19,23 @@ type CanvasDocumentConstructor<T extends ConstructorOf<foundry.abstract.Document
   };
 
 declare class CanvasDocumentMixin<T extends foundry.abstract.Document<any, any>> extends ClientDocumentMixin<T> {
-  constructor(data?: Parameters<T['data']['_initializeSource']>[0], context?: ContextType<T>);
+  constructor(data?: ConstructorDataType<T['data']>, context?: ContextType<T>);
 
   /**
    * A reference to the PlaceableObject instance which represents this Embedded Document.
    * @defaultValue `null`
    */
-  protected _object: PlaceableObject | null; // TODO: Replace mit InstanceType<ObjectClass<T>> | null once the circular reference problem has been solved
+  protected _object: PlaceableObject | null; // TODO: Replace with InstanceType<ObjectClass<T>> | null once the circular reference problem has been solved
 
   /**
    * A lazily constructed PlaceableObject instance which can represent this Document on the game canvas.
    */
-  get object(): PlaceableObject | null; // TODO: Replace mit InstanceType<ObjectClass<T>> | null once the circular reference problem has been solved
+  get object(): PlaceableObject | null; // TODO: Replace with InstanceType<ObjectClass<T>> | null once the circular reference problem has been solved
 
   /**
    * A reference to the CanvasLayer which contains Document objects of this type.
    */
-  get layer(): PlaceablesLayer | null; // TODO: Replace mit InstanceType<LayerClass<T>> | null once the circular reference problem has been solved
+  get layer(): PlaceablesLayer | null; // TODO: Replace with InstanceType<LayerClass<T>> | null once the circular reference problem has been solved
 
   /**
    * An indicator for whether this document is currently rendered on the game canvas.

--- a/src/foundry/foundry.js/clientDocumentMixin.d.ts
+++ b/src/foundry/foundry.js/clientDocumentMixin.d.ts
@@ -1,6 +1,6 @@
 import { ContextType, DocumentModificationOptions } from '../common/abstract/document.mjs';
 
-import { ConfiguredDocumentClass, DocumentConstructor } from '../../types/helperTypes';
+import { ConfiguredDocumentClass, ConstructorDataType, DocumentConstructor } from '../../types/helperTypes';
 
 declare global {
   // TODO: Replace ConstructorOf<…> with DocumentConstructor once the problem with circular reference has been solved
@@ -19,7 +19,7 @@ type ClientDocumentConstructor<T extends ConstructorOf<foundry.abstract.Document
   };
 
 export declare class ClientDocumentMixin<T extends foundry.abstract.Document<any, any>> {
-  constructor(data?: Parameters<T['data']['_initializeSource']>[0], context?: ContextType<T>);
+  constructor(data?: ConstructorDataType<T['data']>, context?: ContextType<T>);
 
   /**
    * A collection of Application instances which should be re-rendered whenever this document is updated.
@@ -33,7 +33,7 @@ export declare class ClientDocumentMixin<T extends foundry.abstract.Document<any
    * A cached reference to the FormApplication instance used to configure this Document.
    * @defaultValue `null`
    */
-  protected _sheet: FormApplication | null; // TODO: Replace mit InstanceType<ConfiguredSheetClass<T>> once the circular reference problem has been solved
+  protected _sheet: FormApplication | null; // TODO: Replace with InstanceType<ConfiguredSheetClass<T>> once the circular reference problem has been solved
 
   /**
    * @see abstract.Document#_initialize
@@ -279,7 +279,10 @@ export declare class ClientDocumentMixin<T extends foundry.abstract.Document<any
    */
   static createDialog<T extends DocumentConstructor>(
     this: T,
-    data?: Parameters<InstanceType<T>['data']['_initializeSource']>[0] & Record<string, unknown>,
+    data?: DeepPartial<
+      | ConstructorDataType<InstanceType<T>['data']>
+      | (ConstructorDataType<InstanceType<T>['data']> & Record<string, unknown>)
+    >,
     options?: Dialog.Options
   ): Promise<InstanceType<ConfiguredDocumentClass<T>> | undefined>;
 
@@ -332,10 +335,10 @@ export declare class ClientDocumentMixin<T extends foundry.abstract.Document<any
    * @param pack - A specific pack being exported to
    * @returns A data object of cleaned data suitable for compendium import
    */
-  toCompendium(
-    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-    pack?: any /* TODO: CompendiumCollection and remove comment above */
-  ): Omit<ReturnType<T['toObject']>, '_id' | 'folder' | 'permission'> & {
+  toCompendium(pack?: CompendiumCollection<CompendiumCollection.Metadata>): Omit<
+    ReturnType<T['toObject']>,
+    '_id' | 'folder' | 'permission'
+  > & {
     permission?: T extends { toObject(): infer U } ? U : never; // TODO: Whether or not this property exists depends on `pack`, improve when `pack` is typed
   };
 
@@ -375,15 +378,15 @@ export declare class ClientDocumentMixin<T extends foundry.abstract.Document<any
     this: T,
     updates?:
       | Array<
-          DeepPartial<Parameters<InstanceType<T>['data']['_initializeSource']>[0]> & { _id: string } & Record<
-              string,
-              unknown
-            >
+          DeepPartial<
+            | ConstructorDataType<InstanceType<T>['data']>
+            | (ConstructorDataType<InstanceType<T>['data']> & Record<string, unknown>)
+          > & { _id: string }
         >
-      | (DeepPartial<Parameters<InstanceType<T>['data']['_initializeSource']>[0]> & { _id: string } & Record<
-            string,
-            unknown
-          >),
+      | (DeepPartial<
+          | ConstructorDataType<InstanceType<T>['data']>
+          | (ConstructorDataType<InstanceType<T>['data']> & Record<string, unknown>)
+        > & { _id: string }),
     options?: DocumentModificationContext
   ): Promise<InstanceType<ConfiguredDocumentClass<T>>[]>;
 

--- a/src/foundry/foundry.js/clientDocuments/activeEffect.d.ts
+++ b/src/foundry/foundry.js/clientDocuments/activeEffect.d.ts
@@ -1,5 +1,5 @@
 import { DocumentModificationOptions } from '../../common/abstract/document.mjs';
-import { ConfiguredDocumentClass } from '../../../types/helperTypes';
+import { ConfiguredDocumentClass, ConstructorDataType } from '../../../types/helperTypes';
 import { EffectChangeData } from '../../common/data/data.mjs/effectChangeData';
 
 declare global {
@@ -133,7 +133,7 @@ declare global {
     protected _getSourceName(): Promise<string>;
 
     protected _preCreate(
-      data: Parameters<foundry.data.ActiveEffectData['_initializeSource']>[0],
+      data: ConstructorDataType<foundry.data.ActiveEffectData>,
       options: DocumentModificationOptions,
       user: foundry.documents.BaseUser
     ): Promise<void>;

--- a/src/foundry/foundry.js/clientDocuments/actor.d.ts
+++ b/src/foundry/foundry.js/clientDocuments/actor.d.ts
@@ -1,4 +1,4 @@
-import { ConfiguredDocumentClass, DocumentConstructor } from '../../../types/helperTypes';
+import { ConfiguredDocumentClass, ConstructorDataType, DocumentConstructor } from '../../../types/helperTypes';
 import { DocumentModificationOptions } from '../../common/abstract/document.mjs';
 import EmbeddedCollection from '../../common/abstract/embedded-collection.mjs';
 
@@ -158,7 +158,7 @@ declare global {
 
     /** @override */
     protected _preCreate(
-      data: Parameters<foundry.data.ActorData['_initializeSource']>[0],
+      data: ConstructorDataType<foundry.data.ActorData>,
       options: DocumentModificationOptions,
       user: foundry.documents.BaseUser
     ): Promise<void>;

--- a/src/foundry/foundry.js/clientDocuments/chatMessage.d.ts
+++ b/src/foundry/foundry.js/clientDocuments/chatMessage.d.ts
@@ -1,7 +1,5 @@
-import { ConfiguredDocumentClass } from '../../../types/helperTypes';
+import { ConfiguredDocumentClass, ConstructorDataType } from '../../../types/helperTypes';
 import { DocumentModificationOptions } from '../../common/abstract/document.mjs';
-import { ChatMessageData } from '../../common/data/data.mjs';
-import { ChatSpeakerData } from '../../common/data/data.mjs/chatSpeakerData';
 
 declare global {
   /**
@@ -105,7 +103,7 @@ declare global {
       actor?: InstanceType<ConfiguredDocumentClass<typeof Actor>>;
       token?: InstanceType<CONFIG['Token']['objectClass']>;
       alias?: string;
-    }): ChatSpeakerData['_source'];
+    }): foundry.data.ChatMessageData['speaker']['_source'];
 
     /**
      * A helper to prepare the speaker object based on a target TokenDocument
@@ -120,7 +118,7 @@ declare global {
     }: {
       token: InstanceType<ConfiguredDocumentClass<typeof foundry.documents.BaseToken>>;
       alias: string;
-    }): ChatSpeakerData['_source'];
+    }): foundry.data.ChatMessageData['speaker']['_source'];
     /**
      * A helper to prepare the speaker object based on a target TokenDocument
      *
@@ -135,7 +133,7 @@ declare global {
     }: {
       token: InstanceType<CONFIG['Token']['objectClass']>;
       alias: string;
-    }): ChatSpeakerData['_source'];
+    }): foundry.data.ChatMessageData['speaker']['_source'];
 
     /**
      * A helper to prepare the speaker object based on a target Actor
@@ -153,7 +151,7 @@ declare global {
       scene?: InstanceType<ConfiguredDocumentClass<typeof Scene>>;
       actor: InstanceType<ConfiguredDocumentClass<typeof Actor>>;
       alias?: string;
-    }): ChatSpeakerData['_source'];
+    }): foundry.data.ChatMessageData['speaker']['_source'];
 
     /**
      * A helper to prepare the speaker object based on a target User
@@ -171,13 +169,13 @@ declare global {
       scene?: InstanceType<ConfiguredDocumentClass<typeof Scene>>;
       user: InstanceType<ConfiguredDocumentClass<typeof User>>;
       alias?: string;
-    }): ChatSpeakerData['_source'];
+    }): foundry.data.ChatMessageData['speaker']['_source'];
 
     /**
      * Obtain an Actor instance which represents the speaker of this message (if any)
      * @param speaker - The speaker data object
      */
-    static getSpeakerActor(speaker: ChatSpeakerData['_source']): Actor | null;
+    static getSpeakerActor(speaker: foundry.data.ChatMessageData['speaker']['_source']): Actor | null;
 
     /**
      * Obtain a data object used to evaluate any dice rolls associated with this particular chat message
@@ -199,17 +197,21 @@ declare global {
 
     /** @override */
     _preCreate(
-      data: Parameters<ChatMessageData['_initializeSource']>[0],
+      data: ConstructorDataType<foundry.data.ChatMessageData>,
       options: DocumentModificationOptions,
       user: foundry.documents.BaseUser
     ): Promise<void>;
 
     /** @override */
-    _onCreate(data: ChatMessageData['_source'], options: DocumentModificationOptions, userId: string): void;
+    _onCreate(
+      data: foundry.data.ChatMessageData['_source'],
+      options: DocumentModificationOptions,
+      userId: string
+    ): void;
 
     /** @override */
     _onUpdate(
-      data: DeepPartial<ChatMessageData['_source']> & Record<string, unknown>,
+      data: DeepPartial<foundry.data.ChatMessageData['_source']> & Record<string, unknown>,
       options: DocumentModificationOptions,
       userId: string
     ): void;

--- a/src/foundry/foundry.js/clientDocuments/combat.d.ts
+++ b/src/foundry/foundry.js/clientDocuments/combat.d.ts
@@ -1,4 +1,4 @@
-import { ConfiguredDocumentClass, PropertiesToSource } from '../../../types/helperTypes';
+import { ConfiguredDocumentClass, ConstructorDataType, PropertiesToSource } from '../../../types/helperTypes';
 import { DocumentModificationOptions } from '../../common/abstract/document.mjs';
 import { CombatantDataProperties } from '../../common/data/data.mjs/combatantData';
 
@@ -180,13 +180,18 @@ declare global {
 
     /** @deprecated since 0.8.0 */
     createCombatant(
-      data: Parameters<Combatant['data']['_initializeSource']>[0],
+      data:
+        | ConstructorDataType<foundry.data.CombatData>
+        | (ConstructorDataType<foundry.data.CombatData> & Record<string, unknown>),
       options?: DocumentModificationContext
     ): this['createEmbeddedDocuments'];
 
     /** @deprecated since 0.8.0 */
     updateCombatant(
-      data: DeepPartial<Parameters<Combatant['data']['_initializeSource']>[0]>,
+      data: DeepPartial<
+        | ConstructorDataType<foundry.data.CombatData>
+        | (ConstructorDataType<foundry.data.CombatData> & Record<string, unknown>)
+      >,
       options?: DocumentModificationContext
     ): NonNullable<ReturnType<this['combatants']['get']>>['update'];
 

--- a/src/foundry/foundry.js/clientDocuments/folder.d.ts
+++ b/src/foundry/foundry.js/clientDocuments/folder.d.ts
@@ -1,5 +1,5 @@
 import { DocumentModificationOptions } from '../../common/abstract/document.mjs';
-import { ConfiguredDocumentClass } from '../../../types/helperTypes';
+import { ConfiguredDocumentClass, ConstructorDataType } from '../../../types/helperTypes';
 
 declare global {
   /**
@@ -68,7 +68,13 @@ declare global {
      * ClientDocumentMixin.createDialog, for which a Promise of the created
      * Document is returned.
      */
-    static createDialog(data?: DeepPartial<foundry.data.FolderData['_source']>, options?: Dialog.Options): any;
+    static createDialog(
+      data?: DeepPartial<
+        | ConstructorDataType<foundry.data.FolderData>
+        | (ConstructorDataType<foundry.data.FolderData> & Record<string, unknown>)
+      >,
+      options?: Dialog.Options
+    ): any;
 
     /**
      * Export all Documents contained in this Folder to a given Compendium pack.

--- a/src/foundry/foundry.js/clientDocuments/item.d.ts
+++ b/src/foundry/foundry.js/clientDocuments/item.d.ts
@@ -1,4 +1,4 @@
-import { ConfiguredDocumentClass } from '../../../types/helperTypes';
+import { ConfiguredDocumentClass, ConstructorDataType } from '../../../types/helperTypes';
 
 declare global {
   /**
@@ -69,10 +69,10 @@ declare global {
      * @deprecated since 0.8.1
      */
     static createOwned(
-      itemData: Parameters<Item['data']['_initializeSource']>[0] & Record<string, unknown>,
+      itemData:
+        | ConstructorDataType<foundry.data.ItemData>
+        | (ConstructorDataType<foundry.data.ItemData> & Record<string, unknown>),
       actor: InstanceType<ConfiguredDocumentClass<typeof foundry.documents.BaseActor>>
     ): InstanceType<ConfiguredDocumentClass<typeof foundry.documents.BaseItem>>;
   }
 }
-
-export {};

--- a/src/foundry/foundry.js/collections/documentCollections/compendiumCollection.d.ts
+++ b/src/foundry/foundry.js/collections/documentCollections/compendiumCollection.d.ts
@@ -1,4 +1,4 @@
-import { ConfiguredDocumentClassForName } from '../../../../types/helperTypes';
+import { ConfiguredDocumentClassForName, ConstructorDataType } from '../../../../types/helperTypes';
 import { IdQuery } from '../../../common/abstract/backend.mjs';
 import { DocumentModificationOptions } from '../../../common/abstract/document.mjs';
 
@@ -191,13 +191,18 @@ declare global {
 
     /** @deprecated since 0.8.0 */
     createEntity(
-      data: Parameters<DocumentInstanceForCompendiumMetadata<T>['data']['_initializeSource']>[0],
+      data:
+        | ConstructorDataType<DocumentInstanceForCompendiumMetadata<T>['data']>
+        | (ConstructorDataType<DocumentInstanceForCompendiumMetadata<T>['data']> & Record<string, unknown>),
       options?: Partial<DocumentModificationOptions>
     ): ReturnType<this['documentClass']['create']>;
 
     /** @deprecated since 0.8.0 */
     updateEntity(
-      data: DeepPartial<Parameters<DocumentInstanceForCompendiumMetadata<T>['data']['_initializeSource']>[0]> & {
+      data: DeepPartial<
+        | ConstructorDataType<DocumentInstanceForCompendiumMetadata<T>['data']>
+        | (ConstructorDataType<DocumentInstanceForCompendiumMetadata<T>['data']> & Record<string, unknown>)
+      > & {
         _id: string;
       },
       options?: Partial<DocumentModificationOptions>

--- a/src/foundry/foundry.js/collections/documentCollections/worldCollections/playlists.d.ts
+++ b/src/foundry/foundry.js/collections/documentCollections/worldCollections/playlists.d.ts
@@ -33,8 +33,7 @@ declare global {
      */
     protected _onChangeScene(
       scene: InstanceType<ConfiguredDocumentClass<typeof foundry.documents.BaseScene>>,
-      data: DeepPartial<Parameters<foundry.documents.BaseScene['data']['_initializeSource']>[0]> &
-        Record<string, unknown>
+      data: DeepPartial<ConstructorParameters<foundry.documents.BaseScene['data']>>
     ): Promise<void>;
   }
 }

--- a/src/types/helperTypes.ts
+++ b/src/types/helperTypes.ts
@@ -37,6 +37,13 @@ type SourceDataType<T extends Document<any, any> | AnyDocumentData> = T extends 
   ? SourceDataType<U>
   : never;
 
+/**
+ * Returns the type of the constructor data for the given {@link DocumentData}.
+ */
+export type ConstructorDataType<T extends AnyDocumentData> = T['_initializeSource'] extends (data: infer U) => any
+  ? U
+  : never;
+
 type ObjectToDeepPartial<T> = T extends object ? DeepPartial<T> : T;
 
 export type PropertyTypeToSourceParameterType<T> = ObjectToDeepPartial<PropertyTypeToSourceType<T>>;

--- a/test-d/foundry/common/abstract/document.mjs.test-d.ts
+++ b/test-d/foundry/common/abstract/document.mjs.test-d.ts
@@ -30,3 +30,13 @@ if (user) {
   expectType<boolean>(user.testUserPermission(user, 'LIMITED', { exact: true }));
   expectType<boolean>(user.testUserPermission(user, 'OWNER', { exact: false }));
 }
+
+// verify that document lifecycle methods work with source data is possible
+
+if (item) {
+  expectType<Promise<Item[]>>(Item.createDocuments([item.toObject()]));
+  expectType<Promise<Item | undefined>>(Item.create(item.toObject()));
+  expectType<Promise<Item[]>>(Item.updateDocuments([item.toObject()]));
+  expectType<Promise<Item | undefined>>(item.update(item.toObject()));
+  expectType<Item | Promise<Item | undefined>>(item.clone(item.toObject()));
+}

--- a/test-d/foundry/foundry.js/clientDocumentMixin.test-d.ts
+++ b/test-d/foundry/foundry.js/clientDocumentMixin.test-d.ts
@@ -17,3 +17,6 @@ expectType<Promise<Item | undefined>>(Item.createDialog()); // ClientDocumentMix
 // Properties
 // TODO: change to <InstanceType<ConfiguredSheetClass<Item>> | null> once the circular reference problem has been solved
 expectType<FormApplication | null>(doc.sheet);
+
+// ensure source can be used to create a new document with createDialog
+expectType<Promise<Item | undefined>>(Item.createDialog(doc.toObject()));


### PR DESCRIPTION
Additionally, this ensures that Document#create and similar methods can be used with _source data.