### PR TITLE
Update Localization

### DIFF
--- a/src/foundry/foundry.js/localization.d.ts
+++ b/src/foundry/foundry.js/localization.d.ts
@@ -1,123 +1,143 @@
-/**
- * A helper class which assists with localization and string translation
- */
-declare class Localization {
-  constructor(language: string);
+import { ModuleData, SystemData } from '../common/packages.mjs';
 
+declare global {
   /**
-   * The target language for localization
-   * @defaultValue `'en'`
+   * A helper class which assists with localization and string translation
    */
-  lang: string;
+  class Localization {
+    constructor(serverLanguage?: string);
 
-  /**
-   * The package authorized to provide default language configurations
-   * @defaultValue `'core'`
-   */
-  defaultModule: string;
+    /**
+     * The target language for localization
+     * @defaultValue `'en'`
+     */
+    lang: string;
 
-  /**
-   * The translation dictionary for the target language
-   * @defaultValue `{}`
-   */
-  translations: Record<string, string>;
+    /**
+     * The package authorized to provide default language configurations
+     * @defaultValue `'core'`
+     */
+    defaultModule: string;
 
-  /**
-   * Fallback translations if the target keys are not found
-   * @defaultValue `{}`
-   */
-  protected _fallback: Record<string, string>;
+    /**
+     * The translation dictionary for the target language
+     * @defaultValue `{}`
+     */
+    translations: Record<string, string | Record<string, string | Record<string, string | Record<string, unknown>>>>;
 
-  /* -------------------------------------------- */
+    /**
+     * Fallback translations if the target keys are not found
+     * @defaultValue `{}`
+     */
+    protected _fallback: Record<
+      string,
+      string | Record<string, string | Record<string, string | Record<string, unknown>>>
+    >;
 
-  /**
-   * Initialize the Localization module
-   * Discover available language translations and apply the current language setting
-   * @returns A Promise which resolves once languages are initialized
-   */
-  initialize(): Promise<void>;
+    /* -------------------------------------------- */
 
-  /* -------------------------------------------- */
+    /**
+     * Initialize the Localization module
+     * Discover available language translations and apply the current language setting
+     * @returns A Promise which resolves once languages are initialized
+     */
+    initialize(): Promise<void>;
 
-  /**
-   * Set a language as the active translation source for the session
-   * @param lang - A language string in CONFIG.supportedLanguages
-   * @returns A Promise which resolves once the translations for the requested language are ready
-   */
-  setLanguage(lang: string): Promise<void>;
+    /* -------------------------------------------- */
 
-  /* -------------------------------------------- */
+    /**
+     * Set a language as the active translation source for the session
+     * @param lang - A language string in CONFIG.supportedLanguages
+     * @returns A Promise which resolves once the translations for the requested language are ready
+     */
+    setLanguage(lang: string): Promise<void>;
 
-  /**
-   * Discover the available supported languages from the set of packages which are provided
-   */
-  protected _discoverSupportedLanguages(): void;
+    /* -------------------------------------------- */
 
-  /* -------------------------------------------- */
+    /**
+     * Discover the available supported languages from the set of packages which are provided
+     */
+    protected _discoverSupportedLanguages(): Record<string, string>;
 
-  /**
-   * Prepare the dictionary of translation strings for the requested language
-   * @param lang - The language for which to load translations
-   * @returns The retrieved translations object
-   */
-  protected _getTranslations(lang: string): Promise<Record<string, string>>;
+    /**
+     * Prepare the dictionary of translation strings for the requested language
+     * @param lang - The language for which to load translations
+     * @returns The retrieved translations object
+     */
+    protected _getTranslations(
+      lang: string
+    ): Promise<Record<string, string | Record<string, string | Record<string, string | Record<string, unknown>>>>>;
 
-  /* -------------------------------------------- */
+    /**
+     * Reduce the languages array provided by a package to an array of file paths of translations to load
+     * @param pkg  - The package data
+     * @param lang - The target language to filter on
+     * @returns An array of translation file paths
+     */
+    protected _filterLanguagePaths(pkg: ModuleData | SystemData, lang: string): string[];
 
-  /**
-   * Load a single translation file and return its contents as processed JSON
-   * @param src - The translation file path to load
-   */
-  protected _loadTranslationFile(src: string): Promise<object>;
+    /**
+     * Load a single translation file and return its contents as processed JSON
+     * @param src - The translation file path to load
+     * @returns The loaded translation dictionary
+     */
+    protected _loadTranslationFile(
+      src: string
+    ): Promise<Record<string, string | Record<string, string | Record<string, string | Record<string, unknown>>>>>;
 
-  /* -------------------------------------------- */
-  /*  Localization API                            */
-  /* -------------------------------------------- */
+    /**
+     * Return whether a certain string has a known translation defined.
+     * @param stringId - The string key being translated
+     * @param fallback - Allow fallback translations to count?
+     *                   (unused)
+     */
+    has(stringId: string, fallback?: boolean): boolean;
 
-  /**
-   * Return whether a certain string has a known translation defined.
-   * @param stringId - The string key being translated
-   * @param fallback - Allow fallback translations to count?
-   *                   (unused)
-   */
-  has(stringId: string, fallback?: any): boolean;
+    /**
+     * Localize a string by drawing a translation from the available translations dictionary, if available
+     * If a translation is not available, the original string is returned
+     * @param stringId - The string ID to translate
+     * @returns The translated string
+     *
+     * @example <caption>Localizing a simple string in JavaScript</caption>
+     * ```typescript
+     * {
+     *   "MYMODULE.MYSTRING": "Hello, this is my module!"
+     * }
+     * game.i18n.localize("MYMODULE.MYSTRING"); // Hello, this is my module!
+     * ```
+     *
+     * @example <caption>Localizing a simple string in Handlebars</caption>
+     * ```handlebars
+     * {{localize "MYMODULE.MYSTRING"}} <!-- Hello, this is my module! -->
+     * ```
+     */
+    localize(stringId: string): string;
 
-  /* -------------------------------------------- */
+    /**
+     * Localize a string including variable formatting for input arguments.
+     * Provide a string ID which defines the localized template.
+     * Variables can be included in the template enclosed in braces and will be substituted using those named keys.
+     *
+     * @param stringId - The string ID to translate
+     * @param data     - Provided input data
+     *                   (defaultValue: `{}`)
+     * @returns The translated and formatted string
+     *
 
-  /**
-   * Localize a string by drawing a translation from the available translations dictionary, if available
-   * If a translation is not available, the original string is returned
-   * @param stringId - The string ID to translate
-   * @returns The translated string
-   *
-   * @example
-   * ```typescript
-   * {
-   *   "MYMODULE.MYSTRING": "Hello, this is my module!"
-   * }
-   * game.i18n.localize("MYMODULE.MYSTRING"); // Hello, this is my module!
-   * ```
-   */
-  localize(stringId: string): string;
-
-  /* -------------------------------------------- */
-
-  /**
-   * Localize a string including variable formatting for input arguments.
-   * Provide a string ID which defines the localized template.
-   * Variables can be included in the template enclosed in braces and will be substituted using those named keys.
-   *
-   * @param stringId - The string ID to translate
-   * @param data     - Provided input data
-   * @returns The translated and formatted string
-   *
-   * @example
-   * ```typescript
-   * {
-   *   "MYMODULE.GREETING": "Hello {name}, this is my module!"
-   * }
-   * game.i18n.format("MYMODULE.GREETING", {name: "Andrew"}); // Hello Andrew, this is my module!
-   * ```
-   */
-  format(stringId: string, data?: Record<string, any>): string;
+     * @example <caption>Localizing a formatted string in JavaScript</caption>
+     * ```typescript
+     * {
+     *   "MYMODULE.GREETING": "Hello {name}, this is my module!"
+     * }
+     * game.i18n.format("MYMODULE.GREETING" {name: "Andrew"}); // Hello Andrew, this is my module!
+     * ```
+     *
+     * @example <caption>Localizing a formatted string in Handlebars</caption>
+     * ```handlebars
+     * {{localize "MYMODULE.GREETING" name="Andrew"}} <!-- Hello, this is my module! -->
+     * ```
+     */
+    format(stringId: string, data?: Record<string, any>): string;
+  }
 }

--- a/src/foundry/foundry.js/localization.d.ts
+++ b/src/foundry/foundry.js/localization.d.ts
@@ -5,6 +5,9 @@ declare global {
    * A helper class which assists with localization and string translation
    */
   class Localization {
+    /**
+     * @param serverLanguage - The default language configuration setting for the server
+     */
     constructor(serverLanguage?: string);
 
     /**
@@ -31,8 +34,6 @@ declare global {
      */
     protected _fallback: Translations;
 
-    /* -------------------------------------------- */
-
     /**
      * Initialize the Localization module
      * Discover available language translations and apply the current language setting
@@ -40,16 +41,12 @@ declare global {
      */
     initialize(): Promise<void>;
 
-    /* -------------------------------------------- */
-
     /**
      * Set a language as the active translation source for the session
      * @param lang - A language string in CONFIG.supportedLanguages
      * @returns A Promise which resolves once the translations for the requested language are ready
      */
     setLanguage(lang: string): Promise<void>;
-
-    /* -------------------------------------------- */
 
     /**
      * Discover the available supported languages from the set of packages which are provided
@@ -131,7 +128,7 @@ declare global {
      * {{localize "MYMODULE.GREETING" name="Andrew"}} <!-- Hello, this is my module! -->
      * ```
      */
-    format(stringId: string, data?: Record<string, any>): string;
+    format(stringId: string, data?: Record<string, unknown>): string;
   }
 }
 

--- a/src/foundry/foundry.js/localization.d.ts
+++ b/src/foundry/foundry.js/localization.d.ts
@@ -23,16 +23,13 @@ declare global {
      * The translation dictionary for the target language
      * @defaultValue `{}`
      */
-    translations: Record<string, string | Record<string, string | Record<string, string | Record<string, unknown>>>>;
+    translations: Translations;
 
     /**
      * Fallback translations if the target keys are not found
      * @defaultValue `{}`
      */
-    protected _fallback: Record<
-      string,
-      string | Record<string, string | Record<string, string | Record<string, unknown>>>
-    >;
+    protected _fallback: Translations;
 
     /* -------------------------------------------- */
 
@@ -64,9 +61,7 @@ declare global {
      * @param lang - The language for which to load translations
      * @returns The retrieved translations object
      */
-    protected _getTranslations(
-      lang: string
-    ): Promise<Record<string, string | Record<string, string | Record<string, string | Record<string, unknown>>>>>;
+    protected _getTranslations(lang: string): Promise<Translations>;
 
     /**
      * Reduce the languages array provided by a package to an array of file paths of translations to load
@@ -81,9 +76,7 @@ declare global {
      * @param src - The translation file path to load
      * @returns The loaded translation dictionary
      */
-    protected _loadTranslationFile(
-      src: string
-    ): Promise<Record<string, string | Record<string, string | Record<string, string | Record<string, unknown>>>>>;
+    protected _loadTranslationFile(src: string): Promise<Translations>;
 
     /**
      * Return whether a certain string has a known translation defined.
@@ -141,3 +134,7 @@ declare global {
     format(stringId: string, data?: Record<string, any>): string;
   }
 }
+
+type Translations = {
+  [K: string]: string | Translations;
+};

--- a/test-d/foundry/foundry.js/localization.test-d.ts
+++ b/test-d/foundry/foundry.js/localization.test-d.ts
@@ -1,12 +1,14 @@
 import { expectType } from 'tsd';
 
+type Translations = {
+  [K: string]: string | Translations;
+};
+
 new Localization();
 const localization = new Localization('en.core');
 expectType<string>(localization.lang);
 expectType<string>(localization.defaultModule);
-expectType<Record<string, string | Record<string, string | Record<string, string | Record<string, unknown>>>>>(
-  localization.translations
-);
+expectType<Translations>(localization.translations);
 expectType<Promise<void>>(localization.initialize());
 expectType<Promise<void>>(localization.setLanguage('de'));
 expectType<boolean>(localization.has('WORLD.DetailTab'));

--- a/test-d/foundry/foundry.js/localization.test-d.ts
+++ b/test-d/foundry/foundry.js/localization.test-d.ts
@@ -1,0 +1,16 @@
+import { expectType } from 'tsd';
+
+new Localization();
+const localization = new Localization('en.core');
+expectType<string>(localization.lang);
+expectType<string>(localization.defaultModule);
+expectType<Record<string, string | Record<string, string | Record<string, string | Record<string, unknown>>>>>(
+  localization.translations
+);
+expectType<Promise<void>>(localization.initialize());
+expectType<Promise<void>>(localization.setLanguage('de'));
+expectType<boolean>(localization.has('WORLD.DetailTab'));
+expectType<boolean>(localization.has('WORLD.DetailTab', true));
+expectType<string>(localization.localize('WORLD.DetailTab'));
+expectType<string>(localization.format('DICE.ErrorNonNumeric'));
+expectType<string>(localization.format('DICE.ErrorNonNumeric', { formula: '2d10' }));


### PR DESCRIPTION
Resolves #332 
Partially also #605 (not for 0.7)

Note: I did not check whether keys or values may be other values as strings. I guess keys cannot, but values can. IMHO, everything else than a string as value in a translation file is a ticket to hell …