### PR TITLE
Update ChatMessage#applyRollMode to be more permissive.

### DIFF
--- a/src/foundry/foundry.js/clientDocuments/chatMessage.d.ts
+++ b/src/foundry/foundry.js/clientDocuments/chatMessage.d.ts
@@ -72,9 +72,9 @@ declare global {
      * @returns The modified ChatMessage data with rollMode preferences applied
      */
     static applyRollMode(
-      chatData: foundry.data.ChatMessageData,
+      chatData: ConstructorDataType<foundry.data.ChatMessageData>,
       rollMode: foundry.CONST.DiceRollMode
-    ): foundry.data.ChatMessageData;
+    ): ConstructorDataType<foundry.data.ChatMessageData>;
 
     /**
      * Update the data of a ChatMessage instance to apply a requested rollMode

--- a/test-d/foundry/foundry.js/clientDocuments/chatMessage.test-d.ts
+++ b/test-d/foundry/foundry.js/clientDocuments/chatMessage.test-d.ts
@@ -1,18 +1,22 @@
 import { expectError, expectType } from 'tsd';
-import { ChatMessageData } from '../../../../src/foundry/common/data/data.mjs';
 import { ChatSpeakerData } from '../../../../src/foundry/common/data/data.mjs/chatSpeakerData';
+import { ConstructorDataType } from '../../../../src/types/helperTypes';
 
 expectType<ChatMessage>(new ChatMessage());
 expectType<ChatMessage>(new ChatMessage({}));
 
-expectType<ChatMessageData>(ChatMessage.applyRollMode(new foundry.data.ChatMessageData(), CONST.DICE_ROLL_MODES.BLIND));
-expectType<ChatMessageData>(
-  ChatMessage.applyRollMode(new foundry.data.ChatMessageData(), CONST.DICE_ROLL_MODES.PRIVATE)
+expectType<ConstructorDataType<foundry.data.ChatMessageData>>(
+  ChatMessage.applyRollMode({}, CONST.DICE_ROLL_MODES.BLIND)
 );
-expectType<ChatMessageData>(
-  ChatMessage.applyRollMode(new foundry.data.ChatMessageData(), CONST.DICE_ROLL_MODES.PUBLIC)
+expectType<ConstructorDataType<foundry.data.ChatMessageData>>(
+  ChatMessage.applyRollMode({}, CONST.DICE_ROLL_MODES.PRIVATE)
 );
-expectType<ChatMessageData>(ChatMessage.applyRollMode(new foundry.data.ChatMessageData(), CONST.DICE_ROLL_MODES.SELF));
+expectType<ConstructorDataType<foundry.data.ChatMessageData>>(
+  ChatMessage.applyRollMode({}, CONST.DICE_ROLL_MODES.PUBLIC)
+);
+expectType<ConstructorDataType<foundry.data.ChatMessageData>>(
+  ChatMessage.applyRollMode({}, CONST.DICE_ROLL_MODES.SELF)
+);
 expectError(ChatMessage.applyRollMode(new foundry.data.ChatMessageData(), 'custom-roll-mode'));
 
 expectType<ChatSpeakerData['_source']>(ChatMessage.getSpeaker());


### PR DESCRIPTION
Rather than fully rehashing this [you can read it here](https://discord.com/channels/732325252788387980/793933527065690184/863969310217207868), but short of it is that it does not really need a ChatMessageData, and works fine with the flatter instance of ChatMessageDataConstructorData, so I've made it a touch more flexible about what it accepts and returns the right thing in both cases.