### PR TITLE
Distinguish between stored documents and temporary ones

### DIFF
--- a/src/foundry/common/abstract/data.mjs.d.ts
+++ b/src/foundry/common/abstract/data.mjs.d.ts
@@ -290,7 +290,7 @@ declare abstract class DocumentData<
    * Extract the source data for the DocumentData into a simple object format that can be serialized.
    * @returns The document source data expressed as a plain object
    */
-  toJSON(): SourceData;
+  toJSON(): this['_id'] extends string ? SourceData & { _id: string } : SourceData;
 
   /**
    * Create a DocumentData instance using a provided serialized JSON string.

--- a/src/foundry/common/abstract/document.mjs.d.ts
+++ b/src/foundry/common/abstract/document.mjs.d.ts
@@ -147,7 +147,7 @@ declare abstract class Document<
       ConstructorDataType<ConcreteDocumentData> | (ConstructorDataType<ConcreteDocumentData> & Record<string, unknown>)
     >,
     { save, keepId }?: { save?: boolean; keepId?: boolean }
-  ): this | Promise<this | undefined>;
+  ): TemporaryDocument<this> | Promise<TemporaryDocument<this> | undefined>;
 
   /**
    * Get the permission level that a specific User has over this Document, a value in CONST.ENTITY_PERMISSIONS.
@@ -634,14 +634,20 @@ declare abstract class Document<
    * @returns The extracted primitive object
    */
   toObject(source?: true): ReturnType<this['toJSON']>;
-  toObject(source: false): ToObjectFalseType<ConcreteDocumentData>;
+  toObject(
+    source: false
+  ): this['id'] extends string
+    ? ToObjectFalseType<ConcreteDocumentData> & { _id: string }
+    : ToObjectFalseType<ConcreteDocumentData>;
 
   /**
    * Convert the Document instance to a primitive object which can be serialized.
    * See DocumentData#toJSON
    * @returns The document data expressed as a plain object
    */
-  toJSON(): ReturnType<ConcreteDocumentData['toJSON']>;
+  toJSON(): this['id'] extends string
+    ? ReturnType<ConcreteDocumentData['toJSON']> & { _id: string }
+    : ReturnType<ConcreteDocumentData['toJSON']>;
 }
 
 export interface DocumentModificationOptions {

--- a/src/foundry/foundry.js/clientDocuments/canvasDocuments/tokenDocument.d.ts
+++ b/src/foundry/foundry.js/clientDocuments/canvasDocuments/tokenDocument.d.ts
@@ -63,7 +63,7 @@ declare global {
     clone(
       data?: Parameters<foundry.documents.BaseToken['clone']>[0],
       options?: Parameters<foundry.documents.BaseToken['clone']>[1]
-    ): this;
+    ): TemporaryDocument<this>;
 
     /**
      * Create a synthetic Actor using a provided Token instance

--- a/src/types/utils.d.ts
+++ b/src/types/utils.d.ts
@@ -110,3 +110,13 @@ type Merge<T, U> = T extends object
       }
     : U
   : U;
+
+type StoredDocument<D extends foundry.abstract.Document<any, any>> = D & {
+  id: string;
+  data: D['data'] & {
+    _id: string;
+    _source: D['data']['_source'] & { _id: string };
+  };
+};
+
+type TemporaryDocument<D> = D extends StoredDocument<infer U> ? U : D;

--- a/test-d/types/utils.test-d.ts
+++ b/test-d/types/utils.test-d.ts
@@ -42,3 +42,39 @@ declare const titlecaseWithSpaces: Titlecase<'foo  bar'>;
 expectType<'Foo  Bar'>(titlecaseWithSpaces);
 declare const titlecaseWithThreeWords: Titlecase<'foo bar baz'>;
 expectType<'Foo Bar Baz'>(titlecaseWithThreeWords);
+
+declare const user: User;
+expectType<string | null>(user.id);
+expectType<string | null>(user.data._id);
+expectType<string | null>(user.data._source._id);
+expectType<string | null>(user.toJSON()._id);
+expectType<string | null>(user.toObject()._id);
+expectType<string | null>(user.toObject(false)._id);
+expectType<User | Promise<User | undefined>>(user.clone());
+
+declare const storedUser: StoredDocument<User>;
+expectType<string>(storedUser.id);
+expectType<string>(storedUser.data._id);
+expectType<string>(storedUser.data._source._id);
+expectType<string>(storedUser.toJSON()._id);
+expectType<string>(storedUser.toObject()._id);
+expectType<string>(storedUser.toObject(false)._id);
+expectType<User | Promise<User | undefined>>(storedUser.clone());
+
+declare const actor: StoredDocument<Actor>;
+expectType<string>(actor.id);
+expectType<string>(actor.data._id);
+expectType<string>(actor.data._source._id);
+expectType<string>(actor.toJSON()._id);
+expectType<string>(actor.toObject()._id);
+expectType<string>(actor.toObject(false)._id);
+expectType<Actor | Promise<Actor | undefined>>(actor.clone());
+
+if (actor.data.type === 'character') {
+  expectType<number>(actor.data.data.health);
+  expectType<number>(actor.data.data.movement);
+} else {
+  expectType<string>(actor.data.data.faction);
+  expectType<number>(actor.data.data.challenge);
+  expectType<number>(actor.data.data.damage);
+}

--- a/test-d/types/utils.test-d.ts
+++ b/test-d/types/utils.test-d.ts
@@ -48,8 +48,11 @@ expectType<string | null>(user.id);
 expectType<string | null>(user.data._id);
 expectType<string | null>(user.data._source._id);
 expectType<string | null>(user.toJSON()._id);
+expectType<string | null>(user.data.toJSON()._id);
 expectType<string | null>(user.toObject()._id);
+expectType<string | null>(user.data.toObject()._id);
 expectType<string | null>(user.toObject(false)._id);
+expectType<string | null>(user.data.toObject(false)._id);
 expectType<User | Promise<User | undefined>>(user.clone());
 
 declare const storedUser: StoredDocument<User>;
@@ -57,8 +60,11 @@ expectType<string>(storedUser.id);
 expectType<string>(storedUser.data._id);
 expectType<string>(storedUser.data._source._id);
 expectType<string>(storedUser.toJSON()._id);
+expectType<string>(storedUser.data.toJSON()._id);
 expectType<string>(storedUser.toObject()._id);
+expectType<string>(storedUser.data.toObject()._id);
 expectType<string>(storedUser.toObject(false)._id);
+expectType<string>(storedUser.data.toObject(false)._id);
 expectType<User | Promise<User | undefined>>(storedUser.clone());
 
 declare const actor: StoredDocument<Actor>;
@@ -66,8 +72,11 @@ expectType<string>(actor.id);
 expectType<string>(actor.data._id);
 expectType<string>(actor.data._source._id);
 expectType<string>(actor.toJSON()._id);
+expectType<string>(actor.data.toJSON()._id);
 expectType<string>(actor.toObject()._id);
+expectType<string>(actor.data.toObject()._id);
 expectType<string>(actor.toObject(false)._id);
+expectType<string>(actor.data.toObject(false)._id);
 expectType<Actor | Promise<Actor | undefined>>(actor.clone());
 
 if (actor.data.type === 'character') {


### PR DESCRIPTION
It is not as smart as I hoped it would be, but if I didn't overlook anything, it seems to work:

This PR adds a Type `StoredDocument<D>` and it's counterpart `TemporaryDocument<D>` (which is just used as return-type for cloning). Sincerely, I could not find a way without modifying `Document`, but it should not affect the original documents.

It could be used to type things like `game.user` or `canvas.scene`.