### PR TITLE
PreciseText → 0.8.8

### DIFF
--- a/src/foundry/foundry.js/pixi/texts/preciseText.d.ts
+++ b/src/foundry/foundry.js/pixi/texts/preciseText.d.ts
@@ -3,6 +3,8 @@
  * At default resolution Text often looks blurry or fuzzy.
  */
 declare class PreciseText extends PIXI.Text {
+  constructor(...args: ConstructorParameters<typeof PIXI.Text>);
+
   _autoResolution: false;
   _resolution: 2;
 }


### PR DESCRIPTION
Resolves #807 

(To be fair, it was already resolved, but the constructor was missing.)