### PR TITLE
AV: Allow customized AVClients and VOICE_MODES

### DIFF
--- a/src/foundry/foundry.js/avClient.d.ts
+++ b/src/foundry/foundry.js/avClient.d.ts
@@ -108,4 +108,9 @@ declare abstract class AVClient {
    * @param changed - The settings which have changed
    */
   onSettingsChanged(changed: DeepPartial<AVSettings.Settings>): void;
+
+  /**
+   * Custom properties or methods implemented by AVClients
+   */
+  [x: string]: any;
 }

--- a/src/foundry/foundry.js/avSettings.d.ts
+++ b/src/foundry/foundry.js/avSettings.d.ts
@@ -22,9 +22,7 @@ declare class AVSettings {
   };
 
   static VOICE_MODES: {
-    ALWAYS: 'always';
-    ACTIVITY: 'activity';
-    PTT: 'ptt';
+    [x: string]: string;
   };
 
   static DEFAULT_CLIENT_SETTINGS: {


### PR DESCRIPTION
An AVClient implentation may change the VOICE_MODES that are
implemented. To do so, AVSettings.VOICE_MODES may be overridden with
different or removed values.

Additionally, an AVClient may implement thier own custom properties or
methods. In this case, `game.webrtc.client` needs to recognize that
these may be used.

Implement both of these changes using recommentations from:
  https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#strict-object-literal-assignment-checking