### PR TITLE
Add core ActiveEffect flags to FlagConfig

### DIFF
--- a/src/foundry/foundry.js/config.d.ts
+++ b/src/foundry/foundry.js/config.d.ts
@@ -122,8 +122,14 @@ declare global {
   // eslint-disable-next-line @typescript-eslint/no-empty-interface
   interface SourceConfig {}
 
-  // eslint-disable-next-line @typescript-eslint/no-empty-interface
-  interface FlagConfig {}
+  interface FlagConfig {
+    ActiveEffect: {
+      core?: {
+        statusId?: string;
+        overlay?: boolean;
+      };
+    };
+  }
 
   // eslint-disable-next-line @typescript-eslint/no-empty-interface
   interface WebRTCConfig {}

--- a/test-d/foundry/foundry.js/clientDocuments/activeEffect.test-d.ts
+++ b/test-d/foundry/foundry.js/clientDocuments/activeEffect.test-d.ts
@@ -1,0 +1,8 @@
+import { expectError, expectType } from 'tsd';
+
+const eff = new ActiveEffect({});
+
+expectType<string | undefined>(eff.getFlag('core', 'statusId'));
+expectType<boolean | undefined>(eff.getFlag('core', 'overlay'));
+expectError(eff.setFlag('core', 'statusId', 0));
+expectError(eff.setFlag('core', 'overlay', 0));


### PR DESCRIPTION
Adds the flag used to tell if an ActiveEffect is considered a status
effect, which controls if the effect is shown as an icon on the token.

Adds the flag used to tell if an ActiveEffect is considered an overlay
effect, which displays over the token image.
