### PR TITLE
Fix IndexTypeForMetadata of CompendiumCollection

### DIFF
--- a/src/foundry/common/data/data.mjs/journalEntryData.d.ts
+++ b/src/foundry/common/data/data.mjs/journalEntryData.d.ts
@@ -35,7 +35,7 @@ interface JournalEntryDataProperties {
   /**
    * An image file path which provides the artwork for this JournalEntry
    */
-  img?: string | null;
+  img: string | null | undefined;
 
   /**
    * The _id of a Folder which contains this JournalEntry

--- a/src/foundry/foundry.js/collections/documentCollections/compendiumCollection.d.ts
+++ b/src/foundry/foundry.js/collections/documentCollections/compendiumCollection.d.ts
@@ -267,7 +267,7 @@ type DocumentInstanceForCompendiumMetadata<T extends CompendiumCollection.Metada
 
 type IndexTypeForMetadata<T extends CompendiumCollection.Metadata> = foundry.utils.Collection<
   Pick<
-    DocumentInstanceForCompendiumMetadata<T>['data'],
-    '_id' | 'name' | 'img' | 'type' extends keyof DocumentInstanceForCompendiumMetadata<T>['data'] ? 'type' : never
+    StoredDocument<DocumentInstanceForCompendiumMetadata<T>>['data'],
+    '_id' | 'name' | 'img' | ('type' extends keyof DocumentInstanceForCompendiumMetadata<T>['data'] ? 'type' : never)
   >
 >;

--- a/test-d/foundry/foundry.js/collections/documentCollections/compendiumCollection.test-d.ts
+++ b/test-d/foundry/foundry.js/collections/documentCollections/compendiumCollection.test-d.ts
@@ -12,3 +12,21 @@ const metadata = {
 const compendiumCollection = new CompendiumCollection(metadata);
 expectType<StoredDocument<JournalEntry>>(compendiumCollection.get('', { strict: true }));
 expectType<Array<StoredDocument<foundry.documents.BaseJournalEntry>['data']['_source']>>(compendiumCollection.toJSON());
+
+expectType<{
+  _id: string;
+  name: string;
+  img: string | null | undefined;
+}>((await compendiumCollection.getIndex()).get('some id', { strict: true }));
+
+const itemCollection = new CompendiumCollection({
+  entity: 'Item',
+  label: 'Important items',
+  name: 'items',
+  package: 'other-package',
+  path: 'path/to/items',
+  private: false
+});
+expectType<{ _id: string; name: string; img: string | null; type: 'armor' | 'weapon' }>(
+  (await itemCollection.getIndex()).get('some id', { strict: true })
+);


### PR DESCRIPTION
The `IndexTypeForMetadata` has invalid properties configured and did not use `StoredDocument` while the rest of the `CompendiumCollection` does.
It also fixes a small issue of `JournalEntryData` where the `img` property was marked invalid.

See [here](https://github.com/League-of-Foundry-Developers/foundry-vtt-types/pull/1178/checks?check_run_id=3600635096) for the result of the failing tests.