### PR TITLE
Remove protected annotation from Combat#current and Combat#previous

### DIFF
--- a/src/foundry/foundry.js/clientDocuments/combat.d.ts
+++ b/src/foundry/foundry.js/clientDocuments/combat.d.ts
@@ -24,10 +24,10 @@ declare global {
     turns: InstanceType<ConfiguredDocumentClass<typeof Combatant>>[];
 
     /** Record the current round, turn, and tokenId to understand changes in the encounter state */
-    protected current: RoundData;
+    current: RoundData;
 
     /** Track the previous round, turn, and tokenId to understand changes in the encounter state */
-    protected previous: RoundData;
+    previous: RoundData;
 
     /**
      * Track whether a sound notification is currently being played to avoid double-dipping


### PR DESCRIPTION
According to Atropos, these parameters are meant to be publicly
readable. Ref:
https://discord.com/channels/170995199584108546/811676497965613117/892110168450547763
