### PR TITLE
Allow optional properties in actor and item data for updates

### DIFF
--- a/src/foundry/foundry.js/pixi/containers/placeableObjects/token.d.ts
+++ b/src/foundry/foundry.js/pixi/containers/placeableObjects/token.d.ts
@@ -450,7 +450,7 @@ declare global {
 
     /** @override */
     protected _onUpdate(
-      data?: DeepPartial<InstanceType<ConfiguredDocumentClass<typeof TokenDocument>>['data']['_source']>,
+      data: DeepPartial<foundry.data.TokenData['_source']>,
       options?: DocumentModificationOptions & { animate?: boolean },
       userId?: string
     ): void;

--- a/src/types/utils.d.ts
+++ b/src/types/utils.d.ts
@@ -3,7 +3,7 @@
  * @internal
  */
 declare type DeepPartial<T> = {
-  [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P];
+  [P in keyof T]?: Exclude<T[P], undefined> extends object ? DeepPartial<Exclude<T[P], undefined>> : T[P];
 };
 
 /**

--- a/src/types/utils.d.ts
+++ b/src/types/utils.d.ts
@@ -2,9 +2,13 @@
  * Recursively sets keys of an object to optional. Used primarily for update methods
  * @internal
  */
-declare type DeepPartial<T> = {
-  [P in keyof T]?: Exclude<T[P], undefined> extends object ? DeepPartial<Exclude<T[P], undefined>> : T[P];
-};
+declare type DeepPartial<T> = T extends Array<infer U>
+  ? Array<DeepPartial<U>>
+  : T extends ReadonlyArray<infer U>
+  ? ReadonlyArray<DeepPartial<U>>
+  : {
+      [P in keyof T]?: Exclude<T[P], undefined> extends object ? DeepPartial<Exclude<T[P], undefined>> : T[P];
+    };
 
 /**
  * References the constructor of type `T`

--- a/test-d/foundry/common/data/data.mjs/actorData.test-d.ts
+++ b/test-d/foundry/common/data/data.mjs/actorData.test-d.ts
@@ -2,7 +2,7 @@ import { expectError, expectType } from 'tsd';
 
 interface CharacterDataSourceData {
   health: number;
-  hands: {
+  hands?: {
     left: string | null;
     right: string | null;
   };
@@ -103,4 +103,5 @@ if (actorData.type === 'character') {
   expectType<string>(actorData.flags['my-module']['hidden-name']);
 }
 
+// Optional properties
 actorData.update({ data: { hands: { left: '' } } });

--- a/test-d/foundry/common/data/data.mjs/actorData.test-d.ts
+++ b/test-d/foundry/common/data/data.mjs/actorData.test-d.ts
@@ -1,8 +1,11 @@
 import { expectError, expectType } from 'tsd';
-import '../../../../../index';
 
 interface CharacterDataSourceData {
   health: number;
+  hands: {
+    left: string | null;
+    right: string | null;
+  };
 }
 
 interface CharacterFlags {
@@ -99,3 +102,5 @@ if (actorData.type === 'character') {
   expectType<number>(actorData.data.damage);
   expectType<string>(actorData.flags['my-module']['hidden-name']);
 }
+
+actorData.update({ data: { hands: { left: '' } } });

--- a/test-d/foundry/common/documents.mjs/baseActor.test-d.ts
+++ b/test-d/foundry/common/documents.mjs/baseActor.test-d.ts
@@ -13,7 +13,7 @@ expectType<EffectDurationDataProperties>(baseActor.data._source.effects[0].durat
 
 interface CharacterDataSourceData {
   health: number;
-  hands: {
+  hands?: {
     left: string | null;
     right: string | null;
   };

--- a/test-d/foundry/common/documents.mjs/baseActor.test-d.ts
+++ b/test-d/foundry/common/documents.mjs/baseActor.test-d.ts
@@ -4,7 +4,6 @@ import type { ActiveEffectDataProperties } from '../../../../src/foundry/common/
 import type { EffectDurationDataProperties } from '../../../../src/foundry/common/data/data.mjs/effectDurationData';
 
 import { expectError, expectType } from 'tsd';
-import '../../../../index';
 
 const baseActor = new foundry.documents.BaseActor();
 expectType<EmbeddedCollection<typeof ActiveEffect, foundry.data.ActorData>>(baseActor.effects);
@@ -14,6 +13,10 @@ expectType<EffectDurationDataProperties>(baseActor.data._source.effects[0].durat
 
 interface CharacterDataSourceData {
   health: number;
+  hands: {
+    left: string | null;
+    right: string | null;
+  };
 }
 
 interface CharacterFlags {

--- a/test-d/types/utils.test-d.ts
+++ b/test-d/types/utils.test-d.ts
@@ -7,6 +7,18 @@ expectType<{ a?: string }>(membersBecomeOptional);
 const nestedMembersBecomeOptional: DeepPartial<{ a: { b: string } }> = { a: {} };
 expectType<{ a?: { b?: string } }>(nestedMembersBecomeOptional);
 
+const membersOfOptionalMembersBecomeOptional: DeepPartial<{ a?: { b: string } }> = { a: {} };
+expectType<{ a?: { b?: string } }>(membersOfOptionalMembersBecomeOptional);
+
+const membersInsideOfArraysBecomeOptional: DeepPartial<Array<{ a: string; b: string }>> = [{ a: 'a' }, { b: 'b' }];
+expectType<Array<{ a?: string; b?: string }>>(membersInsideOfArraysBecomeOptional);
+
+const membersInsideOfReadonlyArraysBecomeOptional: DeepPartial<ReadonlyArray<{ a: string; b: string }>> = [
+  { a: 'a' },
+  { b: 'b' }
+];
+expectType<ReadonlyArray<{ a?: string; b?: string }>>(membersInsideOfReadonlyArraysBecomeOptional);
+
 const expanded1: Expanded<{ foo: string }> = { foo: '' };
 expectType<{ foo: string }>(expanded1);
 const expanded2: Expanded<{ 'foo.bar': string }> = { foo: { bar: '' } };


### PR DESCRIPTION
I'm not 100 % sure about this.

I describe the problem first: If there is an optional property in `ActorData.data` or `ItemData.data` that has an object type, it is not possible to update this object partially.

If I'm right, there are can not be optional properties defined through `template.json` (and in fact it was just mistyped as optional in my code).
But I guess this should be fixed anyway, especially because `DeepPartial` is used not exclusively on actor and item data.