### PR TITLE
Add PlaceableObject#_original for clones

### DIFF
--- a/src/foundry/foundry.js/pixi/containers/placeableObject.d.ts
+++ b/src/foundry/foundry.js/pixi/containers/placeableObject.d.ts
@@ -17,6 +17,7 @@ declare global {
      */
     constructor(document: D);
 
+    /** @internal */
     protected _original?: this | undefined;
 
     /**


### PR DESCRIPTION
This is adds a back reference to the original `PlaceableObject` for clones. It is assigned in the `PlacableObject#clone()` method.