### PR TITLE
0.8.x/mouse interaction manager

### DIFF
--- a/src/foundry/foundry.js/mouseInteractionManager.d.ts
+++ b/src/foundry/foundry.js/mouseInteractionManager.d.ts
@@ -1,9 +1,6 @@
 /**
  * Handle mouse interaction events for a Canvas object.
  * There are three phases of events: hover, click, and drag
- * @typeParam O - Canvas object this instance handles events for
- * @typeParam T - Target object for mouseinteraction events. Generally a `ControlIcon` or `O`.
- *                (default: `O`)
  *
  * Hover Events:
  * _handleMouseOver
@@ -33,22 +30,24 @@
  * _handleDragCancel
  *  action: dragLeftCancel
  *  action: dragRightCancel
+ *
+ * @typeParam Object - The concrete {@link PIXI.Container} object that for which mouse interactions are being managed
  */
-declare class MouseInteractionManager<O extends PIXI.Container = PIXI.Container, T extends PIXI.Container = O> {
+declare class MouseInteractionManager<Object extends PIXI.Container = PIXI.Container> {
   /**
    * @param permissions - (default: `{}`)
    * @param callbacks   - (default: `{}`)
    * @param options     - (default: `{}`)
    */
   constructor(
-    object: O,
+    object: Object,
     layer: MouseInteractionManager['layer'],
     permissions?: MouseInteractionManager['permissions'],
     callbacks?: MouseInteractionManager['callbacks'],
     options?: MouseInteractionManager['options']
   );
 
-  object: O;
+  object: Object;
 
   layer: PIXI.Container;
 
@@ -56,24 +55,25 @@ declare class MouseInteractionManager<O extends PIXI.Container = PIXI.Container,
    * @defaultValue `{}`
    */
   permissions: Partial<
-    Record<MouseInteractionManager.EventNames, ((user: User, event: PIXI.InteractionEvent) => boolean) | boolean>
+    Record<
+      MouseInteractionManager.PermissionAction,
+      ((user: Game['user'], event: PIXI.InteractionEvent) => boolean) | boolean
+    >
   >;
 
   /**
    * @defaultValue `{}`
    */
-  callbacks: Partial<
-    Record<MouseInteractionManager.EventNames, ((event: Event | PIXI.InteractionEvent) => unknown) | null>
-  >;
+  callbacks: Partial<Record<MouseInteractionManager.Action, ((event: Event | PIXI.InteractionEvent) => void) | null>>;
 
   /**
    * @defaultValue `{}`
    */
-  options: { target?: string[] | string | null };
+  options: MouseInteractionManager.Options;
 
   /**
    * The current interaction state
-   * @defaultValue `0`
+   * @defaultValue `MouseInteractionManager.INTERACTION_STATES.NONE`
    */
   state: ValueOf<typeof MouseInteractionManager['INTERACTION_STATES']>;
 
@@ -82,7 +82,10 @@ declare class MouseInteractionManager<O extends PIXI.Container = PIXI.Container,
    * @defaultValue `{}`
    */
   handlers: Partial<
-    Record<'contextmenu' | 'mousedown' | 'mousemove' | 'mouseout' | 'mouseover' | 'mouseup' | 'rightdown', Function>
+    Record<
+      'contextmenu' | 'mousedown' | 'mousemove' | 'mouseout' | 'mouseover' | 'mouseup' | 'rightdown',
+      (event: PIXI.InteractionEvent | MouseEvent) => void
+    >
   >;
 
   /**
@@ -94,6 +97,7 @@ declare class MouseInteractionManager<O extends PIXI.Container = PIXI.Container,
   /**
    * The throttling time below which a mouse move event will not be handled
    * @defaultValue `Math.ceil(1000 / canvas.app.ticker.maxFPS)`
+   * @internal
    */
   protected _dragThrottleMS: number;
 
@@ -116,132 +120,9 @@ declare class MouseInteractionManager<O extends PIXI.Container = PIXI.Container,
   protected _dragRight: boolean;
 
   /**
-   * Get the target
-   * @returns `this.object` or `this.object[this.options.target]`
+   * An optional ControlIcon instance for the object
    */
-  get target(): T;
-
-  /**
-   * Activate interactivity for the handled object
-   */
-  activate(): this;
-
-  /**
-   * Test whether the current user has permission to perform a step of the workflow
-   * @param action - The action being attempted
-   * @param event  - The event being handled
-   * @returns Can the action be performed?
-   */
-  can(action: MouseInteractionManager.EventNames, event: Event | PIXI.InteractionEvent): boolean;
-
-  /**
-   * Execute a callback function associated with a certain action in the workflow
-   * @param action - The action being attempted
-   * @param event  - The event being handled
-   */
-  callback(action: MouseInteractionManager.EventNames, event: Event | PIXI.InteractionEvent): unknown;
-
-  /**
-   * A reference to the possible interaction states which can be observed
-   */
-  get states(): typeof MouseInteractionManager['INTERACTION_STATES'];
-
-  /**
-   * Activate a set of listeners which handle hover events on the target object
-   */
-  protected _activateHoverEvents(): void;
-
-  /**
-   * Activate a new set of listeners for click events on the target object
-   */
-  protected _activateClickEvents(): void;
-
-  /**
-   * Deactivate event listeners for click events on the target object
-   */
-  protected _deactivateClickEvents(): void;
-
-  /**
-   * Activate events required for handling a drag-and-drop workflow
-   */
-  protected _activateDragEvents(): void;
-
-  /**
-   * Deactivate events required for handling drag-and-drop workflow.
-   */
-  protected _deactivateDragEvents(): void;
-
-  /**
-   * Handle mouse-over events which activate downstream listeners and do not stop propagation.
-   */
-  protected _handleMouseOver(event: PIXI.InteractionEvent): unknown;
-
-  /**
-   * Handle mouse-out events which terminate hover workflows and do not stop propagation.
-   */
-  protected _handleMouseOut(event: PIXI.InteractionEvent): unknown;
-
-  /**
-   * Handle mouse-down events which activate downstream listeners.
-   * Stop further propagation only if the event is allowed by either single or double-click.
-   */
-  protected _handleMouseDown(event: PIXI.InteractionEvent): unknown;
-
-  /**
-   * Handle mouse-down which trigger a single left-click workflow.
-   */
-  protected _handleClickLeft(event: PIXI.InteractionEvent): void;
-
-  /**
-   * Handle mouse-down which trigger a single left-click workflow.
-   */
-  protected _handleClickLeft2(event: PIXI.InteractionEvent): unknown;
-
-  /**
-   * Handle right-click mouse-down events.
-   * Stop further propagation only if the event is allowed by either single or double-click.
-   */
-  protected _handleRightDown(event: PIXI.InteractionEvent): unknown;
-
-  /**
-   * Handle single right-click actions.
-   */
-  protected _handleClickRight(event: PIXI.InteractionEvent): void;
-
-  /**
-   * Handle double right-click actions.
-   */
-  protected _handleClickRight2(event: PIXI.InteractionEvent): unknown;
-
-  /**
-   * Handle mouse movement during a drag workflow
-   */
-  protected _handleMouseMove(event: PIXI.InteractionEvent): unknown;
-
-  /**
-   * Handle the beginning of a new drag start workflow, moving all controlled objects on the layer
-   */
-  protected _handleDragStart(event: PIXI.InteractionEvent): unknown;
-
-  /**
-   * Handle the continuation of a drag workflow, moving all controlled objects on the layer
-   */
-  protected _handleDragMove(event: PIXI.InteractionEvent): unknown;
-
-  /**
-   * Handle mouse up events which may optionally conclude a drag workflow
-   */
-  protected _handleMouseUp(event: PIXI.InteractionEvent): void;
-
-  /**
-   * Handle the conclusion of a drag workflow, placing all dragged objects back on the layer
-   */
-  protected _handleDragDrop(event: PIXI.InteractionEvent): void;
-
-  /**
-   * Handle the cancellation of a drag workflow, resetting back to the original state
-   */
-  protected _handleDragCancel(event: PointerEvent): void;
+  controlIcon: ControlIcon | undefined;
 
   /**
    * Enumerate the states of a mouse interaction workflow.
@@ -258,22 +139,185 @@ declare class MouseInteractionManager<O extends PIXI.Container = PIXI.Container,
     DRAG: 3;
     DROP: 4;
   };
+
+  /**
+   * Get the target
+   */
+  get target(): PIXI.Container;
+
+  /**
+   * Activate interactivity for the handled object
+   */
+  activate(): this;
+
+  /**
+   * Test whether the current user has permission to perform a step of the workflow
+   * @param action - The action being attempted
+   * @param event  - The event being handled
+   * @returns Can the action be performed?
+   */
+  can(action: MouseInteractionManager.PermissionAction, event: Event | PIXI.InteractionEvent): boolean;
+
+  /**
+   * Execute a callback function associated with a certain action in the workflow
+   * @param action - The action being attempted
+   * @param event  - The event being handled
+   */
+  callback(action: MouseInteractionManager.Action, event: Event | PIXI.InteractionEvent): unknown;
+
+  /**
+   * A reference to the possible interaction states which can be observed
+   */
+  get states(): typeof MouseInteractionManager['INTERACTION_STATES'];
+
+  /**
+   * Activate a set of listeners which handle hover events on the target object
+   * @internal
+   */
+  protected _activateHoverEvents(): void;
+
+  /**
+   * Activate a new set of listeners for click events on the target object
+   * @internal
+   */
+  protected _activateClickEvents(): void;
+
+  /**
+   * Deactivate event listeners for click events on the target object
+   * @internal
+   */
+  protected _deactivateClickEvents(): void;
+
+  /**
+   * Activate events required for handling a drag-and-drop workflow
+   * @internal
+   */
+  protected _activateDragEvents(): void;
+
+  /**
+   * Deactivate events required for handling drag-and-drop workflow.
+   * @internal
+   */
+  protected _deactivateDragEvents(): void;
+
+  /**
+   * Handle mouse-over events which activate downstream listeners and do not stop propagation.
+   * @internal
+   */
+  protected _handleMouseOver(event: PIXI.InteractionEvent): unknown;
+
+  /**
+   * Handle mouse-out events which terminate hover workflows and do not stop propagation.
+   * @internal
+   */
+  protected _handleMouseOut(event: PIXI.InteractionEvent): unknown;
+
+  /**
+   * Handle mouse-down events which activate downstream listeners.
+   * Stop further propagation only if the event is allowed by either single or double-click.
+   * @internal
+   */
+  protected _handleMouseDown(event: PIXI.InteractionEvent): unknown;
+
+  /**
+   * Handle mouse-down which trigger a single left-click workflow.
+   * @internal
+   */
+  protected _handleClickLeft(event: PIXI.InteractionEvent): void;
+
+  /**
+   * Handle mouse-down which trigger a single left-click workflow.
+   * @internal
+   */
+  protected _handleClickLeft2(event: PIXI.InteractionEvent): unknown;
+
+  /**
+   * Handle right-click mouse-down events.
+   * Stop further propagation only if the event is allowed by either single or double-click.
+   * @internal
+   */
+  protected _handleRightDown(event: PIXI.InteractionEvent): unknown;
+
+  /**
+   * Handle single right-click actions.
+   * @internal
+   */
+  protected _handleClickRight(event: PIXI.InteractionEvent): void;
+
+  /**
+   * Handle double right-click actions.
+   * @internal
+   */
+  protected _handleClickRight2(event: PIXI.InteractionEvent): unknown;
+
+  /**
+   * Handle mouse movement during a drag workflow
+   * @internal
+   */
+  protected _handleMouseMove(event: PIXI.InteractionEvent): unknown;
+
+  /**
+   * Handle the beginning of a new drag start workflow, moving all controlled objects on the layer
+   * @internal
+   */
+  protected _handleDragStart(event: PIXI.InteractionEvent): unknown;
+
+  /**
+   * Handle the continuation of a drag workflow, moving all controlled objects on the layer
+   * @internal
+   */
+  protected _handleDragMove(event: PIXI.InteractionEvent): unknown;
+
+  /**
+   * Handle mouse up events which may optionally conclude a drag workflow
+   * @internal
+   */
+  protected _handleMouseUp(event: PIXI.InteractionEvent): void;
+
+  /**
+   * Handle the conclusion of a drag workflow, placing all dragged objects back on the layer
+   * @internal
+   */
+  protected _handleDragDrop(event: PIXI.InteractionEvent): void;
+
+  /**
+   * Handle the cancellation of a drag workflow, resetting back to the original state
+   * @internal
+   */
+  protected _handleDragCancel(event: MouseEvent): void;
+
+  /**
+   * A public method to cancel a current interaction workflow from this manager.
+   * @param event - The event that initiates the cancellation
+   */
+  cancel(event: Event): void;
 }
 
 declare namespace MouseInteractionManager {
-  type EventNames =
+  type PermissionAction =
     | 'clickLeft'
     | 'clickLeft2'
     | 'clickRight'
     | 'clickRight2'
-    | 'dragLeftCancel'
     | 'dragLeftDrop'
     | 'dragLeftMove'
     | 'dragLeftStart'
-    | 'dragRightCancel'
     | 'dragRightDrop'
     | 'dragRightMove'
     | 'dragRightStart'
     | 'hoverIn'
     | 'hoverOut';
+
+  type Action = PermissionAction | 'dragLeftCancel' | 'dragRightCancel';
+
+  interface Options {
+    /**
+     * @remarks If set, this must be the name of a property of the object that is a {@link PIXI.Container}.
+     */
+    target?: string | null;
+
+    dragResistance?: number;
+  }
 }
+
+declare const a: PIXI.Container;

--- a/src/foundry/foundry.js/pixi/containers/canvasLayers/placeablesLayer.d.ts
+++ b/src/foundry/foundry.js/pixi/containers/canvasLayers/placeablesLayer.d.ts
@@ -273,7 +273,7 @@ declare global {
      * @param event - (unused)
      * @see {@link Canvas#_onClickLeft}
      */
-    protected _onClickLeft(event: PIXI.InteractionEvent): number | void;
+    protected _onClickLeft(event: PIXI.InteractionEvent): void;
 
     /**
      * Handle double left-click events which originate from the Canvas stage and are dispatched to this Layer.
@@ -285,9 +285,8 @@ declare global {
     /**
      * Start a left-click drag workflow originating from the Canvas stage.
      * @see {@link Canvas#_onDragLeftStart}
-     * @remarks This returns Promise<void> but is overridden by some subclasses.
      */
-    protected _onDragLeftStart(event: PIXI.InteractionEvent): Promise<void | PlaceableObject>;
+    protected _onDragLeftStart(event: PIXI.InteractionEvent): void;
 
     /**
      * Continue a left-click drag workflow originating from the Canvas stage.
@@ -298,11 +297,8 @@ declare global {
     /**
      * Conclude a left-click drag workflow originating from the Canvas stage.
      * @see {@link Canvas#_onDragLeftDrop}
-     * @remarks Returns always a promise but is overridden in subclasses.
      */
-    protected _onDragLeftDrop(
-      event: PIXI.InteractionEvent
-    ): Promise<InstanceType<ConfiguredDocumentClassForName<DocumentName>> | void> | void;
+    protected _onDragLeftDrop(event: PIXI.InteractionEvent): void;
 
     /**
      * Cancel a left-click drag workflow originating from the Canvas stage.
@@ -322,23 +318,15 @@ declare global {
      * Handle mouse-wheel events at the PlaceableObjects layer level to rotate multiple objects at once.
      * This handler will rotate all controlled objects by some incremental angle.
      * @param event - The mousewheel event which originated the request
-     * @remarks This methods just returns ReturnType\<this['rotateMany']\>|void but is overridden by subclasses
      */
-    protected _onMouseWheel(
-      event: WheelEvent
-    ):
-      | ReturnType<this['rotateMany']>
-      | ReturnType<InstanceType<ConfiguredObjectClassForName<DocumentName>>['rotate']>
-      | void;
+    protected _onMouseWheel(event: WheelEvent): void;
 
     /**
      * Handle a DELETE keypress while a placeable object is hovered
      * @param event - The delete key press event which triggered the request
      *                (unused)
      */
-    protected _onDeleteKey(
-      event?: any
-    ): Promise<InstanceType<ConfiguredDocumentClassForName<DocumentName>>[] | undefined>;
+    protected _onDeleteKey(event?: any): void;
 
     /**
      * @deprecated since 0.8.0

--- a/src/foundry/foundry.js/pixi/containers/canvasLayers/placeablesLayers/wallsLayer.d.ts
+++ b/src/foundry/foundry.js/pixi/containers/canvasLayers/placeablesLayers/wallsLayer.d.ts
@@ -196,7 +196,7 @@ declare global {
       | this['_cloneType'];
 
     /** @override */
-    protected _onDragLeftStart(event: PIXI.InteractionEvent): Promise<Wall>;
+    protected _onDragLeftStart(event: PIXI.InteractionEvent): void;
 
     /** @override */
     protected _onDragLeftMove(event: PIXI.InteractionEvent): void;

--- a/src/foundry/foundry.js/pixi/containers/placeableObject.d.ts
+++ b/src/foundry/foundry.js/pixi/containers/placeableObject.d.ts
@@ -50,7 +50,7 @@ declare global {
      * A mouse interaction manager instance which handles mouse workflows related to this object.
      * @defaultValue `null`
      */
-    mouseInteractionManager: MouseInteractionManager<this, ControlIcon | this> | null;
+    mouseInteractionManager: MouseInteractionManager<this> | null;
 
     /**
      * An indicator for whether the object is currently controlled

--- a/src/foundry/foundry.js/pixi/containers/placeableObjects/wall.d.ts
+++ b/src/foundry/foundry.js/pixi/containers/placeableObjects/wall.d.ts
@@ -22,7 +22,7 @@ declare global {
     /**
      * @remarks Type is `MouseInteractionManager<this, this['endpoints']>`
      */
-    mouseInteractionManager: MouseInteractionManager<this, any> | null;
+    mouseInteractionManager: MouseInteractionManager<this> | null;
 
     constructor(document: ConcreteWallDocument);
 

--- a/test-d/foundry/foundry.js/pixi/containers/placeableObject.test-d.ts
+++ b/test-d/foundry/foundry.js/pixi/containers/placeableObject.test-d.ts
@@ -29,8 +29,7 @@ expectAssignable<Document<any, any>>(placeable.document);
 expectType<EmbeddedOfSceneDocument>(placeable.document);
 expectType<DocumentSheet>(placeable.sheet);
 
-class NoIcon extends PlaceableObject<EmbeddedOfSceneDocument> {
-  controlIcon!: null;
+class ConcretePlaceableObject extends PlaceableObject<EmbeddedOfSceneDocument> {
   get bounds(): NormalizedRectangle {
     throw new Error('Not implemented');
   }
@@ -41,21 +40,6 @@ class NoIcon extends PlaceableObject<EmbeddedOfSceneDocument> {
     return this;
   }
 }
-expectType<MouseInteractionManager<NoIcon, NoIcon | ControlIcon> | null>(
-  new NoIcon(new EmbeddedOfSceneDocument()).mouseInteractionManager
-);
-
-class HasIcon extends PlaceableObject {
-  get bounds(): NormalizedRectangle {
-    throw new Error('Not implemented');
-  }
-  async draw() {
-    return this;
-  }
-  refresh() {
-    return this;
-  }
-}
-expectType<MouseInteractionManager<HasIcon, HasIcon | ControlIcon> | null>(
-  new HasIcon(new EmbeddedOfSceneDocument()).mouseInteractionManager
+expectType<MouseInteractionManager<ConcretePlaceableObject> | null>(
+  new ConcretePlaceableObject(new EmbeddedOfSceneDocument()).mouseInteractionManager
 );

--- a/test-d/foundry/foundry.js/pixi/containers/placeableObjects/wall.test-d.ts
+++ b/test-d/foundry/foundry.js/pixi/containers/placeableObjects/wall.test-d.ts
@@ -7,7 +7,7 @@ declare const ray: Ray;
 
 const wall = new Wall(doc);
 expectType<DoorControl | null>(wall.doorControl);
-expectType<MouseInteractionManager<Wall, any> | null>(wall.mouseInteractionManager);
+expectType<MouseInteractionManager<Wall> | null>(wall.mouseInteractionManager);
 expectType<Tile | undefined>(wall.roof);
 expectType<[number, number, number, number]>(wall.coords);
 expectType<NormalizedRectangle>(wall.bounds);


### PR DESCRIPTION
This updates `MouseInteractionManager` for foundry 0.8.9.

I also removed the 2nd generic parameter because it seemed pointless to me. It's not practically possible to infer the type parameter from the parameters given to the constructor and it's only used in a place, where imo it's good enough to know that it's a `PIXI.Container`. If you have objections to that, please let me know.

Also pinging @BoltsJ because you added the generic parameters originally.