### PR TITLE
Add uninitialized combat config type

### DIFF
--- a/src/foundry/foundry.js/clientSettings.d.ts
+++ b/src/foundry/foundry.js/clientSettings.d.ts
@@ -219,7 +219,7 @@ declare namespace ClientSettings {
   }
 
   interface Values {
-    'core.combatTrackerConfig': { resource: string; skipDefeated: boolean };
+    'core.combatTrackerConfig': { resource: string; skipDefeated: boolean } | {};
     'core.compendiumConfiguration': Partial<Record<string, CompendiumCollection.Configuration>>;
     'core.rollMode': foundry.CONST.DiceRollMode;
     'core.animateRollTable': boolean;

--- a/test-d/foundry/foundry.js/applications/sidebarTabs/combatTracker.test-d.ts
+++ b/test-d/foundry/foundry.js/applications/sidebarTabs/combatTracker.test-d.ts
@@ -21,7 +21,7 @@ expectType<
       combats: StoredDocument<Combat>[];
       combatCount: number;
       started: boolean;
-      settings: { resource: string; skipDefeated: boolean };
+      settings: { resource: string; skipDefeated: boolean } | {};
       currentIndex: -1;
       hasCombat: false;
       combat: null;
@@ -35,7 +35,7 @@ expectType<
       combats: StoredDocument<Combat>[];
       combatCount: number;
       started: boolean;
-      settings: { resource: string; skipDefeated: boolean };
+      settings: { resource: string; skipDefeated: boolean } | {};
       currentIndex: number;
       hasCombat: true;
       combat: StoredDocument<Combat>;

--- a/test-d/foundry/foundry.js/clientSettings.test-d.ts
+++ b/test-d/foundry/foundry.js/clientSettings.test-d.ts
@@ -73,7 +73,7 @@ clientSettings.register('some', 'stringSetting', {
 
 // core settings
 
-expectType<{ resource: string; skipDefeated: boolean }>(clientSettings.get('core', 'combatTrackerConfig'));
+expectType<{ resource: string; skipDefeated: boolean } | {}>(clientSettings.get('core', 'combatTrackerConfig'));
 expectType<Partial<Record<string, CompendiumCollection.Configuration>>>(
   clientSettings.get('core', 'compendiumConfiguration')
 );


### PR DESCRIPTION
This happens when the user never touched the combat settings since world
creation. In that case, the setting just returns an empty object.