### PR TITLE
Update constants.mjs.d.ts for V9.233

### DIFF
--- a/src/foundry/common/abstract/document.mjs.d.ts
+++ b/src/foundry/common/abstract/document.mjs.d.ts
@@ -153,7 +153,7 @@ declare abstract class Document<
    * @param user - The User being tested
    * @returns A numeric permission level from CONST.ENTITY_PERMISSIONS or null
    */
-  getUserLevel(user: BaseUser): foundry.CONST.EntityPermission | null;
+  getUserLevel(user: BaseUser): foundry.CONST.DOCUMENT_PERMISSION_LEVELS | null;
 
   /**
    * Test whether a certain User has a requested permission level (or greater) over the Document
@@ -165,7 +165,7 @@ declare abstract class Document<
    */
   testUserPermission(
     user: BaseUser,
-    permission: keyof typeof foundry.CONST.ENTITY_PERMISSIONS | foundry.CONST.EntityPermission,
+    permission: keyof typeof foundry.CONST.DOCUMENT_PERMISSION_LEVELS | foundry.CONST.DOCUMENT_PERMISSION_LEVELS,
     { exact }?: { exact?: boolean }
   ): boolean;
 

--- a/src/foundry/common/constants.mjs.d.ts
+++ b/src/foundry/common/constants.mjs.d.ts
@@ -27,42 +27,51 @@ export const ASCII = `__________________________________________________________
 /**
  * Define the allowed ActiveEffect application modes
  */
-export const ACTIVE_EFFECT_MODES: {
+export const ACTIVE_EFFECT_MODES: Readonly<{
   CUSTOM: 0;
   MULTIPLY: 1;
   ADD: 2;
   DOWNGRADE: 3;
   UPGRADE: 4;
   OVERRIDE: 5;
-};
+}>;
+export type ACTIVE_EFFECT_MODES = ValueOf<typeof ACTIVE_EFFECT_MODES>;
 
 /**
- * Define the string name used for the base entity type when specific sub-types are not defined by the system
+ * Define the string name used for the base document type when specific sub-types are not defined by the system
  */
-export const BASE_ENTITY_TYPE: 'base';
+export const BASE_DOCUMENT_TYPE: 'base';
+
+/**
+ * Define the methods by which a Card can be drawn from a Cards stack
+ * TOP and FIRST are synonymous, as are BOTTOM and LAST.
+ */
+export const CARD_DRAW_MODES: Readonly<{
+  FIRST: 0;
+  TOP: 0;
+  LAST: 1;
+  BOTTOM: 1;
+  RANDOM: 2;
+}>;
+export type CARD_DRAW_MODES = ValueOf<typeof CARD_DRAW_MODES>;
 
 /**
  * Valid Chat Message types
  */
-export const CHAT_MESSAGE_TYPES: {
+export const CHAT_MESSAGE_TYPES: Readonly<{
   OTHER: 0;
   OOC: 1;
   IC: 2;
   EMOTE: 3;
   WHISPER: 4;
   ROLL: 5;
-};
-
-/**
- * The allowed Entity types which may exist within a Compendium pack
- * This is a subset of ENTITY_TYPES
- */
-export const COMPENDIUM_ENTITY_TYPES: ['Actor', 'Item', 'Scene', 'JournalEntry', 'Macro', 'RollTable', 'Playlist'];
+}>;
+export type CHAT_MESSAGE_TYPES = ValueOf<typeof CHAT_MESSAGE_TYPES>;
 
 /**
  * Define the set of languages which have built-in support in the core software
  */
-export const CORE_SUPPORTED_LANGUAGES: ['en'];
+export const CORE_SUPPORTED_LANGUAGES: readonly ['en'];
 
 /**
  * The default artwork used for Token images if none is provided
@@ -80,43 +89,11 @@ export const DEFAULT_NOTE_ICON: 'icons/svg/book.svg';
 export const DEFAULT_MACRO_ICON: 'icons/svg/dice-target.svg';
 
 /**
- * The supported dice roll visibility modes
+ * Define the allowed Document class types.
  */
-export const DICE_ROLL_MODES: {
-  PUBLIC: 'roll';
-  PRIVATE: 'gmroll';
-  BLIND: 'blindroll';
-  SELF: 'selfroll';
-};
-
-/**
- * The allowed Drawing types which may be saved
- */
-export const DRAWING_TYPES: {
-  RECTANGLE: 'r';
-  ELLIPSE: 'e';
-  TEXT: 't';
-  POLYGON: 'p';
-  FREEHAND: 'f';
-};
-
-/**
- * The allowed fill types which a Drawing object may display
- * NONE: The drawing is not filled
- * SOLID: The drawing is filled with a solid color
- * PATTERN: The drawing is filled with a tiled image pattern
- */
-export const DRAWING_FILL_TYPES: {
-  NONE: 0;
-  SOLID: 1;
-  PATTERN: 2;
-};
-
-/**
- * Define the allowed Entity class types
- */
-export const ENTITY_TYPES: [
+export const DOCUMENT_TYPES: readonly [
   'Actor',
+  // 'Cards', // TODO: Add when cards support is added
   'ChatMessage',
   'Combat',
   'Item',
@@ -128,27 +105,100 @@ export const ENTITY_TYPES: [
   'Scene',
   'User'
 ];
+export type DOCUMENT_TYPES = ValueOf<typeof DOCUMENT_TYPES>;
 
 /**
- * Define the allowed Entity types which may be dynamically linked in chat
+ * The allowed Document types which may exist within a Compendium pack.
  */
-export const ENTITY_LINK_TYPES: ['Actor', 'Item', 'Scene', 'JournalEntry', 'Macro', 'RollTable'];
+export const COMPENDIUM_DOCUMENT_TYPES: readonly [
+  'Actor',
+  // 'Cards', // TODO: Add when cards support is added
+  'Item',
+  'JournalEntry',
+  'Macro',
+  'Playlist',
+  'RollTable',
+  'Scene',
+  'Adventure'
+];
+export type COMPENDIUM_DOCUMENT_TYPES = ValueOf<typeof COMPENDIUM_DOCUMENT_TYPES>;
 
 /**
- * Define the allowed permission levels for a non-user Entity.
+ * Define the allowed permission levels for a non-user Document.
  * Each level is assigned a value in ascending order. Higher levels grant more permissions.
  */
-export const ENTITY_PERMISSIONS: {
+export const DOCUMENT_PERMISSION_LEVELS: Readonly<{
   NONE: 0;
   LIMITED: 1;
   OBSERVER: 2;
   OWNER: 3;
-};
+}>;
+export type DOCUMENT_PERMISSION_LEVELS = ValueOf<typeof DOCUMENT_PERMISSION_LEVELS>;
 
 /**
- * Define the allowed Entity types which Folders may contain
+ * Define the allowed Document types which may be dynamically linked in chat
  */
-export const FOLDER_ENTITY_TYPES: ['Actor', 'Item', 'Scene', 'JournalEntry', 'Playlist', 'RollTable'];
+export const DOCUMENT_LINK_TYPES: readonly [
+  'Actor',
+  'Item',
+  'Scene',
+  'JournalEntry',
+  'Macro',
+  'RollTable',
+  'PlaylistSound'
+];
+export type DOCUMENT_LINK_TYPES = ValueOf<typeof DOCUMENT_LINK_TYPES>;
+
+/**
+ * The supported dice roll visibility modes
+ */
+export const DICE_ROLL_MODES: Readonly<{
+  PUBLIC: 'publicroll';
+  PRIVATE: 'gmroll';
+  BLIND: 'blindroll';
+  SELF: 'selfroll';
+}>;
+export type DICE_ROLL_MODES = ValueOf<typeof DICE_ROLL_MODES>;
+
+/**
+ * The allowed Drawing types which may be saved
+ */
+export const DRAWING_TYPES: Readonly<{
+  RECTANGLE: 'r';
+  ELLIPSE: 'e';
+  TEXT: 't';
+  POLYGON: 'p';
+  FREEHAND: 'f';
+}>;
+export type DRAWING_TYPES = ValueOf<typeof DRAWING_TYPES>;
+
+/**
+ * The allowed fill types which a Drawing object may display
+ * NONE: The drawing is not filled
+ * SOLID: The drawing is filled with a solid color
+ * PATTERN: The drawing is filled with a tiled image pattern
+ */
+export const DRAWING_FILL_TYPES: Readonly<{
+  NONE: 0;
+  SOLID: 1;
+  PATTERN: 2;
+}>;
+export type DRAWING_FILL_TYPES = ValueOf<typeof DRAWING_FILL_TYPES>;
+
+/**
+ * Define the allowed Document types which Folders may contain
+ */
+export const FOLDER_DOCUMENT_TYPES: readonly [
+  'Actor',
+  'Item',
+  'Scene',
+  'JournalEntry',
+  'Playlist',
+  'RollTable',
+  // 'Cards', // TODO: Add when cards support is added
+  'Macro'
+];
+export type FOLDER_DOCUMENT_TYPES = ValueOf<typeof FOLDER_DOCUMENT_TYPES>;
 
 /**
  * The maximum allowed level of depth for Folder nesting
@@ -158,7 +208,7 @@ export const FOLDER_MAX_DEPTH: 3;
 /**
  * A list of allowed game URL names
  */
-export const GAME_VIEWS: ['game', 'stream'];
+export const GAME_VIEWS: readonly ['game', 'stream'];
 
 /**
  * The minimum allowed grid size which is supported by the software
@@ -168,41 +218,35 @@ export const GRID_MIN_SIZE: 50;
 /**
  * The allowed Grid types which are supported by the software
  */
-export const GRID_TYPES: {
+export const GRID_TYPES: Readonly<{
   GRIDLESS: 0;
   SQUARE: 1;
   HEXODDR: 2;
   HEXEVENR: 3;
   HEXODDQ: 4;
   HEXEVENQ: 5;
-};
+}>;
+export type GRID_TYPES = ValueOf<typeof GRID_TYPES>;
 
 /**
  * A list of supported setup URL names
  */
-export const SETUP_VIEWS: ['license', 'setup', 'players', 'join'];
-
-/**
- * Enumerate the source types which can be used for an AmbientLight placeable object
- */
-export const SOURCE_TYPES: {
-  LOCAL: 'l';
-  GLOBAL: 'g';
-  UNIVERSAL: 'u';
-};
+export const SETUP_VIEWS: readonly ['license', 'setup', 'players', 'join', 'auth'];
 
 /**
  * An Array of valid MacroAction scope values
  */
-export const MACRO_SCOPES: ['global', 'actors', 'actor'];
+export const MACRO_SCOPES: readonly ['global', 'actors', 'actor'];
+export type MACRO_SCOPES = ValueOf<typeof MACRO_SCOPES>;
 
 /**
  * An enumeration of valid Macro types
  */
-export const MACRO_TYPES: {
+export const MACRO_TYPES: Readonly<{
   SCRIPT: 'script';
   CHAT: 'chat';
-};
+}>;
+export type MACRO_TYPES = ValueOf<typeof MACRO_TYPES>;
 
 /**
  * The allowed playback modes for an audio Playlist
@@ -211,29 +255,43 @@ export const MACRO_TYPES: {
  * SHUFFLE: The playlist plays sounds one at a time in randomized order
  * SIMULTANEOUS: The playlist plays all contained sounds at the same time
  */
-export const PLAYLIST_MODES: {
+export const PLAYLIST_MODES: Readonly<{
   DISABLED: -1;
   SEQUENTIAL: 0;
   SHUFFLE: 1;
   SIMULTANEOUS: 2;
-};
+}>;
+export type PLAYLIST_MODES = ValueOf<typeof PLAYLIST_MODES>;
+
+/**
+ * The available sort modes for an audio Playlist.
+ * ALPHABETICAL (default): Sort sounds alphabetically.
+ * MANUAL: Sort sounds by manual drag-and-drop.
+ */
+export const PLAYLIST_SORT_MODES: Readonly<{
+  ALPHABETICAL: 'a';
+  MANUAL: 'm';
+}>;
+export type PLAYLIST_SORT_MODES = ValueOf<typeof PLAYLIST_SORT_MODES>;
 
 /**
  * The allowed package types
  */
-export const PACKAGE_TYPES: ['world', 'system', 'module'];
+export const PACKAGE_TYPES: readonly ['world', 'system', 'module'];
+export type PACKAGE_TYPES = ValueOf<typeof PACKAGE_TYPES>;
 
 /**
  * Encode the reasons why a package may be available or unavailable for use
  */
-export const PACKAGE_AVAILABILITY_CODES: {
+export const PACKAGE_AVAILABILITY_CODES: Readonly<{
   UNKNOWN: -1;
   REQUIRES_UPDATE: 0;
   AVAILABLE: 1;
   REQUIRES_SYSTEM: 2;
   REQUIRES_DEPENDENCY: 3;
   REQUIRES_CORE: 4;
-};
+}>;
+export type PACKAGE_AVAILABILITY_CODES = ValueOf<typeof PACKAGE_AVAILABILITY_CODES>;
 
 /**
  * A safe password string which can be displayed
@@ -243,22 +301,13 @@ export const PASSWORD_SAFE_STRING: '••••••••••••••�
 /**
  * The allowed software update channels
  */
-export const SOFTWARE_UPDATE_CHANNELS: {
-  /**
-   * @defaultValue `'SETUP.UpdateAlpha'`
-   */
-  alpha: string;
-
-  /**
-   * @defaultValue `'SETUP.UpdateBeta'`
-   */
-  beta: string;
-
-  /**
-   * @defaultValue `'SETUP.UpdateBeta'`
-   */
-  release: string;
-};
+export const SOFTWARE_UPDATE_CHANNELS: Readonly<{
+  stable: 'SETUP.UpdateStable';
+  testing: 'SETUP.UpdateTesting';
+  development: 'SETUP.UpdateDevelopment';
+  prototype: 'SETUP.UpdatePrototype';
+}>;
+export type SOFTWARE_UPDATE_CHANNELS = ValueOf<typeof SOFTWARE_UPDATE_CHANNELS>;
 
 /**
  * The default sorting density for manually ordering child objects within a parent
@@ -268,32 +317,44 @@ export const SORT_INTEGER_DENSITY: 100000;
 /**
  * The allowed types of a TableResult document
  */
-export const TABLE_RESULT_TYPES: {
+declare const tableResultTypes: Readonly<{
   TEXT: 0;
-  ENTITY: 1;
+  DOCUMENT: 1;
   COMPENDIUM: 2;
-};
+  /**
+   * @deprecated TABLE_RESULT_TYPES.ENTITY is deprecated. Please use TABLE_RESULT_TYPES.DOCUMENT instead.
+   */
+  get ENTITY(): 1;
+}>;
+
+/**
+ * The allowed types of a TableResult document
+ */
+export const TABLE_RESULT_TYPES: typeof tableResultTypes;
+export type TABLE_RESULT_TYPES = ValueOf<typeof TABLE_RESULT_TYPES>;
 
 /**
  * Define the valid anchor locations for a Tooltip displayed on a Placeable Object
  */
-export const TEXT_ANCHOR_POINTS: {
+export const TEXT_ANCHOR_POINTS: Readonly<{
   CENTER: 0;
   BOTTOM: 1;
   TOP: 2;
   LEFT: 3;
   RIGHT: 4;
-};
+}>;
+export type TEXT_ANCHOR_POINTS = ValueOf<typeof TEXT_ANCHOR_POINTS>;
 
 /**
  * Define the valid occlusion modes which an overhead tile can use
  */
-export const TILE_OCCLUSION_MODES: {
+export const TILE_OCCLUSION_MODES: Readonly<{
   NONE: 0;
   FADE: 1;
   ROOF: 2;
   RADIAL: 3;
-};
+}>;
+export type TILE_OCCLUSION_MODES = ValueOf<typeof TILE_OCCLUSION_MODES>;
 
 /**
  * Describe the various thresholds of token control upon which to show certain pieces of information
@@ -304,14 +365,15 @@ export const TILE_OCCLUSION_MODES: {
  * OWNER - always displayed for a GM or for a user who owns the actor
  * ALWAYS - always displayed for everyone
  */
-export const TOKEN_DISPLAY_MODES: {
+export const TOKEN_DISPLAY_MODES: Readonly<{
   NONE: 0;
   CONTROL: 10;
   OWNER_HOVER: 20;
   HOVER: 30;
   OWNER: 40;
   ALWAYS: 50;
-};
+}>;
+export type TOKEN_DISPLAY_MODES = ValueOf<typeof TOKEN_DISPLAY_MODES>;
 
 /**
  * The allowed Token disposition types
@@ -319,68 +381,54 @@ export const TOKEN_DISPLAY_MODES: {
  * NEUTRAL - Displayed as neutral with a yellow border
  * FRIENDLY - Displayed as an ally with a cyan border
  */
-export const TOKEN_DISPOSITIONS: {
+export const TOKEN_DISPOSITIONS: Readonly<{
   HOSTILE: -1;
   NEUTRAL: 0;
   FRIENDLY: 1;
-};
+}>;
+export type TOKEN_DISPOSITIONS = ValueOf<typeof TOKEN_DISPOSITIONS>;
 
 /**
  * Define the allowed User permission levels.
  * Each level is assigned a value in ascending order. Higher levels grant more permissions.
  */
-export const USER_ROLES: {
+export const USER_ROLES: Readonly<{
   NONE: 0;
   PLAYER: 1;
   TRUSTED: 2;
   ASSISTANT: 3;
   GAMEMASTER: 4;
-};
+}>;
+export type USER_ROLES = ValueOf<typeof USER_ROLES>;
 
 /**
  * Invert the User Role mapping to recover role names from a role integer
  */
-export const USER_ROLE_NAMES: { [Key in keyof typeof USER_ROLES as typeof USER_ROLES[Key]]: Key };
-
-export interface MeasuredTemplateTypes {
-  CIRCLE: 'circle';
-  CONE: 'cone';
-  RECTANGLE: 'rect';
-  RAY: 'ray';
-}
+export const USER_ROLE_NAMES: Readonly<{ [Key in keyof typeof USER_ROLES as typeof USER_ROLES[Key]]: Key }>;
+export type USER_ROLE_NAMES = ValueOf<typeof USER_ROLE_NAMES>;
 
 /**
  * An enumeration of the allowed types for a MeasuredTemplate embedded document
  */
-export const MEASURED_TEMPLATE_TYPES: MeasuredTemplateTypes;
-
-/**
- * A list of MIME types which are treated as uploaded "media", which are allowed to overwrite existing files.
- * Any non-media MIME type is not allowed to replace an existing file.
- * @defaultValue
- * ```typescript
- * [
- *   "application/json", "application/ogg", "application/pdf",
- *   "audio/wave", "audio/wav", "audio/webm", "audio/ogg", "audio/midi", "audio/mpeg", "audio/opus", "audio/aac",
- *   "image/apng", "image/bmp", "image/gif", "image/jpeg", "image/png", "image/svg+xml", "image/tiff", "image/webp",
- *   "text/plain", "text/markdown",
- *   "video/mpeg", "video/mp4", "video/ogg"
- * ]
- * ```
- */
-export const MEDIA_MIME_TYPES: string[];
+export const MEASURED_TEMPLATE_TYPES: Readonly<{
+  CIRCLE: 'circle';
+  CONE: 'cone';
+  RECTANGLE: 'rect';
+  RAY: 'ray';
+}>;
+export type MEASURED_TEMPLATE_TYPES = ValueOf<typeof MEASURED_TEMPLATE_TYPES>;
 
 export interface UserCapability {
   disableGM: boolean;
   hint: string;
   label: string;
-  defaultRole: UserRole;
+  defaultRole: USER_ROLES;
 }
 
 /**
  * Define the recognized User capabilities which individual Users or role levels may be permitted to perform
  */
-export const USER_PERMISSIONS: {
+export const USER_PERMISSIONS: Readonly<{
   /**
    * @defaultValue
    * ```typescript
@@ -614,7 +662,7 @@ export const USER_PERMISSIONS: {
    * ```
    */
   WALL_DOORS: UserCapability;
-};
+}>;
 
 /**
  * The allowed directions of effect that a Wall can have
@@ -622,11 +670,12 @@ export const USER_PERMISSIONS: {
  * LEFT: The wall collides only when a ray strikes its left side
  * RIGHT: The wall collides only when a ray strikes its right side
  */
-export const WALL_DIRECTIONS: {
+export const WALL_DIRECTIONS: Readonly<{
   BOTH: 0;
   LEFT: 1;
   RIGHT: 2;
-};
+}>;
+export type WALL_DIRECTIONS = ValueOf<typeof WALL_DIRECTIONS>;
 
 /**
  * The allowed door types which a Wall may contain
@@ -634,11 +683,12 @@ export const WALL_DIRECTIONS: {
  * DOOR: The wall contains a regular door
  * SECRET: The wall contains a secret door
  */
-export const WALL_DOOR_TYPES: {
+export const WALL_DOOR_TYPES: Readonly<{
   NONE: 0;
   DOOR: 1;
   SECRET: 2;
-};
+}>;
+export type WALL_DOOR_TYPES = ValueOf<typeof WALL_DOOR_TYPES>;
 
 /**
  * The allowed door states which may describe a Wall that contains a door
@@ -646,21 +696,17 @@ export const WALL_DOOR_TYPES: {
  * OPEN: The door is open
  * LOCKED: The door is closed and locked
  */
-export const WALL_DOOR_STATES: {
+export const WALL_DOOR_STATES: Readonly<{
   CLOSED: 0;
   OPEN: 1;
   LOCKED: 2;
-};
+}>;
+export type WALL_DOOR_STATES = ValueOf<typeof WALL_DOOR_STATES>;
 
 /**
- * The types of movement collision which a Wall may impose
- * NONE: Movement does not collide with this wall
- * NORMAL: Movement collides with this wall
+ * The wall properties which restrict the way interaction occurs with a specific wall
  */
-export const WALL_MOVEMENT_TYPES: {
-  NONE: 0;
-  NORMAL: 1;
-};
+export const WALL_RESTRICTION_TYPES: readonly ['light', 'sight', 'sound', 'move'];
 
 /**
  * The types of sensory collision which a Wall may impose
@@ -668,82 +714,211 @@ export const WALL_MOVEMENT_TYPES: {
  * NORMAL: Senses collide with this wall
  * LIMITED: Senses collide with the second intersection, bypassing the first
  */
-export const WALL_SENSE_TYPES: {
+export const WALL_SENSE_TYPES: Readonly<{
   NONE: 0;
+  LIMITED: 10;
+  NORMAL: 20;
+}>;
+export type WALL_SENSE_TYPES = ValueOf<typeof WALL_SENSE_TYPES>;
+
+/**
+ * The types of movement collision which a Wall may impose
+ * NONE: Movement does not collide with this wall
+ * NORMAL: Movement collides with this wall
+ */
+export const WALL_MOVEMENT_TYPES: Readonly<{
+  NONE: typeof WALL_SENSE_TYPES.NONE;
+  NORMAL: typeof WALL_SENSE_TYPES.NORMAL;
+}>;
+export type WALL_MOVEMENT_TYPES = ValueOf<typeof WALL_MOVEMENT_TYPES>;
+
+/**
+ * The possible precedence values a Keybinding might run in
+ * PRIORITY: Runs in the first group along with other PRIORITY keybindings
+ * NORMAL: Runs after the PRIORITY group along with other NORMAL keybindings
+ * DEFERRED: Runs in the last group along with other DEFERRED keybindings
+ */
+export const KEYBINDING_PRECEDENCE: Readonly<{
+  PRIORITY: 0;
   NORMAL: 1;
-  LIMITED: 2;
-};
+  DEFERRED: 2;
+}>;
+export type KEYBINDING_PRECEDENCE = ValueOf<typeof KEYBINDING_PRECEDENCE>;
 
 /**
  * The allowed set of HTML template extensions
- * @defaultValue `["html", "handlebars", "hbs"]`
  */
-export const HTML_FILE_EXTENSIONS: string[];
+export const HTML_FILE_EXTENSIONS: readonly ['html', 'handlebars', 'hbs'];
 
 /**
- * The supported file extensions for image-type files
- * @defaultValue `["jpg", "jpeg", "png", "svg", "webp"]`
+ * The supported file extensions for image-type files, and their corresponding mime types.
  */
-export const IMAGE_FILE_EXTENSIONS: string[];
+export const IMAGE_FILE_EXTENSIONS: Readonly<{
+  apng: 'image/apng';
+  avif: 'image/avif';
+  bmp: 'image/bmp';
+  gif: 'image/gif';
+  jpg: 'image/jpeg';
+  jpeg: 'image/jpeg';
+  png: 'image/png';
+  svg: 'image/svg+xml';
+  tiff: 'image/tiff';
+  webp: 'image/webp';
+}>;
+export type IMAGE_FILE_EXTENSIONS = ValueOf<typeof IMAGE_FILE_EXTENSIONS>;
 
 /**
- * The supported file extensions for video-type files
- * @defaultValue `["mp4", "ogg", "webm", "m4v"]`
+ * The supported file extensions for video-type files, and their corresponding mime types.
  */
-export const VIDEO_FILE_EXTENSIONS: string[];
+export const VIDEO_FILE_EXTENSIONS: Readonly<{
+  m4v: 'video/mp4';
+  mp4: 'video/mp4';
+  ogg: 'video/ogg';
+  webm: 'video/webm';
+}>;
+export type VIDEO_FILE_EXTENSIONS = ValueOf<typeof VIDEO_FILE_EXTENSIONS>;
 
 /**
- * The supported file extensions for audio-type files
- * @defaultValue `["flac", "m4a", "mp3", "ogg", "opus", "wav", "webm"]`
+ * The supported file extensions for audio-type files, and their corresponding mime types.
  */
-export const AUDIO_FILE_EXTENSIONS: string[];
+export const AUDIO_FILE_EXTENSIONS: Readonly<{
+  aac: 'audio/aac';
+  flac: 'audio/flac';
+  m4a: 'audio/mp4';
+  mid: 'audio/midi';
+  mp3: 'audio/mpeg';
+  ogg: 'audio/ogg';
+  opus: 'audio/opus';
+  wav: 'audio/wav';
+  webm: 'audio/webm';
+}>;
+export type AUDIO_FILE_EXTENSIONS = ValueOf<typeof AUDIO_FILE_EXTENSIONS>;
 
 /**
- * @deprecated since 0.8.0
+ * The supported file extensions for text files, and their corresponding mime types.
  */
-export const DRAWING_DEFAULT_VALUES: {
-  width: 0;
-  height: 0;
-  rotation: 0;
-  z: 0;
-  hidden: false;
-  locked: false;
-  fillType: typeof DRAWING_FILL_TYPES.NONE;
-  fillAlpha: 0.5;
-  bezierFactor: 0.0;
-  strokeAlpha: 1.0;
-  strokeWidth: 8;
-  fontSize: 48;
-  textAlpha: 1.0;
-  textColor: '#FFFFFF';
-};
+export const TEXT_FILE_EXTENSIONS: Readonly<{
+  json: 'application/json';
+  md: 'text/markdown';
+  pdf: 'application/pdf';
+  txt: 'text/plain';
+}>;
+export type TEXT_FILE_EXTENSIONS = ValueOf<typeof TEXT_FILE_EXTENSIONS>;
 
-export type ActiveEffectMode = ValueOf<typeof ACTIVE_EFFECT_MODES>;
-export type ChatMessageType = ValueOf<typeof CHAT_MESSAGE_TYPES>;
-export type DiceRollMode = ValueOf<typeof DICE_ROLL_MODES>;
-export type DrawingFillType = ValueOf<typeof DRAWING_FILL_TYPES>;
-export type DrawingType = ValueOf<typeof DRAWING_TYPES>;
-export type EntityPermission = ValueOf<typeof ENTITY_PERMISSIONS>;
-export type EntityType = ValueOf<typeof ENTITY_TYPES>;
-export type FolderEntityTypes = ValueOf<typeof FOLDER_ENTITY_TYPES>;
-export type CompendiumEntityType = ValueOf<typeof COMPENDIUM_ENTITY_TYPES>;
-export type GridType = ValueOf<typeof GRID_TYPES>;
-export type MacroTypes = ValueOf<typeof CONST.MACRO_TYPES>;
-export type MacroScopes = ValueOf<typeof CONST.MACRO_SCOPES>;
-export type PackageAvailabilityCode = ValueOf<typeof PACKAGE_AVAILABILITY_CODES>;
-export type PackageTypes = ValueOf<typeof PACKAGE_TYPES>;
-export type PlaylistMode = ValueOf<typeof PLAYLIST_MODES>;
-export type SoftwareUpdateChannel = ValueOf<typeof SOFTWARE_UPDATE_CHANNELS>;
-export type SourceType = ValueOf<typeof SOURCE_TYPES>;
-export type TableResultType = ValueOf<typeof TABLE_RESULT_TYPES>;
-export type TextAnchorPoint = ValueOf<typeof TEXT_ANCHOR_POINTS>;
-export type TileOcclusionModes = ValueOf<typeof TILE_OCCLUSION_MODES>;
-export type TokenDisplayMode = ValueOf<typeof TOKEN_DISPLAY_MODES>;
-export type TokenDisposition = ValueOf<typeof TOKEN_DISPOSITIONS>;
-export type UserRole = ValueOf<typeof USER_ROLES>;
-export type UserRoleName = ValueOf<typeof USER_ROLE_NAMES>;
-export type WallDirection = ValueOf<typeof WALL_DIRECTIONS>;
-export type WallDoorState = ValueOf<typeof WALL_DOOR_STATES>;
-export type WallDoorType = ValueOf<typeof WALL_DOOR_TYPES>;
-export type WallMovementType = ValueOf<typeof WALL_MOVEMENT_TYPES>;
-export type WallSenseType = ValueOf<typeof WALL_SENSE_TYPES>;
+/**
+ * A list of MIME types which are treated as uploaded "media", which are allowed to overwrite existing files.
+ * Any non-media MIME type is not allowed to replace an existing file.
+ */
+export const MEDIA_MIME_TYPES: readonly [
+  'image/apng',
+  'image/avif',
+  'image/bmp',
+  'image/gif',
+  'image/jpeg',
+  'image/jpeg',
+  'image/png',
+  'image/svg+xml',
+  'image/tiff',
+  'image/webp',
+  'video/mp4',
+  'video/mp4',
+  'video/ogg',
+  'video/webm',
+  'audio/aac',
+  'audio/flac',
+  'audio/mp4',
+  'audio/midi',
+  'audio/mpeg',
+  'audio/ogg',
+  'audio/opus',
+  'audio/wav',
+  'audio/webm',
+  'application/json',
+  'text/markdown',
+  'application/pdf',
+  'text/plain'
+];
+
+/**
+ * Stores shared commonly used timeouts, measured in MS
+ */
+export const TIMEOUTS: Readonly<{
+  FOUNDRY_WEBSITE: 10000;
+  PACKAGE_REPOSITORY: 5000;
+  IP_DISCOVERY: 5000;
+}>;
+export type TIMEOUTS = ValueOf<typeof TIMEOUTS>;
+
+/**
+ * Enumerate the source types which can be used for an AmbientLight placeable object
+ * @deprecated since v9
+ */
+export const SOURCE_TYPES: Readonly<{
+  LOCAL: 'l';
+  GLOBAL: 'g';
+  UNIVERSAL: 'u';
+}>;
+/**
+ * Enumerate the source types which can be used for an AmbientLight placeable object
+ * @deprecated since v9
+ */
+export type SOURCE_TYPES = ValueOf<typeof SOURCE_TYPES>;
+
+/**
+ * Define the allowed Entity class types
+ * @deprecated since v9 - use CONST.DOCUMENT_TYPES instead.
+ */
+export const ENTITY_TYPES: typeof DOCUMENT_TYPES;
+/**
+ * Define the allowed Entity class types
+ * @deprecated since v9 - use CONST.DOCUMENT_TYPES instead.
+ */
+export type ENTITY_TYPES = ValueOf<typeof ENTITY_TYPES>;
+
+/**
+ * Define the allowed Document types which Folders may contain
+ * @deprecated since v9 - use CONST.FOLDER_DOCUMENT_TYPES instead.
+ */
+export const FOLDER_ENTITY_TYPES: typeof FOLDER_DOCUMENT_TYPES;
+/**
+ * Define the allowed Document types which Folders may contain
+ * @deprecated since v9 - use CONST.FOLDER_DOCUMENT_TYPES instead.
+ */
+export type FOLDER_ENTITY_TYPES = ValueOf<typeof FOLDER_ENTITY_TYPES>;
+
+/**
+ * Define the allowed permission levels for a non-user Entity.
+ * Each level is assigned a value in ascending order. Higher levels grant more permissions.
+ * @deprecated since v9 - use CONST.DOCUMENT_PERMISSION_LEVELS instead.
+ */
+export const ENTITY_PERMISSIONS: typeof DOCUMENT_PERMISSION_LEVELS;
+/**
+ * Define the allowed permission levels for a non-user Entity.
+ * Each level is assigned a value in ascending order. Higher levels grant more permissions.
+ * @deprecated since v9 - use CONST.DOCUMENT_PERMISSION_LEVELS instead.
+ */
+export type ENTITY_PERMISSIONS = ValueOf<typeof ENTITY_PERMISSIONS>;
+
+/**
+ * Define the allowed Entity types which may be dynamically linked in chat
+ * @deprecated since v9 - use CONST.DOCUMENT_LINK_TYPES instead.
+ */
+export const ENTITY_LINK_TYPES: typeof DOCUMENT_LINK_TYPES;
+/**
+ * Define the allowed Entity types which may be dynamically linked in chat
+ * @deprecated since v9 - use CONST.DOCUMENT_LINK_TYPES instead.
+ */
+export type ENTITY_LINK_TYPES = ValueOf<typeof ENTITY_LINK_TYPES>;
+
+/**
+ * The allowed Entity types which may exist within a Compendium pack
+ * This is a subset of ENTITY_TYPES
+ * @deprecated sinve v9 - use CONST.COMPENDIUM_DOCUMENT_TYPES instead.
+ */
+export const COMPENDIUM_ENTITY_TYPES: typeof COMPENDIUM_DOCUMENT_TYPES;
+/**
+ * The allowed Entity types which may exist within a Compendium pack
+ * This is a subset of ENTITY_TYPES
+ * @deprecated sinve v9 - use CONST.COMPENDIUM_DOCUMENT_TYPES instead.
+ */
+export type COMPENDIUM_ENTITY_TYPES = ValueOf<typeof COMPENDIUM_ENTITY_TYPES>;

--- a/src/foundry/common/data/data.mjs/actorData.d.ts
+++ b/src/foundry/common/data/data.mjs/actorData.d.ts
@@ -96,7 +96,7 @@ interface ActorDataBaseProperties {
    * An object which configures user permissions to this Actor
    * @defaultValue `{ default: CONST.ENTITY_PERMISSIONS.NONE }`
    */
-  permission: Partial<Record<string, foundry.CONST.EntityPermission>>;
+  permission: Partial<Record<string, foundry.CONST.DOCUMENT_PERMISSION_LEVELS>>;
 
   /**
    * An object of optional key/value flags
@@ -164,7 +164,7 @@ interface ActorDataConstructorData {
    * An object which configures user permissions to this Actor
    * @defaultValue `{ default: CONST.ENTITY_PERMISSIONS.NONE }`
    */
-  permission?: Partial<Record<string, foundry.CONST.EntityPermission>> | null;
+  permission?: Partial<Record<string, foundry.CONST.DOCUMENT_PERMISSION_LEVELS>> | null;
 
   /**
    * An object of optional key/value flags

--- a/src/foundry/common/data/data.mjs/ambientLightData.d.ts
+++ b/src/foundry/common/data/data.mjs/ambientLightData.d.ts
@@ -8,7 +8,7 @@ import { DarknessActivation, DarknessActivationConstructorData } from './darknes
 
 interface AmbientLightDataSchema extends DocumentSchema {
   _id: typeof fields.DOCUMENT_ID;
-  t: DocumentField<CONST.SourceType> & {
+  t: DocumentField<CONST.SOURCE_TYPES> & {
     type: String;
     required: true;
     default: 'l';
@@ -48,7 +48,7 @@ interface AmbientLightDataProperties {
    * The source type in CONST.SOURCE_TYPES which defines the behavior of this light
    * @defaultValue `'l'`
    */
-  t: CONST.SourceType;
+  t: CONST.SOURCE_TYPES;
 
   /**
    * The x-coordinate position of the origin of the light
@@ -137,7 +137,7 @@ interface AmbientLightDataConstructorData {
    * The source type in CONST.SOURCE_TYPES which defines the behavior of this light
    * @defaultValue `'l'`
    */
-  t?: CONST.SourceType | null;
+  t?: CONST.SOURCE_TYPES | null;
 
   /**
    * The x-coordinate position of the origin of the light

--- a/src/foundry/common/data/data.mjs/chatMessageData.d.ts
+++ b/src/foundry/common/data/data.mjs/chatMessageData.d.ts
@@ -6,7 +6,7 @@ import { ChatSpeakerData, ChatSpeakerDataConstructorData } from './chatSpeakerDa
 
 interface ChatMessageDataSchema extends DocumentSchema {
   _id: typeof fields.DOCUMENT_ID;
-  type: DocumentField<CONST.ChatMessageType> & {
+  type: DocumentField<CONST.CHAT_MESSAGE_TYPES> & {
     type: typeof Number;
     required: true;
     default: typeof CONST.CHAT_MESSAGE_TYPES.OTHER;
@@ -41,7 +41,7 @@ interface ChatMessageDataProperties {
    * The message type from CONST.CHAT_MESSAGE_TYPES
    * @defaultValue `CONST.CHAT_MESSAGE_TYPES.OTHER`
    */
-  type: CONST.ChatMessageType;
+  type: CONST.CHAT_MESSAGE_TYPES;
 
   /**
    * The _id of the User document who generated this message
@@ -117,7 +117,7 @@ export interface ChatMessageDataConstructorData {
    * The message type from CONST.CHAT_MESSAGE_TYPES
    * @defaultValue `CONST.CHAT_MESSAGE_TYPES.OTHER`
    */
-  type?: CONST.ChatMessageType | null;
+  type?: CONST.CHAT_MESSAGE_TYPES | null;
 
   /**
    * The _id of the User document who generated this message

--- a/src/foundry/common/data/data.mjs/drawingData.d.ts
+++ b/src/foundry/common/data/data.mjs/drawingData.d.ts
@@ -13,11 +13,11 @@ import {
 interface DrawingDataSchema extends DocumentSchema {
   _id: typeof fields.DOCUMENT_ID;
   author: ForeignDocumentField<{ type: typeof documents.BaseUser; required: true }>;
-  type: DocumentField<foundry.CONST.DrawingType> & {
+  type: DocumentField<foundry.CONST.MACRO_TYPES> & {
     type: typeof String;
     required: true;
     default: typeof CONST.DRAWING_TYPES.POLYGON;
-    validate: (t: unknown) => t is foundry.CONST.DrawingType;
+    validate: (t: unknown) => t is foundry.CONST.MACRO_TYPES;
     validationError: 'Invalid {name} {field} which must be a value in CONST.DRAWING_TYPES';
   };
   x: typeof fields.REQUIRED_NUMBER;
@@ -38,7 +38,7 @@ interface DrawingDataSchema extends DocumentSchema {
     typeof fields.REQUIRED_NUMBER,
     {
       default: typeof CONST.DRAWING_FILL_TYPES.NONE;
-      validate: (v: unknown) => v is foundry.CONST.DrawingFillType;
+      validate: (v: unknown) => v is foundry.CONST.DRAWING_FILL_TYPES;
       validationError: 'Invalid {name} {field} which must be a value in CONST.DRAWING_FILL_TYPES';
     }
   >;
@@ -82,7 +82,7 @@ interface DrawingDataProperties {
    * The value in CONST.DRAWING_TYPES which defines the geometry type of this drawing
    * @defaultValue `CONST.DRAWING_TYPES.POLYGON`
    */
-  type: foundry.CONST.DrawingType;
+  type: foundry.CONST.MACRO_TYPES;
 
   /**
    * The x-coordinate position of the top-left corner of the drawn shape
@@ -136,7 +136,7 @@ interface DrawingDataProperties {
    * The fill type of the drawing shape, a value from CONST.DRAWING_FILL_TYPES
    * @defaultValue `CONST.DRAWING_FILL_TYPES.NONE`
    */
-  fillType: foundry.CONST.DrawingFillType;
+  fillType: foundry.CONST.DRAWING_FILL_TYPES;
 
   /**
    * An optional color string with which to fill the drawing geometry
@@ -236,7 +236,7 @@ interface DrawingDataConstructorData {
    * The value in CONST.DRAWING_TYPES which defines the geometry type of this drawing
    * @defaultValue `CONST.DRAWING_TYPES.POLYGON`
    */
-  type?: foundry.CONST.DrawingType | null;
+  type?: foundry.CONST.DRAWING_TYPES | null;
 
   /**
    * The x-coordinate position of the top-left corner of the drawn shape
@@ -290,7 +290,7 @@ interface DrawingDataConstructorData {
    * The fill type of the drawing shape, a value from CONST.DRAWING_FILL_TYPES
    * @defaultValue `CONST.DRAWING_FILL_TYPES.NONE`
    */
-  fillType?: foundry.CONST.DrawingFillType | null;
+  fillType?: foundry.CONST.DRAWING_FILL_TYPES | null;
 
   /**
    * An optional color string with which to fill the drawing geometry

--- a/src/foundry/common/data/data.mjs/effectChangeData.d.ts
+++ b/src/foundry/common/data/data.mjs/effectChangeData.d.ts
@@ -33,7 +33,7 @@ interface EffectChangeDataProperties {
   /**
    * The modification mode with which the change is applied
    */
-  mode: CONST.ActiveEffectMode;
+  mode: CONST.ACTIVE_EFFECT_MODES;
 
   /**
    * The priority level with which this change is applied
@@ -57,7 +57,7 @@ export interface EffectChangeDataConstructorData {
   /**
    * The modification mode with which the change is applied
    */
-  mode?: CONST.ActiveEffectMode | null;
+  mode?: CONST.ACTIVE_EFFECT_MODES | null;
 
   /**
    * The priority level with which this change is applied

--- a/src/foundry/common/data/data.mjs/folderData.d.ts
+++ b/src/foundry/common/data/data.mjs/folderData.d.ts
@@ -6,10 +6,10 @@ import { ConfiguredFlags, PropertiesToSource } from '../../../../types/helperTyp
 interface FolderDataSchema extends DocumentSchema {
   _id: typeof fields.DOCUMENT_ID;
   name: typeof fields.REQUIRED_STRING;
-  type: DocumentField<foundry.CONST.FolderEntityTypes> & {
+  type: DocumentField<foundry.CONST.FOLDER_DOCUMENT_TYPES> & {
     type: String;
     required: true;
-    validate: (t: unknown) => t is foundry.CONST.FolderEntityTypes;
+    validate: (t: unknown) => t is foundry.CONST.FOLDER_DOCUMENT_TYPES;
     validationError: 'Invalid Folder type provided';
   };
   description: typeof fields.STRING_FIELD;
@@ -40,7 +40,7 @@ interface FolderDataProperties {
   /**
    * The document type which this Folder contains, from CONST.FOLDER_ENTITY_TYPES
    */
-  type: foundry.CONST.FolderEntityTypes;
+  type: foundry.CONST.FOLDER_DOCUMENT_TYPES;
 
   /**
    * An HTML description of the contents of this folder
@@ -91,7 +91,7 @@ interface FolderDataConstructorData {
   /**
    * The document type which this Folder contains, from CONST.FOLDER_ENTITY_TYPES
    */
-  type: foundry.CONST.FolderEntityTypes;
+  type: foundry.CONST.FOLDER_DOCUMENT_TYPES;
 
   /**
    * An HTML description of the contents of this folder

--- a/src/foundry/common/data/data.mjs/itemData.d.ts
+++ b/src/foundry/common/data/data.mjs/itemData.d.ts
@@ -77,7 +77,7 @@ interface ItemDataBaseProperties {
    * An object which configures user permissions to this Item
    * @defaultValue `{ default: CONST.ENTITY_PERMISSIONS.NONE }`
    */
-  permission: Partial<Record<string, foundry.CONST.EntityPermission>>;
+  permission: Partial<Record<string, foundry.CONST.DOCUMENT_PERMISSION_LEVELS>>;
 
   /**
    * An object of optional key/value flags
@@ -134,7 +134,7 @@ interface ItemDataConstructorData {
    * An object which configures user permissions to this Item
    * @defaultValue `{ default: CONST.ENTITY_PERMISSIONS.NONE }`
    */
-  permission?: Partial<Record<string, foundry.CONST.EntityPermission>> | null;
+  permission?: Partial<Record<string, foundry.CONST.DOCUMENT_PERMISSION_LEVELS>> | null;
 
   /**
    * An object of optional key/value flags

--- a/src/foundry/common/data/data.mjs/journalEntryData.d.ts
+++ b/src/foundry/common/data/data.mjs/journalEntryData.d.ts
@@ -53,7 +53,7 @@ interface JournalEntryDataProperties {
    * An object which configures user permissions to this JournalEntry
    * @defaultValue `{ default: CONST.ENTITY_PERMISSIONS.NONE }`
    */
-  permission: Partial<Record<string, foundry.CONST.EntityPermission>>;
+  permission: Partial<Record<string, foundry.CONST.DOCUMENT_PERMISSION_LEVELS>>;
 
   /**
    * An object of optional key/value flags
@@ -101,7 +101,7 @@ interface JournalEntryConstructorData {
    * An object which configures user permissions to this JournalEntry
    * @defaultValue `{ default: CONST.ENTITY_PERMISSIONS.NONE }`
    */
-  permission?: Partial<Record<string, foundry.CONST.EntityPermission>> | null;
+  permission?: Partial<Record<string, foundry.CONST.DOCUMENT_PERMISSION_LEVELS>> | null;
 
   /**
    * An object of optional key/value flags

--- a/src/foundry/common/data/data.mjs/macroData.d.ts
+++ b/src/foundry/common/data/data.mjs/macroData.d.ts
@@ -47,7 +47,7 @@ interface MacroDataProperties {
   /**
    * A Macro subtype from CONST.MACRO_TYPES
    */
-  type: foundry.CONST.MacroTypes;
+  type: foundry.CONST.MACRO_TYPES;
 
   /**
    * The _id of a User document which created this Macro *
@@ -64,7 +64,7 @@ interface MacroDataProperties {
    * The scope of this Macro application from CONST.MACRO_SCOPES
    * @defaultValue `'global'`
    */
-  scope: foundry.CONST.MacroScopes;
+  scope: foundry.CONST.MACRO_SCOPES;
 
   /**
    * The string content of the macro command
@@ -88,7 +88,7 @@ interface MacroDataProperties {
    * An object which configures user permissions to this Macro
    * @defaultValue `{ default: CONST.ENTITY_PERMISSIONS.NONE }`
    */
-  permission: Partial<Record<string, foundry.CONST.EntityPermission>>;
+  permission: Partial<Record<string, foundry.CONST.DOCUMENT_PERMISSION_LEVELS>>;
 
   /**
    * An object of optional key/value flags
@@ -111,7 +111,7 @@ interface MacroDataConstructorData {
   /**
    * A Macro subtype from CONST.MACRO_TYPES
    */
-  type?: foundry.CONST.MacroTypes | null;
+  type?: foundry.CONST.MACRO_TYPES | null;
 
   /**
    * The _id of a User document which created this Macro *
@@ -128,7 +128,7 @@ interface MacroDataConstructorData {
    * The scope of this Macro application from CONST.MACRO_SCOPES
    * @defaultValue `'global'`
    */
-  scope?: foundry.CONST.MacroScopes | null;
+  scope?: foundry.CONST.MACRO_SCOPES | null;
 
   /**
    * The string content of the macro command
@@ -152,7 +152,7 @@ interface MacroDataConstructorData {
    * An object which configures user permissions to this Macro
    * @defaultValue `{ default: CONST.ENTITY_PERMISSIONS.NONE }`
    */
-  permission?: Partial<Record<string, foundry.CONST.EntityPermission>> | null;
+  permission?: Partial<Record<string, foundry.CONST.DOCUMENT_PERMISSION_LEVELS>> | null;
 
   /**
    * An object of optional key/value flags

--- a/src/foundry/common/data/data.mjs/measuredTemplateData.d.ts
+++ b/src/foundry/common/data/data.mjs/measuredTemplateData.d.ts
@@ -42,7 +42,7 @@ interface MeasuredTemplateDataProperties {
    * The value in CONST.MEASURED_TEMPLATE_TYPES which defines the geometry type of this template
    * @defaultValue `'circle'`
    */
-  t: ValueOf<foundry.CONST.MeasuredTemplateTypes>;
+  t: foundry.CONST.MEASURED_TEMPLATE_TYPES;
 
   /**
    * The x-coordinate position of the origin of the template effect
@@ -116,7 +116,7 @@ interface MeasuredTemplateDataConstructorData {
    * The value in CONST.MEASURED_TEMPLATE_TYPES which defines the geometry type of this template
    * @defaultValue `'circle'`
    */
-  t?: ValueOf<foundry.CONST.MeasuredTemplateTypes> | null;
+  t?: ValueOf<foundry.CONST.MEASURED_TEMPLATE_TYPES> | null;
 
   /**
    * The x-coordinate position of the origin of the template effect

--- a/src/foundry/common/data/data.mjs/noteData.d.ts
+++ b/src/foundry/common/data/data.mjs/noteData.d.ts
@@ -43,7 +43,7 @@ interface NoteDataSchema extends DocumentSchema {
     type: typeof Number;
     required: true;
     default: typeof CONST.TEXT_ANCHOR_POINTS.BOTTOM;
-    validate: (p: unknown) => p is foundry.CONST.TextAnchorPoint;
+    validate: (p: unknown) => p is foundry.CONST.TEXT_ANCHOR_POINTS;
     validationError: 'Invalid {name} {field} which must be a value in CONST.TEXT_ANCHOR_POINTS';
   };
   textColor: FieldReturnType<typeof fields.COLOR_FIELD, { default: '#FFFFFF' }>;
@@ -112,7 +112,7 @@ interface NoteDataProperties {
    * to the note icon.
    * @defaultValue `CONST.TEXT_ANCHOR_POINTS.BOTTOM`
    */
-  textAnchor: foundry.CONST.TextAnchorPoint;
+  textAnchor: foundry.CONST.TEXT_ANCHOR_POINTS;
 
   /**
    * The string that defines the color with which the note text is rendered
@@ -189,7 +189,7 @@ interface NoteDataConstructorData {
    * to the note icon.
    * @defaultValue `CONST.TEXT_ANCHOR_POINTS.BOTTOM`
    */
-  textAnchor?: foundry.CONST.TextAnchorPoint | null;
+  textAnchor?: foundry.CONST.TEXT_ANCHOR_POINTS | null;
 
   /**
    * The string that defines the color with which the note text is rendered

--- a/src/foundry/common/data/data.mjs/playlistData.d.ts
+++ b/src/foundry/common/data/data.mjs/playlistData.d.ts
@@ -10,11 +10,11 @@ interface PlaylistDataSchema extends DocumentSchema {
   name: typeof fields.REQUIRED_STRING;
   description: typeof fields.BLANK_STRING;
   sounds: fields.EmbeddedCollectionField<typeof documents.BasePlaylistSound>;
-  mode: DocumentField<foundry.CONST.PlaylistMode> & {
+  mode: DocumentField<foundry.CONST.PLAYLIST_MODES> & {
     type: typeof Number;
     required: true;
     default: typeof CONST.PLAYLIST_MODES.SEQUENTIAL;
-    validate: (m: unknown) => m is foundry.CONST.PlaylistMode;
+    validate: (m: unknown) => m is foundry.CONST.PLAYLIST_MODES;
     validationError: 'Invalid {name} {field} provided which must be a value from CONST.PLAYLIST_MODES';
   };
   playing: typeof fields.BOOLEAN_FIELD;
@@ -51,7 +51,7 @@ interface PlaylistDataProperties {
    * The playback mode for sounds in this playlist
    * @defaultValue `CONST.PLAYLIST_MODES.SEQUENTIAL`
    */
-  mode: foundry.CONST.PlaylistMode;
+  mode: foundry.CONST.PLAYLIST_MODES;
 
   /**
    * Is this playlist currently playing?
@@ -79,7 +79,7 @@ interface PlaylistDataProperties {
    * An object which configures user permissions to this playlist
    * @defaultValue `{ default: CONST.ENTITY_PERMISSIONS.NONE }`
    */
-  permission: Record<string, foundry.CONST.EntityPermission>;
+  permission: Record<string, foundry.CONST.DOCUMENT_PERMISSION_LEVELS>;
 
   /**
    * An object of optional key/value flags
@@ -116,7 +116,7 @@ interface PlaylistDataConstructorData {
    * The playback mode for sounds in this playlist
    * @defaultValue `CONST.PLAYLIST_MODES.SEQUENTIAL`
    */
-  mode?: foundry.CONST.PlaylistMode | null | undefined;
+  mode?: foundry.CONST.PLAYLIST_MODES | null | undefined;
 
   /**
    * Is this playlist currently playing?
@@ -144,7 +144,7 @@ interface PlaylistDataConstructorData {
    * An object which configures user permissions to this playlist
    * @defaultValue `{ default: CONST.ENTITY_PERMISSIONS.NONE }`
    */
-  permission?: Record<string, foundry.CONST.EntityPermission> | undefined | null;
+  permission?: Record<string, foundry.CONST.DOCUMENT_PERMISSION_LEVELS> | undefined | null;
 
   /**
    * An object of optional key/value flags

--- a/src/foundry/common/data/data.mjs/rollTableData.d.ts
+++ b/src/foundry/common/data/data.mjs/rollTableData.d.ts
@@ -82,7 +82,7 @@ interface RollTableDataProperties {
    * An object which configures user permissions to this RollTable
    * @defaultValue `{ default: CONST.ENTITY_PERMISSIONS.NONE }`
    */
-  permission: Partial<Record<string, foundry.CONST.EntityPermission>>;
+  permission: Partial<Record<string, foundry.CONST.DOCUMENT_PERMISSION_LEVELS>>;
 
   /**
    * An object of optional key/value flags
@@ -148,7 +148,7 @@ interface RollTableDataConstructorData {
    * An object which configures user permissions to this RollTable
    * @defaultValue `{ default: CONST.ENTITY_PERMISSIONS.NONE }`
    */
-  permission?: Partial<Record<string, foundry.CONST.EntityPermission>> | null;
+  permission?: Partial<Record<string, foundry.CONST.DOCUMENT_PERMISSION_LEVELS>> | null;
 
   /**
    * An object of optional key/value flags

--- a/src/foundry/common/data/data.mjs/sceneData.d.ts
+++ b/src/foundry/common/data/data.mjs/sceneData.d.ts
@@ -51,7 +51,7 @@ interface SceneDataSchema extends DocumentSchema {
     typeof fields.REQUIRED_NUMBER,
     {
       default: typeof CONST.GRID_TYPES.SQUARE;
-      validate: (t: unknown) => t is CONST.GridType;
+      validate: (t: unknown) => t is CONST.GRID_TYPES;
       validationError: 'Invalid {name } {field} which must be a value in CONST.GRID_TYPES';
     }
   >;
@@ -186,7 +186,7 @@ interface SceneDataProperties {
    * The type of grid used in this scene, a number from CONST.GRID_TYPES
    * @defaultValue `CONST.GRID_TYPES.SQUARE`
    */
-  gridType: CONST.GridType;
+  gridType: CONST.GRID_TYPES;
 
   /**
    * The grid size which represents the width (or height) of a single grid space
@@ -346,7 +346,7 @@ interface SceneDataProperties {
    * An object which configures user permissions to this Actor
    * @defaultValue `{ default: CONST.ENTITY_PERMISSIONS.NONE }`
    */
-  permission: Partial<Record<string, foundry.CONST.EntityPermission>>;
+  permission: Partial<Record<string, foundry.CONST.DOCUMENT_PERMISSION_LEVELS>>;
 
   /**
    * An object of optional key/value flags
@@ -441,7 +441,7 @@ interface SceneDataConstructorData {
    * The type of grid used in this scene, a number from CONST.GRID_TYPES
    * @defaultValue `CONST.GRID_TYPES.SQUARE`
    */
-  gridType?: CONST.GridType | null;
+  gridType?: CONST.GRID_TYPES | null;
 
   /**
    * The grid size which represents the width (or height) of a single grid space
@@ -601,7 +601,7 @@ interface SceneDataConstructorData {
    * An object which configures user permissions to this Actor
    * @defaultValue `{ default: CONST.ENTITY_PERMISSIONS.NONE }`
    */
-  permission?: Partial<Record<string, foundry.CONST.EntityPermission>> | null;
+  permission?: Partial<Record<string, foundry.CONST.DOCUMENT_PERMISSION_LEVELS>> | null;
 
   /**
    * An object of optional key/value flags

--- a/src/foundry/common/data/data.mjs/tableResultData.d.ts
+++ b/src/foundry/common/data/data.mjs/tableResultData.d.ts
@@ -5,10 +5,10 @@ import { fields } from '../module.mjs';
 
 interface TableResultDataSchema extends DocumentSchema {
   _id: typeof fields.DOCUMENT_ID;
-  type: DocumentField<foundry.CONST.TableResultType> & {
+  type: DocumentField<foundry.CONST.TABLE_RESULT_TYPES> & {
     type: typeof Number;
     default: typeof CONST.TABLE_RESULT_TYPES.TEXT;
-    validate: (t: unknown) => t is foundry.CONST.TableResultType;
+    validate: (t: unknown) => t is foundry.CONST.TABLE_RESULT_TYPES;
     validationError: 'Invalid TableResult type provided';
   };
   text: typeof fields.BLANK_STRING;
@@ -46,7 +46,7 @@ interface TableResultDataProperties {
    * A result sub-type from CONST.TABLE_RESULT_TYPES
    * @defaultValue `CONST.TABLE_RESULT_TYPES.TEXT`
    */
-  type: foundry.CONST.TableResultType;
+  type: foundry.CONST.TABLE_RESULT_TYPES;
 
   /**
    * The text which describes the table result
@@ -104,7 +104,7 @@ interface TableResultDataConstructorData {
    * A result sub-type from CONST.TABLE_RESULT_TYPES
    * @defaultValue `CONST.TABLE_RESULT_TYPES.TEXT`
    */
-  type?: foundry.CONST.TableResultType | null | undefined;
+  type?: foundry.CONST.TABLE_RESULT_TYPES | null | undefined;
 
   /**
    * The text which describes the table result

--- a/src/foundry/common/data/data.mjs/tileOcclusion.d.ts
+++ b/src/foundry/common/data/data.mjs/tileOcclusion.d.ts
@@ -8,7 +8,7 @@ interface TileOcclusionSchema extends DocumentSchema {
     typeof fields.REQUIRED_NUMBER,
     {
       default: typeof CONST.TILE_OCCLUSION_MODES.FADE;
-      validate: (m: unknown) => m is foundry.CONST.TileOcclusionModes;
+      validate: (m: unknown) => m is foundry.CONST.TILE_OCCLUSION_MODES;
       validationError: 'Invalid {name} {field} which must be a value in CONST.TILE_OCCLUSION_MODES';
     }
   >;
@@ -20,7 +20,7 @@ interface TileOcclusionProperties {
    * The occlusion mode from CONST.TILE_OCCLUSION_MODES
    * @defaultValue `CONST.TILE_OCCLUSION_MODES.FADE`
    */
-  mode: foundry.CONST.TileOcclusionModes;
+  mode: foundry.CONST.TILE_OCCLUSION_MODES;
 
   /**
    * The occlusion alpha between 0 and 1
@@ -34,7 +34,7 @@ export interface TileOcclusionConstructorData {
    * The occlusion mode from CONST.TILE_OCCLUSION_MODES
    * @defaultValue `CONST.TILE_OCCLUSION_MODES.FADE`
    */
-  mode?: foundry.CONST.TileOcclusionModes | null;
+  mode?: foundry.CONST.TILE_OCCLUSION_MODES | null;
 
   /**
    * The occlusion alpha between 0 and 1

--- a/src/foundry/common/data/data.mjs/tokenData.d.ts
+++ b/src/foundry/common/data/data.mjs/tokenData.d.ts
@@ -14,7 +14,7 @@ interface VisionFieldOptions {
 export interface TokenDataSchema extends DocumentSchema {
   _id: typeof fields.DOCUMENT_ID;
   name: typeof fields.STRING_FIELD;
-  displayName: DocumentField<CONST.TokenDisplayMode> & {
+  displayName: DocumentField<CONST.TOKEN_DISPLAY_MODES> & {
     type: typeof Number;
     required: true;
     default: typeof CONST.TOKEN_DISPLAY_MODES.NONE;
@@ -68,14 +68,14 @@ export interface TokenDataSchema extends DocumentSchema {
     required: true;
     default: {};
   };
-  disposition: DocumentField<CONST.TokenDisposition> & {
+  disposition: DocumentField<CONST.TOKEN_DISPOSITIONS> & {
     type: typeof Number;
     required: true;
     default: typeof CONST.TOKEN_DISPOSITIONS.HOSTILE;
     validate: (n: any) => boolean;
     validationError: 'Invalid {name} {field} which must be a value in CONST.TOKEN_DISPOSITIONS';
   };
-  displayBars: DocumentField<CONST.TokenDisplayMode> & {
+  displayBars: DocumentField<CONST.TOKEN_DISPLAY_MODES> & {
     type: typeof Number;
     required: true;
     default: typeof CONST.TOKEN_DISPLAY_MODES.NONE;
@@ -111,7 +111,7 @@ export interface TokenDataProperties {
    * The display mode of the Token nameplate, from CONST.TOKEN_DISPLAY_MODES
    * @defaultValue `CONST.TOKEN_DISPLAY_MODES.NONE`
    */
-  displayName: CONST.TokenDisplayMode;
+  displayName: CONST.TOKEN_DISPLAY_MODES;
 
   /**
    * The _id of an Actor document which this Token represents
@@ -288,13 +288,13 @@ export interface TokenDataProperties {
    * A displayed Token disposition from CONST.TOKEN_DISPOSITIONS
    * @defaultValue `CONST.TOKEN_DISPOSITIONS.HOSTILE`
    */
-  disposition: CONST.TokenDisposition;
+  disposition: CONST.TOKEN_DISPOSITIONS;
 
   /**
    * The display mode of Token resource bars, from CONST.TOKEN_DISPLAY_MODES
    * @defaultValue `CONST.TOKEN_DISPLAY_MODES.NONE`
    */
-  displayBars: CONST.TokenDisplayMode;
+  displayBars: CONST.TOKEN_DISPLAY_MODES;
 
   /**
    * The configuration of the Token's primary resource bar
@@ -331,7 +331,7 @@ export interface TokenDataConstructorData {
    * The display mode of the Token nameplate, from CONST.TOKEN_DISPLAY_MODES
    * @defaultValue `CONST.TOKEN_DISPLAY_MODES.NONE`
    */
-  displayName?: CONST.TokenDisplayMode | null;
+  displayName?: CONST.TOKEN_DISPLAY_MODES | null;
 
   /**
    * The _id of an Actor document which this Token represents
@@ -508,13 +508,13 @@ export interface TokenDataConstructorData {
    * A displayed Token disposition from CONST.TOKEN_DISPOSITIONS
    * @defaultValue `CONST.TOKEN_DISPOSITIONS.HOSTILE`
    */
-  disposition?: CONST.TokenDisposition | null;
+  disposition?: CONST.TOKEN_DISPOSITIONS | null;
 
   /**
    * The display mode of Token resource bars, from CONST.TOKEN_DISPLAY_MODES
    * @defaultValue `CONST.TOKEN_DISPLAY_MODES.NONE`
    */
-  displayBars?: CONST.TokenDisplayMode | null;
+  displayBars?: CONST.TOKEN_DISPLAY_MODES | null;
 
   /**
    * The configuration of the Token's primary resource bar

--- a/src/foundry/common/data/data.mjs/userData.d.ts
+++ b/src/foundry/common/data/data.mjs/userData.d.ts
@@ -42,7 +42,7 @@ interface UserDataProperties {
   password: string;
   passwordSalt?: string;
   permissions: Partial<Record<keyof typeof CONST.USER_PERMISSIONS, boolean>>;
-  role: foundry.CONST.UserRole;
+  role: foundry.CONST.USER_ROLES;
   flags: ConfiguredFlags<'User'>;
 }
 
@@ -56,7 +56,7 @@ interface UserDataConstructorData {
   password?: string | null;
   passwordSalt?: string | null;
   permissions?: Partial<Record<keyof typeof CONST.USER_PERMISSIONS, boolean>> | null;
-  role?: foundry.CONST.UserRole | null;
+  role?: foundry.CONST.USER_ROLES | null;
   flags?: ConfiguredFlags<'User'> | null;
 }
 

--- a/src/foundry/common/data/data.mjs/wallData.d.ts
+++ b/src/foundry/common/data/data.mjs/wallData.d.ts
@@ -15,7 +15,7 @@ interface WallDataSchema extends DocumentSchema {
     typeof fields.REQUIRED_NUMBER,
     {
       default: typeof CONST.WALL_MOVEMENT_TYPES.NORMAL;
-      validate: (v: unknown) => v is foundry.CONST.WallMovementType;
+      validate: (v: unknown) => v is foundry.CONST.WALL_MOVEMENT_TYPES;
       validationError: 'Invalid {name} {field} which must be a value in CONST.WALL_MOVEMENT_TYPES';
     }
   >;
@@ -23,7 +23,7 @@ interface WallDataSchema extends DocumentSchema {
     typeof fields.REQUIRED_NUMBER,
     {
       default: typeof CONST.WALL_SENSE_TYPES.NORMAL;
-      validate: (v: unknown) => v is foundry.CONST.WallSenseType;
+      validate: (v: unknown) => v is foundry.CONST.WALL_SENSE_TYPES;
       validationError: 'Invalid {name} {field} which must be a value in CONST.WALL_SENSE_TYPES';
     }
   >;
@@ -31,7 +31,7 @@ interface WallDataSchema extends DocumentSchema {
     typeof fields.REQUIRED_NUMBER,
     {
       default: typeof CONST.WALL_SENSE_TYPES.NORMAL;
-      validate: (v: unknown) => v is foundry.CONST.WallSenseType;
+      validate: (v: unknown) => v is foundry.CONST.WALL_SENSE_TYPES;
       validationError: 'Invalid {name} {field} which must be a value in CONST.WALL_SENSE_TYPES';
     }
   >;
@@ -39,7 +39,7 @@ interface WallDataSchema extends DocumentSchema {
     typeof fields.REQUIRED_NUMBER,
     {
       default: typeof CONST.WALL_DIRECTIONS.BOTH;
-      validate: (v: unknown) => v is foundry.CONST.WallDirection;
+      validate: (v: unknown) => v is foundry.CONST.WALL_DIRECTIONS;
       validationError: 'Invalid {name} {field} which must be a value in CONST.WALL_DIRECTIONS';
     }
   >;
@@ -47,7 +47,7 @@ interface WallDataSchema extends DocumentSchema {
     typeof fields.REQUIRED_NUMBER,
     {
       default: typeof CONST.WALL_DOOR_TYPES.NONE;
-      validate: (v: unknown) => v is foundry.CONST.WallDoorType;
+      validate: (v: unknown) => v is foundry.CONST.WALL_DOOR_TYPES;
       validationError: 'Invalid {name} {field} which must be a value in CONST.WALL_DOOR_TYPES';
     }
   >;
@@ -55,7 +55,7 @@ interface WallDataSchema extends DocumentSchema {
     typeof fields.REQUIRED_NUMBER,
     {
       default: typeof CONST.WALL_DOOR_STATES.CLOSED;
-      validate: (v: unknown) => v is foundry.CONST.WallDoorState;
+      validate: (v: unknown) => v is foundry.CONST.WALL_DOOR_STATES;
       validationError: 'Invalid {name} {field} which must be a value in CONST.WALL_DOOR_STATES';
     }
   >;
@@ -77,36 +77,36 @@ interface WallDataProperties {
    * The movement restriction type of this wall
    * @defaultValue `CONST.WALL_MOVEMENT_TYPES.NORMAL`
    */
-  move: foundry.CONST.WallMovementType;
+  move: foundry.CONST.WALL_MOVEMENT_TYPES;
 
   /**
    * The sensory restriction type of this wall
    * @defaultValue `CONST.WALL_SENSE_TYPES.NORMAL`
    */
-  sense: foundry.CONST.WallSenseType;
+  sense: foundry.CONST.WALL_SENSE_TYPES;
 
   /**
    * @defaultValue `CONST.WALL_SENSE_TYPES.NORMAL`
    */
-  sound: foundry.CONST.WallSenseType;
+  sound: foundry.CONST.WALL_SENSE_TYPES;
 
   /**
    * The direction of effect imposed by this wall
    * @defaultValue `CONST.WALL_DIRECTIONS.BOTH`
    */
-  dir: foundry.CONST.WallDirection;
+  dir: foundry.CONST.WALL_DIRECTIONS;
 
   /**
    * The type of door which this wall contains, if any
    * @defaultValue `CONST.WALL_DOOR_TYPES.NONE`
    */
-  door: foundry.CONST.WallDoorType;
+  door: foundry.CONST.WALL_DOOR_TYPES;
 
   /**
    * The state of the door this wall contains, if any
    * @defaultValue `CONST.WALL_DOOR_STATES.CLOSED`
    */
-  ds: foundry.CONST.WallDoorState;
+  ds: foundry.CONST.WALL_DOOR_STATES;
 
   /**
    * An object of optional key/value flags
@@ -130,36 +130,36 @@ interface WallDataConstructorData {
    * The movement restriction type of this wall
    * @defaultValue `CONST.WALL_MOVEMENT_TYPES.NORMAL`
    */
-  move?: foundry.CONST.WallMovementType | null;
+  move?: foundry.CONST.WALL_MOVEMENT_TYPES | null;
 
   /**
    * The sensory restriction type of this wall
    * @defaultValue `CONST.WALL_SENSE_TYPES.NORMAL`
    */
-  sense?: foundry.CONST.WallSenseType | null;
+  sense?: foundry.CONST.WALL_SENSE_TYPES | null;
 
   /**
    * @defaultValue `CONST.WALL_SENSE_TYPES.NORMAL`
    */
-  sound?: foundry.CONST.WallSenseType | null;
+  sound?: foundry.CONST.WALL_SENSE_TYPES | null;
 
   /**
    * The direction of effect imposed by this wall
    * @defaultValue `CONST.WALL_DIRECTIONS.BOTH`
    */
-  dir?: foundry.CONST.WallDirection | null;
+  dir?: foundry.CONST.WALL_DIRECTIONS | null;
 
   /**
    * The type of door which this wall contains, if any
    * @defaultValue `CONST.WALL_DOOR_TYPES.NONE`
    */
-  door?: foundry.CONST.WallDoorType | null;
+  door?: foundry.CONST.WALL_DOOR_TYPES | null;
 
   /**
    * The state of the door this wall contains, if any
    * @defaultValue `CONST.WALL_DOOR_STATES.CLOSED`
    */
-  ds?: foundry.CONST.WallDoorState | null;
+  ds?: foundry.CONST.WALL_DOOR_STATES | null;
 
   /**
    * An object of optional key/value flags

--- a/src/foundry/common/data/fields.mjs.d.ts
+++ b/src/foundry/common/data/fields.mjs.d.ts
@@ -334,7 +334,7 @@ interface DocumentId extends DocumentField<string | null> {
  * Default: `{ default: CONST.ENTITY_PERMISSIONS.NONE }`
  */
 export declare const DOCUMENT_PERMISSIONS: DocumentPermissions;
-interface DocumentPermissions extends DocumentField<Partial<Record<string, foundry.CONST.EntityPermission>>> {
+interface DocumentPermissions extends DocumentField<Partial<Record<string, foundry.CONST.DOCUMENT_PERMISSION_LEVELS>>> {
   type: typeof Object;
   required: true;
   nullable: false;

--- a/src/foundry/common/documents.mjs/baseActiveEffect.d.ts
+++ b/src/foundry/common/documents.mjs/baseActiveEffect.d.ts
@@ -33,7 +33,7 @@ export declare class BaseActiveEffect extends Document<
 
   testUserPermission(
     user: BaseUser,
-    permission: keyof typeof foundry.CONST.ENTITY_PERMISSIONS | foundry.CONST.EntityPermission,
+    permission: keyof typeof foundry.CONST.ENTITY_PERMISSIONS | foundry.CONST.DOCUMENT_PERMISSION_LEVELS,
     { exact }: { exact?: boolean }
   ): boolean;
 }

--- a/src/foundry/common/documents.mjs/baseDrawing.d.ts
+++ b/src/foundry/common/documents.mjs/baseDrawing.d.ts
@@ -33,7 +33,7 @@ export declare class BaseDrawing extends Document<
   /** @override */
   testUserPermission(
     user: BaseUser,
-    permission: keyof typeof foundry.CONST.ENTITY_PERMISSIONS | foundry.CONST.EntityPermission,
+    permission: keyof typeof foundry.CONST.ENTITY_PERMISSIONS | foundry.CONST.DOCUMENT_PERMISSION_LEVELS,
     { exact }?: { exact?: boolean }
   ): boolean;
 

--- a/src/foundry/common/documents.mjs/baseItem.d.ts
+++ b/src/foundry/common/documents.mjs/baseItem.d.ts
@@ -39,7 +39,7 @@ export declare class BaseItem extends Document<data.ItemData, InstanceType<Confi
 
   testUserPermission(
     user: BaseUser,
-    permission: keyof typeof foundry.CONST.ENTITY_PERMISSIONS | foundry.CONST.EntityPermission,
+    permission: keyof typeof foundry.CONST.ENTITY_PERMISSIONS | foundry.CONST.DOCUMENT_PERMISSION_LEVELS,
     { exact }: { exact?: boolean }
   ): boolean;
 

--- a/src/foundry/common/documents.mjs/baseMeasuredTemplate.d.ts
+++ b/src/foundry/common/documents.mjs/baseMeasuredTemplate.d.ts
@@ -32,7 +32,7 @@ export declare class BaseMeasuredTemplate extends Document<
   /** @override */
   testUserPermission(
     user: BaseUser,
-    permission: keyof typeof foundry.CONST.ENTITY_PERMISSIONS | foundry.CONST.EntityPermission,
+    permission: keyof typeof foundry.CONST.ENTITY_PERMISSIONS | foundry.CONST.DOCUMENT_PERMISSION_LEVELS,
     { exact }?: { exact?: boolean }
   ): boolean;
 

--- a/src/foundry/common/documents.mjs/baseNote.d.ts
+++ b/src/foundry/common/documents.mjs/baseNote.d.ts
@@ -1,7 +1,6 @@
 import { ConfiguredDocumentClass } from '../../../types/helperTypes';
 import { DocumentMetadata } from '../abstract/document.mjs';
 import { Document } from '../abstract/module.mjs';
-import { EntityPermission } from '../constants.mjs';
 import * as data from '../data/data.mjs';
 import { BaseScene } from './baseScene';
 import { BaseUser } from './baseUser';
@@ -30,7 +29,7 @@ export declare class BaseNote extends Document<data.NoteData, InstanceType<Confi
   /** @override */
   testUserPermission(
     user: BaseUser,
-    permission: keyof typeof foundry.CONST.ENTITY_PERMISSIONS | EntityPermission,
+    permission: keyof typeof foundry.CONST.DOCUMENT_PERMISSION_LEVELS | foundry.CONST.DOCUMENT_PERMISSION_LEVELS,
     { exact }?: { exact?: boolean }
   ): boolean;
 }

--- a/src/foundry/common/documents.mjs/basePlaylistSound.d.ts
+++ b/src/foundry/common/documents.mjs/basePlaylistSound.d.ts
@@ -30,7 +30,7 @@ export declare class BasePlaylistSound extends Document<
   /** @override */
   testUserPermission(
     user: BaseUser,
-    permission: keyof typeof foundry.CONST.ENTITY_PERMISSIONS | foundry.CONST.EntityPermission,
+    permission: keyof typeof foundry.CONST.DOCUMENT_PERMISSION_LEVELS | foundry.CONST.DOCUMENT_PERMISSION_LEVELS,
     { exact }?: { exact?: boolean }
   ): boolean;
 }

--- a/src/foundry/common/documents.mjs/baseTableResult.d.ts
+++ b/src/foundry/common/documents.mjs/baseTableResult.d.ts
@@ -34,7 +34,7 @@ export declare class BaseTableResult extends Document<
 
   testUserPermission(
     user: BaseUser,
-    permission: keyof typeof foundry.CONST.ENTITY_PERMISSIONS | foundry.CONST.EntityPermission,
+    permission: keyof typeof foundry.CONST.DOCUMENT_PERMISSION_LEVELS | foundry.CONST.DOCUMENT_PERMISSION_LEVELS,
     { exact }?: { exact?: boolean }
   ): boolean;
 }

--- a/src/foundry/common/packages.mjs/packageCompendiumData.d.ts
+++ b/src/foundry/common/packages.mjs/packageCompendiumData.d.ts
@@ -15,7 +15,7 @@ interface PackageCompendiumDataSchema extends DocumentSchema {
   entity: FieldReturnType<
     typeof fields.REQUIRED_STRING,
     {
-      validate: (v: string) => v is foundry.CONST.CompendiumEntityType;
+      validate: (v: string) => v is foundry.CONST.COMPENDIUM_DOCUMENT_TYPES;
       validationError: 'Invalid package compendium entity type provided which must be a value in CONST.COMPENDIUM_ENTITY_TYPES';
     }
   >;
@@ -35,7 +35,7 @@ interface PackageCompendiumDataProperties {
   private: boolean;
 
   /** The specific document type that is contained within this compendium pack */
-  entity: foundry.CONST.CompendiumEntityType;
+  entity: foundry.CONST.COMPENDIUM_DOCUMENT_TYPES;
 
   /** Denote that this compendium pack requires a specific game system to function properly. */
   system?: string;
@@ -54,7 +54,7 @@ interface PackageCompendiumDataConstructorData {
   private?: boolean | null;
 
   /** The specific document type that is contained within this compendium pack */
-  entity: foundry.CONST.CompendiumEntityType;
+  entity: foundry.CONST.COMPENDIUM_DOCUMENT_TYPES;
 
   /** Denote that this compendium pack requires a specific game system to function properly. */
   system?: string;

--- a/src/foundry/common/packages.mjs/packageDependencyData.d.ts
+++ b/src/foundry/common/packages.mjs/packageDependencyData.d.ts
@@ -20,7 +20,7 @@ interface PackageDependencyDataProperties {
   name: string;
 
   /** The dependency package type, from CONST.PACKAGE_TYPES */
-  type: foundry.CONST.PackageTypes;
+  type: foundry.CONST.PACKAGE_TYPES;
 
   /** An explicit manifest URL, otherwise learned from the Foundry web server */
   manifest?: string;
@@ -31,7 +31,7 @@ interface PackageDependencyDataConstructorData {
   name: string;
 
   /** The dependency package type, from CONST.PACKAGE_TYPES */
-  type?: foundry.CONST.PackageTypes | null;
+  type?: foundry.CONST.PACKAGE_TYPES | null;
 
   /** An explicit manifest URL, otherwise learned from the Foundry web server */
   manifest?: string | null;

--- a/src/foundry/common/packages.mjs/tagPackageAvailability.d.ts
+++ b/src/foundry/common/packages.mjs/tagPackageAvailability.d.ts
@@ -4,6 +4,6 @@
  * @remarks This doesn't actually update the package, it just sets the `unavailable` and `incompatible` flags if needed.
  */
 export declare function tagPackageAvailability(pkg: {
-  availability: foundry.CONST.PackageAvailabilityCode;
-  type: foundry.CONST.PackageTypes;
+  availability: foundry.CONST.PACKAGE_AVAILABILITY_CODES;
+  type: foundry.CONST.PACKAGE_TYPES;
 }): void;

--- a/src/foundry/foundry.js/applications/formApplications/documentSheet.d.ts
+++ b/src/foundry/foundry.js/applications/formApplications/documentSheet.d.ts
@@ -120,7 +120,7 @@ declare global {
       /**
        * @defaultValue {@link ENTITY_PERMISSIONS.LIMITED}
        */
-      viewPermission: foundry.CONST.EntityPermission;
+      viewPermission: foundry.CONST.DOCUMENT_PERMISSION_LEVELS;
     }
   }
 }

--- a/src/foundry/foundry.js/applications/formApplications/documentSheets/activeEffectConfig.d.ts
+++ b/src/foundry/foundry.js/applications/formApplications/documentSheets/activeEffectConfig.d.ts
@@ -67,7 +67,7 @@ declare global {
       isActorEffect: boolean;
       isItemEffect: boolean;
       submitText: string;
-      modes: Record<foundry.CONST.ActiveEffectMode, string>;
+      modes: Record<foundry.CONST.ACTIVE_EFFECT_MODES, string>;
     }
 
     type Options = DocumentSheet.Options;

--- a/src/foundry/foundry.js/applications/formApplications/documentSheets/actorSheet.d.ts
+++ b/src/foundry/foundry.js/applications/formApplications/documentSheets/actorSheet.d.ts
@@ -194,7 +194,7 @@ declare global {
 
       interface Folder {
         type: 'Folder';
-        documentName: foundry.CONST.FolderEntityTypes;
+        documentName: foundry.CONST.FOLDER_DOCUMENT_TYPES;
         id: string;
       }
     }

--- a/src/foundry/foundry.js/applications/formApplications/documentSheets/folderConfig.d.ts
+++ b/src/foundry/foundry.js/applications/formApplications/documentSheets/folderConfig.d.ts
@@ -64,7 +64,7 @@ declare global {
       name: string;
       parent: string;
       sorting: SortingModes;
-      type: foundry.CONST.FolderEntityTypes;
+      type: foundry.CONST.FOLDER_DOCUMENT_TYPES;
     }
   }
 }

--- a/src/foundry/foundry.js/applications/formApplications/documentSheets/lightConfig.d.ts
+++ b/src/foundry/foundry.js/applications/formApplications/documentSheets/lightConfig.d.ts
@@ -64,7 +64,7 @@ declare global {
     interface Data<Options extends DocumentSheet.Options>
       extends DocumentSheet.Data<InstanceType<ConfiguredDocumentClassForName<'AmbientLight'>>, Options> {
       submitText: string;
-      lightTypes: Record<foundry.CONST.SourceType, string>;
+      lightTypes: Record<foundry.CONST.SOURCE_TYPES, string>;
       lightAnimations: Record<string, string> & {
         '': 'None';
       };

--- a/src/foundry/foundry.js/applications/formApplications/documentSheets/measuredTemplateConfig.d.ts
+++ b/src/foundry/foundry.js/applications/formApplications/documentSheets/measuredTemplateConfig.d.ts
@@ -50,7 +50,7 @@ declare global {
       direction: number | null;
       distance: number | null;
       fillColor: string;
-      t: ValueOf<foundry.CONST.MeasuredTemplateTypes>;
+      t: ValueOf<foundry.CONST.MEASURED_TEMPLATE_TYPES>;
       texture: string;
       width: number | null;
       x: number | null;

--- a/src/foundry/foundry.js/applications/formApplications/documentSheets/noteConfig.d.ts
+++ b/src/foundry/foundry.js/applications/formApplications/documentSheets/noteConfig.d.ts
@@ -51,7 +51,7 @@ declare global {
       entries: Journal['contents'];
       icons: CONFIG['JournalEntry']['noteIcons'];
       fontFamilies: Record<string, string>;
-      textAnchors: Record<foundry.CONST.TextAnchorPoint, string>;
+      textAnchors: Record<foundry.CONST.TEXT_ANCHOR_POINTS, string>;
       submitText: string;
     }
 
@@ -63,7 +63,7 @@ declare global {
       iconSize: number | null;
       iconTint: string;
       text: string;
-      textAnchor: foundry.CONST.TextAnchorPoint;
+      textAnchor: foundry.CONST.TEXT_ANCHOR_POINTS;
       textColor: string;
       x: number | null;
       y: number | null;

--- a/src/foundry/foundry.js/applications/formApplications/documentSheets/permissionControl.d.ts
+++ b/src/foundry/foundry.js/applications/formApplications/documentSheets/permissionControl.d.ts
@@ -43,14 +43,14 @@ declare global {
   namespace PermissionControl {
     interface Data<ConcreteDocument extends foundry.abstract.Document<any, any>> extends DocumentSheet.Data {
       entity: ConcreteDocument;
-      currentDefault: foundry.CONST.EntityPermission | '-1';
+      currentDefault: foundry.CONST.DOCUMENT_PERMISSION_LEVELS | '-1';
       instructions: string;
-      defaultLevels: Record<foundry.CONST.EntityPermission, string> & { '-1'?: string };
-      playerLevels: Record<foundry.CONST.EntityPermission | '-1', string> & { '-2'?: string };
+      defaultLevels: Record<foundry.CONST.DOCUMENT_PERMISSION_LEVELS, string> & { '-1'?: string };
+      playerLevels: Record<foundry.CONST.DOCUMENT_PERMISSION_LEVELS | '-1', string> & { '-2'?: string };
       isFolder: boolean;
       users: {
         user: InstanceType<ConfiguredDocumentClassForName<'User'>>;
-        level: foundry.CONST.EntityPermission | '-1';
+        level: foundry.CONST.DOCUMENT_PERMISSION_LEVELS | '-1';
       }[];
     }
 
@@ -60,7 +60,7 @@ declare global {
     }
 
     namespace FormData {
-      type InputPermissionLevel = foundry.CONST.EntityPermission | -1 | -2;
+      type InputPermissionLevel = foundry.CONST.DOCUMENT_PERMISSION_LEVELS | -1 | -2;
     }
   }
 }

--- a/src/foundry/foundry.js/applications/formApplications/documentSheets/playlistConfig.d.ts
+++ b/src/foundry/foundry.js/applications/formApplications/documentSheets/playlistConfig.d.ts
@@ -43,7 +43,7 @@ declare global {
   namespace PlaylistConfig {
     interface Data<Options extends DocumentSheet.Options = DocumentSheet.Options>
       extends DocumentSheet.Data<InstanceType<ConfiguredDocumentClass<typeof Playlist>>, Options> {
-      modes: Record<foundry.CONST.PlaylistMode, string>;
+      modes: Record<foundry.CONST.PLAYLIST_MODES, string>;
     }
   }
 }

--- a/src/foundry/foundry.js/applications/formApplications/documentSheets/rollTableConfig.d.ts
+++ b/src/foundry/foundry.js/applications/formApplications/documentSheets/rollTableConfig.d.ts
@@ -186,7 +186,7 @@ declare global {
     } & {
       [Key in number as `results.${number}.text`]: string;
     } & {
-      [Key in number as `results.${number}.type`]: foundry.CONST.TableResultType;
+      [Key in number as `results.${number}.type`]: foundry.CONST.TABLE_RESULT_TYPES;
     } & {
       [Key in number as `results.${number}.weight`]: string;
     };

--- a/src/foundry/foundry.js/applications/formApplications/documentSheets/sceneConfig.d.ts
+++ b/src/foundry/foundry.js/applications/formApplications/documentSheets/sceneConfig.d.ts
@@ -50,7 +50,7 @@ declare global {
      * Get an enumeration of the available grid types which can be applied to this Scene
      * @internal
      */
-    protected static _getGridTypes(): Record<foundry.CONST.GridType, string>;
+    protected static _getGridTypes(): Record<foundry.CONST.GRID_TYPES, string>;
 
     /**
      * Get the available weather effect types which can be applied to this Scene
@@ -127,7 +127,7 @@ declare global {
       gridAlpha: number;
       gridColor: string;
       gridDistance: number | null;
-      gridType: foundry.CONST.GridType;
+      gridType: foundry.CONST.GRID_TYPES;
       gridUnits: string;
       hasGlobalThreshold: boolean;
       height: number | null;
@@ -140,7 +140,7 @@ declare global {
       navName: string;
       navigation: boolean;
       padding: number;
-      'permission.default': foundry.CONST.EntityPermission;
+      'permission.default': foundry.CONST.DOCUMENT_PERMISSION_LEVELS;
       playlist: string;
       shiftX: number | null;
       shiftY: number | null;

--- a/src/foundry/foundry.js/applications/formApplications/documentSheets/tileConfig.d.ts
+++ b/src/foundry/foundry.js/applications/formApplications/documentSheets/tileConfig.d.ts
@@ -51,7 +51,7 @@ declare global {
     interface Data<Options extends DocumentSheet.Options>
       extends DocumentSheet.Data<InstanceType<ConfiguredDocumentClassForName<'Tile'>>, Options> {
       submitText: string;
-      occlusionModes: Record<foundry.CONST.TileOcclusionModes, string>;
+      occlusionModes: Record<foundry.CONST.TILE_OCCLUSION_MODES, string>;
     }
 
     type FormData = Pick<TileDataConstructorData, 'height' | 'img' | 'rotation' | 'width' | 'x' | 'y'>;

--- a/src/foundry/foundry.js/applications/formApplications/drawingConfig.d.ts
+++ b/src/foundry/foundry.js/applications/formApplications/drawingConfig.d.ts
@@ -76,7 +76,7 @@ declare global {
       bezierFactor: number;
       fillAlpha: number;
       fillColor: string;
-      fillType: foundry.CONST.DrawingFillType;
+      fillType: foundry.CONST.DRAWING_FILL_TYPES;
       fontFamily: string;
       fontSize: number | null;
       height: number | null;

--- a/src/foundry/foundry.js/applications/formApplications/gridConfig.d.ts
+++ b/src/foundry/foundry.js/applications/formApplications/gridConfig.d.ts
@@ -156,7 +156,7 @@ declare global {
     }
 
     type FormData = {
-      gridType: foundry.CONST.GridType;
+      gridType: foundry.CONST.GRID_TYPES;
       grid: number | null;
       scale: number | null;
       shiftX: number | null;

--- a/src/foundry/foundry.js/applications/formApplications/tokenConfig.d.ts
+++ b/src/foundry/foundry.js/applications/formApplications/tokenConfig.d.ts
@@ -115,9 +115,9 @@ declare global {
       barAttributes: Record<string, string[]>;
       bar1: ReturnType<TokenDocument['getBarAttribute']>;
       bar2: ReturnType<TokenDocument['getBarAttribute']>;
-      displayModes: Record<foundry.CONST.TokenDisplayMode, string>;
+      displayModes: Record<foundry.CONST.TOKEN_DISPLAY_MODES, string>;
       actors: { _id: string; name: string }[];
-      dispositions: Record<foundry.CONST.TokenDisposition, string>;
+      dispositions: Record<foundry.CONST.TOKEN_DISPOSITIONS, string>;
       lightAnimations: { [Key in keyof typeof CONFIG.Canvas.lightAnimations]: string } & { '': string };
       lightAlpha: number;
       isGM: boolean;
@@ -134,9 +134,9 @@ declare global {
       brightSight: number | null;
       dimLight: number | null;
       dimSight: number | null;
-      displayBars: foundry.CONST.TokenDisplayMode;
-      displayName: foundry.CONST.TokenDisplayMode;
-      disposition: foundry.CONST.TokenDisposition;
+      displayBars: foundry.CONST.TOKEN_DISPLAY_MODES;
+      displayName: foundry.CONST.TOKEN_DISPLAY_MODES;
+      disposition: foundry.CONST.TOKEN_DISPOSITIONS;
       elevation: number | null;
       height: number | null;
       img: string;

--- a/src/foundry/foundry.js/applications/formApplications/wallConfig.d.ts
+++ b/src/foundry/foundry.js/applications/formApplications/wallConfig.d.ts
@@ -61,12 +61,12 @@ declare global {
     }
 
     interface FormData {
-      dir: foundry.CONST.WallDirection;
-      door: foundry.CONST.WallDoorType;
-      ds?: foundry.CONST.WallDoorState;
-      move: foundry.CONST.WallMovementType;
-      sense: foundry.CONST.WallSenseType;
-      sound: foundry.CONST.WallSenseType;
+      dir: foundry.CONST.WALL_DIRECTIONS;
+      door: foundry.CONST.WALL_DOOR_TYPES;
+      ds?: foundry.CONST.WALL_DOOR_STATES;
+      move: foundry.CONST.WALL_MOVEMENT_TYPES;
+      sense: foundry.CONST.WALL_SENSE_TYPES;
+      sound: foundry.CONST.WALL_SENSE_TYPES;
     }
   }
 }

--- a/src/foundry/foundry.js/applications/sidebarTabs/chatLog.d.ts
+++ b/src/foundry/foundry.js/applications/sidebarTabs/chatLog.d.ts
@@ -275,7 +275,7 @@ declare global {
      * @param mode - The new roll mode setting
      * @internal
      */
-    protected static _setRollMode(mode: foundry.CONST.DiceRollMode): void;
+    protected static _setRollMode(mode: foundry.CONST.DICE_ROLL_MODES): void;
   }
 
   namespace ChatLog {
@@ -296,7 +296,7 @@ declare global {
 
     interface Data {
       user: InstanceType<ConfiguredDocumentClass<typeof User>>;
-      rollMode: foundry.CONST.DiceRollMode;
+      rollMode: foundry.CONST.DICE_ROLL_MODES;
       rollModes: typeof CONFIG['Dice']['rollModes'];
       isStream: boolean;
     }

--- a/src/foundry/foundry.js/applications/sidebarTabs/compendiumDirectory.d.ts
+++ b/src/foundry/foundry.js/applications/sidebarTabs/compendiumDirectory.d.ts
@@ -60,10 +60,10 @@ declare global {
   namespace CompendiumDirectory {
     interface Data {
       user: InstanceType<ConfiguredDocumentClass<typeof User>>;
-      packs: { [DocumentName in foundry.CONST.CompendiumEntityType]?: PackData<DocumentName> };
+      packs: { [DocumentName in foundry.CONST.COMPENDIUM_DOCUMENT_TYPES]?: PackData<DocumentName> };
     }
 
-    interface PackData<DocumentName extends foundry.CONST.CompendiumEntityType> {
+    interface PackData<DocumentName extends foundry.CONST.COMPENDIUM_DOCUMENT_TYPES> {
       label: DocumentName;
       packs: CompendiumCollection<CompendiumCollection.Metadata & { entity: DocumentName }>[];
     }

--- a/src/foundry/foundry.js/applications/sidebarTabs/sidebarDirectories/playlistDirectory.d.ts
+++ b/src/foundry/foundry.js/applications/sidebarTabs/sidebarDirectories/playlistDirectory.d.ts
@@ -114,13 +114,13 @@ declare global {
      * Given a constant playback mode, provide the FontAwesome icon used to display it
      * @internal
      */
-    protected _getModeIcon(mode: foundry.CONST.PlaylistMode): string;
+    protected _getModeIcon(mode: foundry.CONST.PLAYLIST_MODES): string;
 
     /**
      * Given a constant playback mode, provide the string tooltip used to describe it
      * @internal
      */
-    protected _getModeTooltip(mode: foundry.CONST.PlaylistMode): string;
+    protected _getModeTooltip(mode: foundry.CONST.PLAYLIST_MODES): string;
 
     /** @override */
     activateListeners(html: JQuery): void;

--- a/src/foundry/foundry.js/applications/sidebarTabs/sidebarDirectory.d.ts
+++ b/src/foundry/foundry.js/applications/sidebarTabs/sidebarDirectory.d.ts
@@ -8,7 +8,7 @@ declare global {
    * @typeParam Options - The type of the options object
    */
   abstract class SidebarDirectory<
-    Name extends foundry.CONST.EntityType | 'FogExploration',
+    Name extends foundry.CONST.DOCUMENT_TYPES | 'FogExploration',
     Options extends SidebarDirectory.Options = SidebarDirectory.Options
   > extends SidebarTab<Options> {
     constructor(options?: Partial<SidebarDirectory.Options>);
@@ -54,7 +54,7 @@ declare global {
      * The WorldCollection instance which this Sidebar Directory displays.
      */
     static get collection(): WorldCollection<
-      ConfiguredDocumentClassForName<foundry.CONST.EntityType | 'FogExploration'>,
+      ConfiguredDocumentClassForName<foundry.CONST.DOCUMENT_TYPES | 'FogExploration'>,
       string
     >;
 

--- a/src/foundry/foundry.js/clientDocumentMixin.d.ts
+++ b/src/foundry/foundry.js/clientDocumentMixin.d.ts
@@ -367,7 +367,7 @@ export declare class ClientDocumentMixin<T extends foundry.abstract.Document<any
    */
   hasPerm(
     user: foundry.documents.BaseUser,
-    permission: keyof typeof foundry.CONST.ENTITY_PERMISSIONS | foundry.CONST.EntityPermission,
+    permission: keyof typeof foundry.CONST.DOCUMENT_PERMISSION_LEVELS | foundry.CONST.DOCUMENT_PERMISSION_LEVELS,
     exact?: boolean
   ): ReturnType<T['testUserPermission']>;
 

--- a/src/foundry/foundry.js/clientDocuments/chatMessage.d.ts
+++ b/src/foundry/foundry.js/clientDocuments/chatMessage.d.ts
@@ -73,14 +73,14 @@ declare global {
      */
     static applyRollMode(
       chatData: ConstructorDataType<foundry.data.ChatMessageData>,
-      rollMode: foundry.CONST.DiceRollMode
+      rollMode: foundry.CONST.DICE_ROLL_MODES
     ): ConstructorDataType<foundry.data.ChatMessageData>;
 
     /**
      * Update the data of a ChatMessage instance to apply a requested rollMode
      * @param rollMode - The rollMode preference to apply to this message data
      */
-    applyRollMode(rollMode: foundry.CONST.DiceRollMode): void;
+    applyRollMode(rollMode: foundry.CONST.DICE_ROLL_MODES): void;
 
     /**
      * Attempt to determine who is the speaking character (and token) for a certain Chat Message

--- a/src/foundry/foundry.js/clientDocuments/combatant.d.ts
+++ b/src/foundry/foundry.js/clientDocuments/combatant.d.ts
@@ -75,7 +75,7 @@ declare global {
     /** @override */
     testUserPermission(
       user: BaseUser,
-      permission: keyof typeof foundry.CONST.ENTITY_PERMISSIONS | foundry.CONST.EntityPermission,
+      permission: keyof typeof foundry.CONST.DOCUMENT_PERMISSION_LEVELS | foundry.CONST.DOCUMENT_PERMISSION_LEVELS,
       { exact }?: { exact?: boolean }
     ): boolean;
 

--- a/src/foundry/foundry.js/clientDocuments/playlist.d.ts
+++ b/src/foundry/foundry.js/clientDocuments/playlist.d.ts
@@ -38,7 +38,7 @@ declare global {
     /**
      * The playback mode for the Playlist instance
      */
-    get mode(): foundry.CONST.PlaylistMode;
+    get mode(): foundry.CONST.PLAYLIST_MODES;
 
     /**
      * The order in which sounds within this playlist will be played (if sequential or shuffled)

--- a/src/foundry/foundry.js/clientDocuments/rollTable.d.ts
+++ b/src/foundry/foundry.js/clientDocuments/rollTable.d.ts
@@ -158,7 +158,7 @@ declare global {
       /**
        * The chat roll mode to use when displaying the result
        */
-      rollMode: foundry.CONST.DiceRollMode;
+      rollMode: foundry.CONST.DICE_ROLL_MODES;
     }
 
     /**

--- a/src/foundry/foundry.js/clientSettings.d.ts
+++ b/src/foundry/foundry.js/clientSettings.d.ts
@@ -221,7 +221,7 @@ declare namespace ClientSettings {
   interface Values {
     'core.combatTrackerConfig': { resource: string; skipDefeated: boolean } | {};
     'core.compendiumConfiguration': Partial<Record<string, CompendiumCollection.Configuration>>;
-    'core.rollMode': foundry.CONST.DiceRollMode;
+    'core.rollMode': foundry.CONST.DICE_ROLL_MODES;
     'core.animateRollTable': boolean;
     'core.permissions': Game.Permissions;
     'core.defaultDrawingConfig': foundry.data.DrawingData['_source'] | {};

--- a/src/foundry/foundry.js/game.d.ts
+++ b/src/foundry/foundry.js/game.d.ts
@@ -448,7 +448,7 @@ declare global {
         label: string;
         path: string;
         private: boolean;
-        entity: foundry.CONST.CompendiumEntityType;
+        entity: foundry.CONST.COMPENDIUM_DOCUMENT_TYPES;
         system?: string;
         absPath: string;
         package: string;
@@ -475,7 +475,7 @@ declare global {
           templates?: Partial<Record<string, unknown>>;
         } & Partial<Record<string, unknown>>;
       };
-      entityTypes: { [Key in foundry.CONST.EntityType | 'Setting' | 'FogExploration']: string[] };
+      entityTypes: { [Key in foundry.CONST.DOCUMENT_TYPES | 'Setting' | 'FogExploration']: string[] };
       model: {
         Actor: Partial<Record<string, Partial<Record<string, unknown>>>>;
         Item: Partial<Record<string, Partial<Record<string, unknown>>>>;
@@ -526,7 +526,7 @@ declare global {
         label: string;
         path: string;
         private: boolean;
-        entity: foundry.CONST.CompendiumEntityType;
+        entity: foundry.CONST.COMPENDIUM_DOCUMENT_TYPES;
         system?: string;
         package: string;
         index: { name: string; type: string; _id: string }[];
@@ -535,7 +535,7 @@ declare global {
       systemUpdate: string | null;
     } & {
       [DocumentType in
-        | foundry.CONST.EntityType
+        | foundry.CONST.DOCUMENT_TYPES
         | 'Setting' as ConfiguredDocumentClassForName<DocumentType>['metadata']['collection']]?: InstanceType<
         ConfiguredDocumentClassForName<DocumentType>
       >['data']['_source'][];
@@ -548,11 +548,13 @@ declare global {
     };
 
     type Permissions = {
-      [Key in keyof typeof foundry.CONST.USER_PERMISSIONS]: foundry.CONST.UserRole[];
+      [Key in keyof typeof foundry.CONST.USER_PERMISSIONS]: foundry.CONST.USER_ROLES[];
     };
 
     type View = ValueOf<typeof foundry.CONST.GAME_VIEWS>;
   }
 }
 
-type ConfiguredCollectionClassForName<Name extends foundry.CONST.EntityType> = InstanceType<CONFIG[Name]['collection']>;
+type ConfiguredCollectionClassForName<Name extends foundry.CONST.DOCUMENT_TYPES> = InstanceType<
+  CONFIG[Name]['collection']
+>;

--- a/src/foundry/foundry.js/pixi/containers/canvasLayers/gridLayer.d.ts
+++ b/src/foundry/foundry.js/pixi/containers/canvasLayers/gridLayer.d.ts
@@ -42,7 +42,7 @@ declare class GridLayer extends CanvasLayer<GridLayer.LayerOptions> {
   /**
    * The grid type rendered in this Scene
    */
-  get type(): foundry.CONST.GridType;
+  get type(): foundry.CONST.GRID_TYPES;
 
   /**
    * A convenient reference to the pixel grid size used throughout this layer
@@ -177,7 +177,7 @@ interface DrawOptions {
   /**
    * @defaultValue `null`
    */
-  type?: foundry.CONST.GridType | null;
+  type?: foundry.CONST.GRID_TYPES | null;
 
   /**
    * @defaultValue `null`

--- a/src/foundry/foundry.js/pixi/containers/canvasLayers/placeablesLayers/wallsLayer.d.ts
+++ b/src/foundry/foundry.js/pixi/containers/canvasLayers/placeablesLayers/wallsLayer.d.ts
@@ -189,9 +189,9 @@ declare global {
      */
     protected _getWallDataFromActiveTool(tool: string):
       | {
-          move: foundry.CONST.WallMovementType;
-          sense: foundry.CONST.WallSenseType;
-          door?: foundry.CONST.WallDoorType;
+          move: foundry.CONST.WALL_MOVEMENT_TYPES;
+          sense: foundry.CONST.WALL_SENSE_TYPES;
+          door?: foundry.CONST.WALL_DOOR_TYPES;
         }
       | this['_cloneType'];
 

--- a/src/foundry/foundry.js/pixi/containers/placeableObjects/token.d.ts
+++ b/src/foundry/foundry.js/pixi/containers/placeableObjects/token.d.ts
@@ -258,7 +258,7 @@ declare global {
      * @param mode - The mode from CONST.TOKEN_DISPLAY_MODES
      * @returns Is the attribute viewable?
      */
-    protected _canViewMode(mode: foundry.CONST.TokenDisplayMode): boolean;
+    protected _canViewMode(mode: foundry.CONST.TOKEN_DISPLAY_MODES): boolean;
 
     /**
      * Animate Token movement along a certain path which is defined by a Ray object

--- a/src/foundry/foundry.js/pointSource.d.ts
+++ b/src/foundry/foundry.js/pointSource.d.ts
@@ -178,7 +178,7 @@ declare class PointSource {
    * The source type from CONST.SOURCE_TYPES
    * @defaultValue `undefined`
    */
-  type?: foundry.CONST.SourceType;
+  type?: foundry.CONST.SOURCE_TYPES;
 
   /**
    * An animation configuration for the source
@@ -366,7 +366,7 @@ declare namespace PointSource {
      * The source type from CONST.SOURCE_TYPES
      * @defaultValue `CONST.SOURCE_TYPES.LOCAL`
      */
-    type?: foundry.CONST.SourceType;
+    type?: foundry.CONST.SOURCE_TYPES;
 
     /**
      * An animation configuration for the source

--- a/src/foundry/foundry.js/roll.d.ts
+++ b/src/foundry/foundry.js/roll.d.ts
@@ -373,15 +373,15 @@ declare global {
      */
     toMessage<T extends DeepPartial<ConstructorParameters<ConfiguredDocumentClass<typeof ChatMessage>>[0]> = {}>(
       messageData?: T,
-      { rollMode, create }?: { rollMode?: foundry.CONST.DiceRollMode; create?: true }
+      { rollMode, create }?: { rollMode?: foundry.CONST.DICE_ROLL_MODES; create?: true }
     ): Promise<InstanceType<ConfiguredDocumentClass<typeof ChatMessage>> | undefined>;
     toMessage<T extends DeepPartial<ConstructorParameters<ConfiguredDocumentClass<typeof ChatMessage>>[0]> = {}>(
       messageData: T,
-      { rollMode, create }: { rollMode?: foundry.CONST.DiceRollMode; create: false }
+      { rollMode, create }: { rollMode?: foundry.CONST.DICE_ROLL_MODES; create: false }
     ): MessageData<T>;
     toMessage<T extends DeepPartial<ConstructorParameters<ConfiguredDocumentClass<typeof ChatMessage>>[0]> = {}>(
       messageData: T,
-      { rollMode, create }: { rollMode?: foundry.CONST.DiceRollMode; create: boolean }
+      { rollMode, create }: { rollMode?: foundry.CONST.DICE_ROLL_MODES; create: boolean }
     ): Promise<InstanceType<ConfiguredDocumentClass<typeof ChatMessage>> | undefined> | MessageData<T>;
 
     /**

--- a/src/types/utils.d.ts
+++ b/src/types/utils.d.ts
@@ -75,7 +75,7 @@ type Expanded<O> = O extends Record<string, unknown>
  * Union type of the types of the values in `T`
  * @internal
  */
-type ValueOf<T> = T extends Array<unknown> ? T[number] : T[keyof T];
+type ValueOf<T> = T extends Array<unknown> | ReadonlyArray<unknown> ? T[number] : T[keyof T];
 
 /**
  * Transforms a string to lowercase and the first character to uppercase.

--- a/test-d/foundry/foundry.js/applications/formApplications/documentSheets/activeEffectConfig.test-d.ts
+++ b/test-d/foundry/foundry.js/applications/formApplications/documentSheets/activeEffectConfig.test-d.ts
@@ -13,7 +13,7 @@ expectType<foundry.data.ActiveEffectData>((await config.getData()).data);
 expectType<boolean>((await config.getData()).isActorEffect);
 expectType<boolean>((await config.getData()).isItemEffect);
 expectType<string>((await config.getData()).submitText);
-expectType<Record<foundry.CONST.ActiveEffectMode, string>>((await config.getData()).modes);
+expectType<Record<foundry.CONST.ACTIVE_EFFECT_MODES, string>>((await config.getData()).modes);
 expectType<DocumentSheet.Options>(config.options);
 
 const withCustomOptions = new ActiveEffectConfig<DocumentSheet.Options & { custom: true }>(new ActiveEffect());

--- a/test-d/foundry/foundry.js/applications/formApplications/documentSheets/macroConfig.test-d.ts
+++ b/test-d/foundry/foundry.js/applications/formApplications/documentSheets/macroConfig.test-d.ts
@@ -11,7 +11,7 @@ const config = new MacroConfig(macro);
 expectType<Macro>(config.object);
 expectType<Macro>(config.getData().document);
 expectType<Array<'script' | 'chat'>>(config.getData().macroTypes);
-expectType<['global', 'actors', 'actor']>(config.getData().macroScopes);
+expectType<readonly ['global', 'actors', 'actor']>(config.getData().macroScopes);
 expectType<MacroConfig.Options>(config.getData().options);
 
 const withCustomOptions = new MacroConfig<DocumentSheet.Options & { custom: true }>(macro);

--- a/test-d/foundry/foundry.js/clientSettings.test-d.ts
+++ b/test-d/foundry/foundry.js/clientSettings.test-d.ts
@@ -77,4 +77,4 @@ expectType<{ resource: string; skipDefeated: boolean } | {}>(clientSettings.get(
 expectType<Partial<Record<string, CompendiumCollection.Configuration>>>(
   clientSettings.get('core', 'compendiumConfiguration')
 );
-expectType<foundry.CONST.DiceRollMode>(clientSettings.get('core', 'rollMode'));
+expectType<foundry.CONST.DICE_ROLL_MODES>(clientSettings.get('core', 'rollMode'));

--- a/test-d/foundry/foundry.js/pixi/containers/canvasLayers/gridLayer.test-d.ts
+++ b/test-d/foundry/foundry.js/pixi/containers/canvasLayers/gridLayer.test-d.ts
@@ -9,7 +9,7 @@ expectType<'grid'>(layer.options.name);
 expectType<BaseGrid | undefined>(layer.grid);
 expectType<PIXI.Container | undefined>(layer.highlight);
 expectType<Record<string, GridHighlight>>(layer.highlightLayers);
-expectType<foundry.CONST.GridType>(layer.type);
+expectType<foundry.CONST.GRID_TYPES>(layer.type);
 expectType<number>(layer.size);
 expectType<number>(layer.w);
 expectType<number>(layer.h);


### PR DESCRIPTION
Additionally, the type belonging to the constants have been renamed to
the names of the values to better reflect the fact that they are
considered enums by foundry.

Closes #978