### PR TITLE
V9/refactor data

### DIFF
--- a/src/foundry/common/data/data.mjs/activeEffectData.d.ts
+++ b/src/foundry/common/data/data.mjs/activeEffectData.d.ts
@@ -6,24 +6,24 @@ import { EffectChangeData, EffectChangeDataConstructorData } from './effectChang
 import { EffectDurationData, EffectDurationDataConstructorData } from './effectDurationData';
 
 interface ActiveEffectDataSchema extends DocumentSchema {
-  _id: typeof fields.DOCUMENT_ID;
+  _id: fields.DocumentId;
   changes: DocumentField<EffectChangeData[]> & {
     type: [typeof EffectChangeData];
     required: true;
     default: [];
   };
-  disabled: typeof fields.BOOLEAN_FIELD;
+  disabled: fields.BooleanField;
   duration: DocumentField<EffectDurationData> & {
     type: typeof EffectDurationData;
     required: true;
-    default: {};
+    default: Record<string, never>;
   };
-  icon: typeof fields.IMAGE_FIELD;
-  label: typeof fields.BLANK_STRING;
-  origin: typeof fields.STRING_FIELD;
-  tint: typeof fields.COLOR_FIELD;
-  transfer: FieldReturnType<typeof fields.BOOLEAN_FIELD, { default: true }>;
-  flags: typeof fields.OBJECT_FIELD; // TODO: add more concrete object type
+  icon: fields.ImageField;
+  label: fields.BlankString;
+  origin: fields.StringField;
+  tint: fields.ColorField;
+  transfer: FieldReturnType<fields.BooleanField, { default: true }>;
+  flags: fields.ObjectField;
 }
 
 interface CoreFlags {
@@ -33,11 +33,13 @@ interface CoreFlags {
 interface ActiveEffectDataProperties {
   /**
    * The _id which uniquely identifies the ActiveEffect within a parent Actor or Item
+   * @defaultValue `null`
    */
   _id: string | null;
 
   /**
    * The array of EffectChangeData objects which the ActiveEffect applies
+   * @defaultValue `[]`
    */
   changes: EffectChangeData[];
 
@@ -49,6 +51,7 @@ interface ActiveEffectDataProperties {
 
   /**
    * An EffectDurationData object which describes the duration of the ActiveEffect
+   * @defaultValue `new EffectDurationData({})`
    */
   duration: EffectDurationData;
 
@@ -59,7 +62,7 @@ interface ActiveEffectDataProperties {
 
   /**
    * A text label which describes the name of the ActiveEffect
-   * @defaultValue `''`
+   * @defaultValue `""`
    */
   label: string;
 
@@ -89,11 +92,13 @@ interface ActiveEffectDataProperties {
 interface ActiveEffectDataConstructorData {
   /**
    * The _id which uniquely identifies the ActiveEffect within a parent Actor or Item
+   * @defaultValue `null`
    */
   _id?: string | null | undefined;
 
   /**
    * The array of EffectChangeData objects which the ActiveEffect applies
+   * @defaultValue `[]`
    */
   changes?: EffectChangeDataConstructorData[] | null | undefined;
 
@@ -105,6 +110,7 @@ interface ActiveEffectDataConstructorData {
 
   /**
    * An EffectDurationData object which describes the duration of the ActiveEffect
+   * @defaultValue `new EffectDurationData({})`
    */
   duration?: EffectDurationDataConstructorData | null | undefined;
 
@@ -115,7 +121,7 @@ interface ActiveEffectDataConstructorData {
 
   /**
    * A text label which describes the name of the ActiveEffect
-   * @defaultValue `''`
+   * @defaultValue `""`
    */
   label?: string | null | undefined;
 
@@ -146,15 +152,16 @@ interface ActiveEffectDataConstructorData {
  * The data schema for an ActiveEffect document.
  * @see BaseActiveEffect
  */
-export declare class ActiveEffectData extends DocumentData<
+export class ActiveEffectData extends DocumentData<
   ActiveEffectDataSchema,
   ActiveEffectDataProperties,
   PropertiesToSource<ActiveEffectDataProperties>,
   ActiveEffectDataConstructorData,
   documents.BaseActiveEffect
 > {
+  /** @override */
   static defineSchema(): ActiveEffectDataSchema;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export declare interface ActiveEffectData extends ActiveEffectDataProperties {}
+export interface ActiveEffectData extends ActiveEffectDataProperties {}

--- a/src/foundry/common/data/data.mjs/actorData.d.ts
+++ b/src/foundry/common/data/data.mjs/actorData.d.ts
@@ -74,13 +74,13 @@ interface ActorDataBaseProperties {
 
   /**
    * A Collection of Item embedded Documents
-   * @defaultValue `[]`
+   * @defaultValue `new EmbeddedCollection(ItemData, [], BaseItem.implementation)`
    */
   items: EmbeddedCollection<ConfiguredDocumentClass<typeof documents.BaseItem>, ActorData>;
 
   /**
    * A collection of ActiveEffect embedded Documents
-   * @defaultValue `[]`
+   * @defaultValue `new EmbeddedCollection(ActiveEffectData, [], BaseActiveEffect.implementation)`
    */
   effects: EmbeddedCollection<ConfiguredDocumentClass<typeof documents.BaseActiveEffect>, ActorData>;
 
@@ -146,13 +146,13 @@ interface ActorDataConstructorData {
 
   /**
    * A Collection of Item embedded Documents
-   * @defaultValue `[]`
+   * @defaultValue `new EmbeddedCollection(ItemData, [], BaseItem.implementation)`
    */
   items?: ConstructorParameters<ConfiguredDocumentClass<typeof documents.BaseItem>>[0][] | null | undefined;
 
   /**
    * A collection of ActiveEffect embedded Documents
-   * @defaultValue `[]`
+   * @defaultValue `new EmbeddedCollection(ActiveEffectData, [], BaseActiveEffect.implementation)`
    */
   effects?: ConstructorParameters<ConfiguredDocumentClass<typeof documents.BaseActiveEffect>>[0][] | null | undefined;
 

--- a/src/foundry/common/data/data.mjs/actorData.d.ts
+++ b/src/foundry/common/data/data.mjs/actorData.d.ts
@@ -1,4 +1,3 @@
-import EmbeddedCollection from '../../abstract/embedded-collection.mjs';
 import {
   ConfiguredData,
   ConfiguredDocumentClass,
@@ -7,23 +6,24 @@ import {
   FieldReturnType,
   PropertiesToSource
 } from '../../../../types/helperTypes';
+import EmbeddedCollection from '../../abstract/embedded-collection.mjs';
 import { DocumentData } from '../../abstract/module.mjs';
 import * as documents from '../../documents.mjs';
-import * as fields from '../fields.mjs';
 import { PrototypeTokenData } from '../data.mjs';
+import * as fields from '../fields.mjs';
 import { PrototypeTokenDataConstructorData } from './prototypeTokenData.js';
 
 interface ActorDataSchema extends DocumentSchema {
-  _id: typeof fields.DOCUMENT_ID;
-  name: typeof fields.REQUIRED_STRING;
+  _id: fields.DocumentId;
+  name: fields.RequiredString;
   type: DocumentField<string> & {
     type: typeof String;
     required: true;
     validate: (t: unknown) => boolean;
     validationError: 'The provided Actor type must be in the array of types defined by the game system';
   };
-  img: FieldReturnType<typeof fields.IMAGE_FIELD, { default: () => string }>;
-  data: FieldReturnType<typeof fields.OBJECT_FIELD, { default: (data: { type: string }) => any }>; // TODO
+  img: FieldReturnType<fields.ImageField, { default: () => string }>;
+  data: FieldReturnType<fields.ObjectField, { default: (data: { type: string }) => any }>; // TODO
   token: DocumentField<PrototypeTokenData> & {
     type: typeof PrototypeTokenData;
     required: true;
@@ -32,9 +32,9 @@ interface ActorDataSchema extends DocumentSchema {
   items: fields.EmbeddedCollectionField<typeof documents.BaseItem>;
   effects: fields.EmbeddedCollectionField<typeof documents.BaseActiveEffect>;
   folder: fields.ForeignDocumentField<{ type: typeof documents.BaseFolder }>;
-  sort: typeof fields.INTEGER_SORT_FIELD;
-  permission: typeof fields.DOCUMENT_PERMISSIONS;
-  flags: typeof fields.OBJECT_FIELD;
+  sort: fields.IntegerSortField;
+  permission: fields.DocumentPermissions;
+  flags: fields.ObjectField;
 }
 
 interface ActorDataBaseProperties {
@@ -62,21 +62,25 @@ interface ActorDataBaseProperties {
 
   /**
    * The system data object which is defined by the system template.json model
+   * @defaultValue template from template.json for type or `{}`
    */
   data: object;
 
   /**
    * Default Token settings which are used for Tokens created from this Actor
+   * @defaultValue `new PrototypeTokenData({ this.data.name, this.data.img })`
    */
   token: PrototypeTokenData;
 
   /**
    * A Collection of Item embedded Documents
+   * @defaultValue `[]`
    */
   items: EmbeddedCollection<ConfiguredDocumentClass<typeof documents.BaseItem>, ActorData>;
 
   /**
    * A collection of ActiveEffect embedded Documents
+   * @defaultValue `[]`
    */
   effects: EmbeddedCollection<ConfiguredDocumentClass<typeof documents.BaseActiveEffect>, ActorData>;
 
@@ -130,21 +134,25 @@ interface ActorDataConstructorData {
 
   /**
    * The system data object which is defined by the system template.json model
+   * @defaultValue template from template.json for type or `{}`
    */
   data?: DeepPartial<ActorDataSource['data']> | null | undefined;
 
   /**
    * Default Token settings which are used for Tokens created from this Actor
+   * @defaultValue `new PrototypeTokenData({ this.data.name, this.data.img })`
    */
   token?: PrototypeTokenDataConstructorData | null | undefined;
 
   /**
    * A Collection of Item embedded Documents
+   * @defaultValue `[]`
    */
   items?: ConstructorParameters<ConfiguredDocumentClass<typeof documents.BaseItem>>[0][] | null | undefined;
 
   /**
    * A collection of ActiveEffect embedded Documents
+   * @defaultValue `[]`
    */
   effects?: ConstructorParameters<ConfiguredDocumentClass<typeof documents.BaseActiveEffect>>[0][] | null | undefined;
 
@@ -152,7 +160,7 @@ interface ActorDataConstructorData {
    * The _id of a Folder which contains this Actor
    * @defaultValue `null`
    */
-  folder?: string | null | undefined;
+  folder?: InstanceType<ConfiguredDocumentClass<typeof documents.BaseFolder>> | string | null | undefined;
 
   /**
    * The numeric sort value which orders this Actor relative to its siblings
@@ -182,6 +190,7 @@ type DocumentDataConstructor = Pick<typeof DocumentData, keyof typeof DocumentDa
 interface ActorDataConstructor extends DocumentDataConstructor {
   new (data: ActorDataConstructorData, document?: documents.BaseActor | null): ActorData;
 
+  /** @override */
   defineSchema(): ActorDataSchema;
 
   /**
@@ -203,9 +212,11 @@ export type ActorData = DocumentData<
   documents.BaseActor
 > &
   ActorDataProperties & {
+    /** @override */
     _initializeSource(data: ActorDataConstructorData): ActorDataSource;
 
+    /** @override */
     _initialize(): void;
   };
 
-export declare const ActorData: ActorDataConstructor;
+export const ActorData: ActorDataConstructor;

--- a/src/foundry/common/data/data.mjs/ambientLightData.d.ts
+++ b/src/foundry/common/data/data.mjs/ambientLightData.d.ts
@@ -5,19 +5,19 @@ import * as fields from '../fields.mjs';
 import type { LightData, LightDataConstructorData } from './lightData.js';
 
 interface AmbientLightDataSchema extends DocumentSchema {
-  _id: typeof fields.DOCUMENT_ID;
-  x: typeof fields.REQUIRED_NUMBER;
-  y: typeof fields.REQUIRED_NUMBER;
-  rotation: FieldReturnType<typeof fields.ANGLE_FIELD, { default: 0 }>;
-  walls: FieldReturnType<typeof fields.BOOLEAN_FIELD, { default: true }>;
-  vision: typeof fields.BOOLEAN_FIELD;
+  _id: fields.DocumentId;
+  x: fields.RequiredNumber;
+  y: fields.RequiredNumber;
+  rotation: FieldReturnType<fields.AngleField, { default: 0 }>;
+  walls: FieldReturnType<fields.BooleanField, { default: true }>;
+  vision: fields.BooleanField;
   config: DocumentField<LightData> & {
     type: typeof LightData;
     required: true;
-    default: {};
+    default: Record<string, never>;
   };
-  hidden: typeof fields.BOOLEAN_FIELD;
-  flags: typeof fields.OBJECT_FIELD;
+  hidden: fields.BooleanField;
+  flags: fields.ObjectField;
 }
 
 interface AmbientLightDataProperties {
@@ -103,19 +103,19 @@ interface AmbientLightDataConstructorData {
    * Whether or not this light source is constrained by Walls
    * @defaultValue `true`
    */
-  walls?: boolean | undefined | null;
+  walls?: boolean | null | undefined;
 
   /**
    * Whether or not this light source provides a source of vision
    * @defaultValue `false`
    */
-  vision?: boolean | undefined | null;
+  vision?: boolean | null | undefined;
 
   /**
    * Light configuration data
    * @defaultValue `new LightData({})`
    */
-  config?: LightDataConstructorData | undefined | null;
+  config?: LightDataConstructorData | null | undefined;
 
   /**
    * Is the light source currently hidden?
@@ -134,19 +134,22 @@ interface AmbientLightDataConstructorData {
  * The data schema for a AmbientLight embedded document.
  * @see BaseAmbientLight
  */
-export declare class AmbientLightData extends DocumentData<
+export class AmbientLightData extends DocumentData<
   AmbientLightDataSchema,
   AmbientLightDataProperties,
   PropertiesToSource<AmbientLightDataProperties>,
   AmbientLightDataConstructorData,
   BaseAmbientLight
 > {
+  /** @override */
   static defineSchema(): AmbientLightDataSchema;
 
+  /** @override */
   _initializeSource(data: AmbientLightDataConstructorData): PropertiesToSource<AmbientLightDataProperties>;
 
-  _initialize(): void;
+  /** @override */
+  protected _initialize(): void;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export declare interface AmbientLightData extends AmbientLightDataProperties {}
+export interface AmbientLightData extends AmbientLightDataProperties {}

--- a/src/foundry/common/data/data.mjs/ambientSoundData.d.ts
+++ b/src/foundry/common/data/data.mjs/ambientSoundData.d.ts
@@ -5,22 +5,22 @@ import * as fields from '../fields.mjs';
 import { DarknessActivation, DarknessActivationConstructorData } from './darknessActivation';
 
 interface AmbientSoundDataSchema extends DocumentSchema {
-  _id: typeof fields.DOCUMENT_ID;
-  x: typeof fields.REQUIRED_NUMBER;
-  y: typeof fields.REQUIRED_NUMBER;
-  radius: typeof fields.NONNEGATIVE_NUMBER_FIELD;
-  path: typeof fields.AUDIO_FIELD;
-  repeat: typeof fields.BOOLEAN_FIELD;
-  volume: FieldReturnType<typeof fields.ALPHA_FIELD, { default: 0.5 }>;
-  walls: FieldReturnType<typeof fields.BOOLEAN_FIELD, { default: true }>;
-  easing: FieldReturnType<typeof fields.BOOLEAN_FIELD, { default: true }>;
-  hidden: typeof fields.BOOLEAN_FIELD;
+  _id: fields.DocumentId;
+  x: fields.RequiredNumber;
+  y: fields.RequiredNumber;
+  radius: fields.NonnegativeNumberField;
+  path: fields.AudioField;
+  repeat: fields.BooleanField;
+  volume: FieldReturnType<fields.AlphaField, { default: 0.5 }>;
+  walls: FieldReturnType<fields.BooleanField, { default: true }>;
+  easing: FieldReturnType<fields.BooleanField, { default: true }>;
+  hidden: fields.BooleanField;
   darkness: DocumentField<DarknessActivation> & {
     type: typeof DarknessActivation;
     required: true;
-    default: {};
+    default: Record<string, never>;
   };
-  flags: typeof fields.OBJECT_FIELD;
+  flags: fields.ObjectField;
 }
 
 interface AmbientSoundDataProperties {
@@ -65,7 +65,7 @@ interface AmbientSoundDataProperties {
   /** @defaultValue `false` */
   hidden: boolean;
 
-  /** @defaultValue `{}` */
+  /** @defaultValue `new DarknessActivation({})` */
   darkness: DarknessActivation;
 
   /**
@@ -117,7 +117,7 @@ interface AmbientSoundDataConstructorData {
   /** @defaultValue `false` */
   hidden?: boolean | null | undefined;
 
-  /** @defaultValue `{}` */
+  /** @defaultValue `new DarknessActivation({})` */
   darkness?: DarknessActivationConstructorData | null | undefined;
 
   /**
@@ -131,15 +131,17 @@ interface AmbientSoundDataConstructorData {
  * The data schema for a AmbientSound embedded document.
  * @see BaseAmbientSound
  */
-export declare class AmbientSoundData extends DocumentData<
+export class AmbientSoundData extends DocumentData<
   AmbientSoundDataSchema,
   AmbientSoundDataProperties,
   PropertiesToSource<AmbientSoundDataProperties>,
   AmbientSoundDataConstructorData,
   documents.BaseAmbientSound
 > {
+  /** @override */
   static defineSchema(): AmbientSoundDataSchema;
 
+  /** @override */
   _initializeSource(data: AmbientSoundDataConstructorData): PropertiesToSource<AmbientSoundDataProperties>;
 
   /** @override */
@@ -147,4 +149,4 @@ export declare class AmbientSoundData extends DocumentData<
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export declare interface AmbientSoundData extends AmbientSoundDataProperties {}
+export interface AmbientSoundData extends AmbientSoundDataProperties {}

--- a/src/foundry/common/data/data.mjs/ambientSoundData.d.ts
+++ b/src/foundry/common/data/data.mjs/ambientSoundData.d.ts
@@ -56,6 +56,9 @@ interface AmbientSoundDataProperties {
    */
   volume: number;
 
+  /** @defaultValue `false` */
+  walls: boolean;
+
   /** @defaultValue `true` */
   easing: boolean;
 
@@ -104,6 +107,9 @@ interface AmbientSoundDataConstructorData {
    * @defaultValue `0.5`
    */
   volume?: number | null | undefined;
+
+  /** @defaultValue `false` */
+  walls?: boolean | null | undefined;
 
   /** @defaultValue `true` */
   easing?: boolean | null | undefined;

--- a/src/foundry/common/data/data.mjs/animationData.d.ts
+++ b/src/foundry/common/data/data.mjs/animationData.d.ts
@@ -4,7 +4,7 @@ import { BaseAmbientLight } from '../../documents.mjs';
 import * as fields from '../fields.mjs';
 
 interface AnimationDataSchema extends DocumentSchema {
-  type: typeof fields.STRING_FIELD;
+  type: fields.StringField;
   speed: DocumentField<number> & {
     type: typeof Number;
     required: false;
@@ -19,7 +19,7 @@ interface AnimationDataSchema extends DocumentSchema {
     validate: (a: number) => boolean;
     validationError: 'Light animation intensity must be an integer between 1 and 10';
   };
-  reverse: typeof fields.BOOLEAN_FIELD;
+  reverse: fields.BooleanField;
 }
 
 interface AnimationDataProperties {
@@ -44,7 +44,7 @@ interface AnimationDataProperties {
   reverse: boolean;
 }
 
-export interface AnimationDataConstructorData {
+interface AnimationDataConstructorData {
   /**
    * The animation type which is applied
    */
@@ -63,21 +63,22 @@ export interface AnimationDataConstructorData {
   intensity?: number | null | undefined;
 
   /** @defaultValue `false` */
-  reverse?: boolean | undefined | null;
+  reverse?: boolean | null | undefined;
 }
 
 /**
  * An embedded data object which defines the properties of a light source animation
  */
-export declare class AnimationData extends DocumentData<
+export class AnimationData extends DocumentData<
   AnimationDataSchema,
   AnimationDataProperties,
   PropertiesToSource<AnimationDataProperties>,
   AnimationDataConstructorData,
   BaseAmbientLight
 > {
+  /** @override */
   static defineSchema(): AnimationDataSchema;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export declare interface AnimationData extends AnimationDataProperties {}
+export interface AnimationData extends AnimationDataProperties {}

--- a/src/foundry/common/data/data.mjs/cardData.d.ts
+++ b/src/foundry/common/data/data.mjs/cardData.d.ts
@@ -6,16 +6,16 @@ import type {
   PropertiesToSource
 } from '../../../../types/helperTypes.js';
 import type DocumentData from '../../abstract/data.mjs.js';
-import * as fields from '../fields.mjs';
 import * as documents from '../../documents.mjs';
+import * as fields from '../fields.mjs';
 import type { CardFaceData, CardFaceDataConstructorData } from './cardFaceData.js';
 
 interface CardDataSchema extends DocumentSchema {
-  _id: typeof fields.DOCUMENT_ID;
-  name: typeof fields.REQUIRED_STRING;
-  description: typeof fields.BLANK_STRING;
+  _id: fields.DocumentId;
+  name: fields.RequiredString;
+  description: fields.BlankString;
   type: FieldReturnType<
-    typeof fields.REQUIRED_STRING,
+    fields.RequiredString,
     {
       default: () => string;
       validate: (t: unknown) => boolean;
@@ -23,19 +23,19 @@ interface CardDataSchema extends DocumentSchema {
     }
   >;
   data: fields.SystemDataField;
-  suit: typeof fields.BLANK_STRING;
-  value: typeof fields.NUMERIC_FIELD;
-  back: {
+  suit: fields.BlankString;
+  value: fields.NumericField;
+  back: DocumentField<CardFaceData> & {
     type: typeof CardFaceData;
     required: true;
     default: Record<string, never>;
   };
-  faces: {
+  faces: DocumentField<CardFaceData[]> & {
     type: [typeof CardFaceData];
     required: true;
     default: [];
   };
-  face: {
+  face: DocumentField<number> & {
     type: typeof Number;
     required: true;
     default: null;
@@ -43,13 +43,13 @@ interface CardDataSchema extends DocumentSchema {
     validate: (f: unknown) => boolean;
     validationError: '{name} {field} "{value}" must have a non-negative integer value or null';
   };
-  drawn: typeof fields.BOOLEAN_FIELD;
-  origin: typeof fields.DOCUMENT_ID;
-  width: typeof fields.POSITIVE_INTEGER_FIELD;
-  height: typeof fields.POSITIVE_INTEGER_FIELD;
-  rotation: typeof fields.ANGLE_FIELD;
-  sort: typeof fields.INTEGER_SORT_FIELD;
-  flags: typeof fields.OBJECT_FIELD;
+  drawn: fields.BooleanField;
+  origin: fields.DocumentId;
+  width: fields.PositiveIntegerField;
+  height: fields.PositiveIntegerField;
+  rotation: fields.AngleField;
+  sort: fields.IntegerSortField;
+  flags: fields.ObjectField;
 }
 
 interface CardDataBaseProperties {
@@ -74,7 +74,10 @@ interface CardDataBaseProperties {
    */
   type: string;
 
-  /** Game system data which is defined by the system template.json model */
+  /**
+   * Game system data which is defined by the system template.json model
+   * @defaultValue template from template.json for type or `{}`
+   */
   data: object;
 
   /**
@@ -84,7 +87,7 @@ interface CardDataBaseProperties {
   suit: string;
 
   /** An optional numeric value of the card which is used by default sorting */
-  value: number | undefined | null;
+  value: number | null | undefined;
 
   /**
    * An object of face data which describes the back of this card
@@ -146,7 +149,7 @@ interface CardDataConstructorData {
    * The _id which uniquely identifies this Card document
    * @defaultValue `null`
    */
-  _id?: string | undefined | null;
+  _id?: string | null | undefined;
 
   /** The text name of this card */
   name: string;
@@ -155,78 +158,82 @@ interface CardDataConstructorData {
    * A text description of this card which applies to all faces
    * @defaultValue `""`
    */
-  description?: string | undefined | null;
+  description?: string | null | undefined;
 
   /**
    * A category of card (for example, a suit) to which this card belongs
    * @defaultValue `game.system.documentTypes.Card[0]`
    */
-  type?: CardDataSource['type'] | undefined | null;
+  type?: CardDataSource['type'] | null | undefined;
 
-  /** Game system data which is defined by the system template.json model */
-  data?: DeepPartial<CardDataSource['data']> | undefined | null;
+  /**
+   * Game system data which is defined by the system template.json model
+   * @defaultValue template from template.json for type or `{}`
+   */
+  data?: DeepPartial<CardDataSource['data']> | null | undefined;
 
   /**
    * An optional suit designation which is used by default sorting
    * @defaultValue `""`
    */
-  suit?: string | undefined | null;
+  suit?: string | null | undefined;
 
   /** An optional numeric value of the card which is used by default sorting */
-  value?: number | undefined | null;
+  value?: number | null | undefined;
 
   /**
    * An object of face data which describes the back of this card
    * @defaultValue `new CardFaceData({})`
-   */ back?: CardFaceDataConstructorData | undefined | null;
+   */
+  back?: CardFaceDataConstructorData | null | undefined;
 
   /**
    * An array of face data which represent displayable faces of this card
    * @defaultValue `[]`
    */
-  faces?: CardFaceDataConstructorData[] | undefined | null;
+  faces?: CardFaceDataConstructorData[] | null | undefined;
 
   /**
    * The index of the currently displayed face
    * @defaultValue `null`
    */
-  face?: number | undefined | null;
+  face?: number | null | undefined;
 
   /**
    * Whether this card is currently drawn from its source deck
    * @defaultValue `false`
    */
-  drawn?: boolean | undefined | null;
+  drawn?: boolean | null | undefined;
 
   /**
    * The document ID of the origin deck to which this card belongs
    * @defaultValue `null`
    */
-  origin?: string | undefined | null;
+  origin?: string | null | undefined;
 
   /** The visible width of this card */
-  width?: number | undefined | null;
+  width?: number | null | undefined;
 
   /** The visible height of this card */
-  height?: number | undefined | null;
+  height?: number | null | undefined;
 
   /**
    * The angle of rotation of this card
    * @defaultValue `360`
    */
-  rotation?: number | undefined | null;
+  rotation?: number | null | undefined;
 
   /**
    * The sort order of this card relative to others in the same stack
    * @defaultValue `0`
    */
-  sort?: number | undefined | null;
+  sort?: number | null | undefined;
 
   /**
    * An object of optional key/value flags
    * @defaultValue `{}`
    */
-  flags?: ConfiguredFlags<'Card'> | undefined | null;
+  flags?: ConfiguredFlags<'Card'> | null | undefined;
 }
 
 type CardDataBaseSource = PropertiesToSource<CardDataBaseProperties>;
@@ -238,6 +245,7 @@ type DocumentDataConstructor = Pick<typeof DocumentData, keyof typeof DocumentDa
 interface CardDataConstructor extends DocumentDataConstructor {
   new (data: CardDataConstructorData, document?: documents.BaseCard | null | undefined): CardData;
 
+  /** @override */
   defineSchema(): CardDataSchema;
 }
 
@@ -254,4 +262,4 @@ export type CardData = DocumentData<
 > &
   CardDataProperties;
 
-export declare const CardData: CardDataConstructor;
+export const CardData: CardDataConstructor;

--- a/src/foundry/common/data/data.mjs/cardFaceData.d.ts
+++ b/src/foundry/common/data/data.mjs/cardFaceData.d.ts
@@ -3,9 +3,9 @@ import type DocumentData from '../../abstract/data.mjs.js';
 import * as fields from '../fields.mjs';
 
 interface CardFaceDataSchema extends DocumentSchema {
-  name: typeof fields.BLANK_STRING;
-  text: typeof fields.BLANK_STRING;
-  img: typeof fields.VIDEO_FIELD;
+  name: fields.BlankString;
+  text: fields.BlankString;
+  img: fields.VideoField;
 }
 
 interface CardFaceDataProperties {
@@ -22,7 +22,7 @@ interface CardFaceDataProperties {
   text: string;
 
   /** A displayed image or video file which depicts the face */
-  img: string | undefined | null;
+  img: string | null | undefined;
 }
 
 interface CardFaceDataConstructorData {
@@ -30,28 +30,29 @@ interface CardFaceDataConstructorData {
    * A name for this card face
    * @defaultValue `""`
    */
-  name?: string | undefined | null;
+  name?: string | null | undefined;
 
   /**
    * Displayed text that belongs to this face
    * @defaultValue `""`
    */
-  text?: string | undefined | null;
+  text?: string | null | undefined;
 
   /** A displayed image or video file which depicts the face */
-  img?: string | undefined | null;
+  img?: string | null | undefined;
 }
 
 /**
  * The data schema of a single card face which belongs to a specific Card.
  * @see CardData
  */
-export declare class CardFaceData extends DocumentData<
+export class CardFaceData extends DocumentData<
   CardFaceDataSchema,
   CardFaceDataProperties,
   PropertiesToSource<CardFaceDataProperties>,
   CardFaceDataConstructorData
 > {
+  /** @override */
   static defineSchema(): CardFaceDataSchema;
 
   /**
@@ -60,3 +61,6 @@ export declare class CardFaceData extends DocumentData<
    */
   static DEFAULT_ICON: string;
 }
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface CardFaceData extends CardFaceDataProperties {}

--- a/src/foundry/common/data/data.mjs/cardsData.d.ts
+++ b/src/foundry/common/data/data.mjs/cardsData.d.ts
@@ -72,7 +72,7 @@ interface CardsDataBaseProperties {
 
   /**
    * A collection of Card documents which currently belong to this stack
-   * @defaultValue `[]`
+   * @defaultValue `new EmbeddedCollection(CardData, [], BaseCard.implementation)`
    */
   cards: EmbeddedCollection<ConfiguredDocumentClass<typeof documents.BaseCard>, CardsData>;
 
@@ -155,7 +155,7 @@ interface CardsDataConstructorData {
 
   /**
    * A collection of Card documents which currently belong to this stack
-   * @defaultValue `[]`
+   * @defaultValue `new EmbeddedCollection(CardData, [], BaseCard.implementation)`
    */
   cards?: ConstructorParameters<ConfiguredDocumentClass<typeof documents.BaseCard>>[0][] | null | undefined;
 

--- a/src/foundry/common/data/data.mjs/cardsData.d.ts
+++ b/src/foundry/common/data/data.mjs/cardsData.d.ts
@@ -12,28 +12,28 @@ import * as documents from '../../documents.mjs';
 import * as fields from '../fields.mjs';
 
 interface CardsDataSchema extends DocumentSchema {
-  _id: typeof fields.DOCUMENT_ID;
-  name: typeof fields.REQUIRED_STRING;
+  _id: fields.DocumentId;
+  name: fields.RequiredString;
   type: FieldReturnType<
-    typeof fields.REQUIRED_STRING,
+    fields.RequiredString,
     {
       default: () => string;
       validate: (t: unknown) => boolean;
       validationError: '{name} {field} "{value}" is not a valid type';
     }
   >;
-  description: typeof fields.BLANK_STRING;
-  img: FieldReturnType<typeof fields.VIDEO_FIELD, { default: () => string }>;
+  description: fields.BlankString;
+  img: FieldReturnType<fields.VideoField, { default: () => string }>;
   data: fields.SystemDataField;
   cards: fields.EmbeddedCollectionField<typeof documents.BaseCard>;
-  width: typeof fields.POSITIVE_INTEGER_FIELD;
-  heigth: typeof fields.POSITIVE_INTEGER_FIELD;
-  rotation: typeof fields.ANGLE_FIELD;
-  displayCount: typeof fields.BOOLEAN_FIELD;
+  width: fields.PositiveIntegerField;
+  heigth: fields.PositiveIntegerField;
+  rotation: fields.AngleField;
+  displayCount: fields.BooleanField;
   folder: fields.ForeignDocumentField<{ type: typeof documents.BaseFolder }>;
-  sort: typeof fields.INTEGER_SORT_FIELD;
-  permission: typeof fields.DOCUMENT_PERMISSIONS;
-  flags: typeof fields.OBJECT_FIELD;
+  sort: fields.IntegerSortField;
+  permission: fields.DocumentPermissions;
+  flags: fields.ObjectField;
 }
 
 interface CardsDataBaseProperties {
@@ -64,10 +64,16 @@ interface CardsDataBaseProperties {
    */
   img: string | null;
 
-  /** Game system data which is defined by the system template.json model */
+  /**
+   * Game system data which is defined by the system template.json model
+   * @defaultValue template from template.json for type or `{}`
+   */
   data: object;
 
-  /** A collection of Card documents which currently belong to this stack */
+  /**
+   * A collection of Card documents which currently belong to this stack
+   * @defaultValue `[]`
+   */
   cards: EmbeddedCollection<ConfiguredDocumentClass<typeof documents.BaseCard>, CardsData>;
 
   /** The visible width of this stack */
@@ -118,73 +124,82 @@ interface CardsDataConstructorData {
    * The _id which uniquely identifies this stack of Cards document
    * @defaultValue `null`
    */
-  _id?: string | undefined | null;
+  _id?: string | null | undefined;
 
   /** The text name of this stack */
   name: string;
 
-  /** The type of this stack, in BaseCards.metadata.types */
-  type?: CardsDataSource['type'] | undefined | null;
+  /**
+   * The type of this stack, in BaseCards.metadata.types
+   * @defaultValue `game.system.documentTypes.Cards[0]`
+   */
+  type?: CardsDataSource['type'] | null | undefined;
 
   /**
    * A text description of this stack
    * @defaultValue `""`
    */
-  description?: string | undefined | null;
+  description?: string | null | undefined;
 
   /**
    * An image or video which is used to represent the stack of cards
    * @defaultValue `CardsData.DEFAULT_ICON`
    */
-  img?: string | undefined | null;
+  img?: string | null | undefined;
 
-  /** Game system data which is defined by the system template.json model */
-  data?: DeepPartial<CardsDataSource['data']> | undefined | null;
+  /**
+   * Game system data which is defined by the system template.json model
+   * @defaultValue template from template.json for type or `{}`
+   */
+  data?: DeepPartial<CardsDataSource['data']> | null | undefined;
 
-  /** A collection of Card documents which currently belong to this stack */
-  cards?: ConstructorParameters<ConfiguredDocumentClass<typeof documents.BaseCard>>[0][] | undefined | null;
+  /**
+   * A collection of Card documents which currently belong to this stack
+   * @defaultValue `[]`
+   */
+  cards?: ConstructorParameters<ConfiguredDocumentClass<typeof documents.BaseCard>>[0][] | null | undefined;
 
   /** The visible width of this stack */
-  width?: number | undefined | null;
+  width?: number | null | undefined;
 
   /** The visible height of this stack */
-  height?: number | undefined | null;
+  height?: number | null | undefined;
 
   /**
    * The angle of rotation of this stack
    * @defaultValue `360`
    */
-  rotation?: number | undefined | null;
+  rotation?: number | null | undefined;
 
   /**
    * Whether or not to publicly display the number of cards in this stack
    * @defaultValue `false`
    */
-  displayCount?: boolean | undefined | null;
+  displayCount?: boolean | null | undefined;
 
   /**
    * The _id of a Folder which contains this document
    * @defaultValue `null`
    */
-  folder?: string | undefined | null;
+  folder?: InstanceType<ConfiguredDocumentClass<typeof documents.BaseFolder>> | string | null | undefined;
 
   /**
    * The sort order of this stack relative to others in its parent collection
    * @defaultValue `0`
    */
-  sort?: number | undefined | null;
+  sort?: number | null | undefined;
 
   /**
    * An object which configures user permissions to this stack
    * @defaultValue `{ default: CONST.ENTITY_PERMISSIONS.NONE }`
    */
-  permission?: Record<string, foundry.CONST.DOCUMENT_PERMISSION_LEVELS> | undefined | null;
+  permission?: Record<string, foundry.CONST.DOCUMENT_PERMISSION_LEVELS> | null | undefined;
 
   /**
    * An object of optional key/value flags
    * @defaultValue `{}`
    */
-  flags?: ConfiguredFlags<'Cards'> | undefined | null;
+  flags?: ConfiguredFlags<'Cards'> | null | undefined;
 }
 
 type CardsDataBaseSource = PropertiesToSource<CardsDataBaseProperties>;
@@ -196,6 +211,7 @@ type DocumentDataConstructor = Pick<typeof DocumentData, keyof typeof DocumentDa
 interface CardsDataConstructor extends DocumentDataConstructor {
   new (data: CardsDataConstructorData, document?: documents.BaseCards | null | undefined): CardsData;
 
+  /** @override */
   defineSchema(): CardsDataSchema;
 
   /**
@@ -219,4 +235,4 @@ export type CardsData = DocumentData<
 > &
   CardsDataProperties;
 
-export declare const CardsData: CardsDataConstructor;
+export const CardsData: CardsDataConstructor;

--- a/src/foundry/common/data/data.mjs/chatMessageData.d.ts
+++ b/src/foundry/common/data/data.mjs/chatMessageData.d.ts
@@ -5,16 +5,16 @@ import {
   PropertiesToSource
 } from '../../../../types/helperTypes';
 import { DocumentData } from '../../abstract/module.mjs';
-import { CONST, documents } from '../../module.mjs';
+import { documents } from '../../module.mjs';
 import * as fields from '../fields.mjs';
 import { ChatSpeakerData, ChatSpeakerDataConstructorData } from './chatSpeakerData';
 
 interface ChatMessageDataSchema extends DocumentSchema {
   _id: fields.DocumentId;
-  type: DocumentField<CONST.CHAT_MESSAGE_TYPES> & {
+  type: DocumentField<foundry.CONST.CHAT_MESSAGE_TYPES> & {
     type: typeof Number;
     required: true;
-    default: typeof CONST.CHAT_MESSAGE_TYPES.OTHER;
+    default: typeof foundry.CONST.CHAT_MESSAGE_TYPES.OTHER;
     validate: typeof _validateChatMessageType;
     validationError: 'The provided ChatMessage type must be in CONST.CHAT_MESSAGE_TYPES';
   };
@@ -51,7 +51,7 @@ interface ChatMessageDataProperties {
    * The message type from CONST.CHAT_MESSAGE_TYPES
    * @defaultValue `CONST.CHAT_MESSAGE_TYPES.OTHER`
    */
-  type: CONST.CHAT_MESSAGE_TYPES;
+  type: foundry.CONST.CHAT_MESSAGE_TYPES;
 
   /**
    * The _id of the User document who generated this message
@@ -128,7 +128,7 @@ interface ChatMessageDataConstructorData {
    * The message type from CONST.CHAT_MESSAGE_TYPES
    * @defaultValue `CONST.CHAT_MESSAGE_TYPES.OTHER`
    */
-  type?: CONST.CHAT_MESSAGE_TYPES | null | undefined;
+  type?: foundry.CONST.CHAT_MESSAGE_TYPES | null | undefined;
 
   /**
    * The _id of the User document who generated this message

--- a/src/foundry/common/data/data.mjs/chatMessageData.d.ts
+++ b/src/foundry/common/data/data.mjs/chatMessageData.d.ts
@@ -1,11 +1,16 @@
-import { ConfiguredFlags, FieldReturnType, PropertiesToSource } from '../../../../types/helperTypes';
+import {
+  ConfiguredDocumentClass,
+  ConfiguredFlags,
+  FieldReturnType,
+  PropertiesToSource
+} from '../../../../types/helperTypes';
 import { DocumentData } from '../../abstract/module.mjs';
 import { CONST, documents } from '../../module.mjs';
 import * as fields from '../fields.mjs';
 import { ChatSpeakerData, ChatSpeakerDataConstructorData } from './chatSpeakerData';
 
 interface ChatMessageDataSchema extends DocumentSchema {
-  _id: typeof fields.DOCUMENT_ID;
+  _id: fields.DocumentId;
   type: DocumentField<CONST.CHAT_MESSAGE_TYPES> & {
     type: typeof Number;
     required: true;
@@ -14,26 +19,31 @@ interface ChatMessageDataSchema extends DocumentSchema {
     validationError: 'The provided ChatMessage type must be in CONST.CHAT_MESSAGE_TYPES';
   };
   user: fields.ForeignDocumentField<{ type: typeof documents.BaseUser; required: true }>;
-  timestamp: FieldReturnType<typeof fields.TIMESTAMP_FIELD, { required: true }>;
-  flavor: typeof fields.STRING_FIELD;
-  content: typeof fields.BLANK_STRING;
-  speaker: DocumentField<ChatSpeakerData> & { type: typeof ChatSpeakerData; required: true; default: {} };
+  timestamp: FieldReturnType<fields.TimestampField, { required: true }>;
+  flavor: fields.StringField;
+  content: fields.BlankString;
+  speaker: DocumentField<ChatSpeakerData> & {
+    type: typeof ChatSpeakerData;
+    required: true;
+    default: Record<string, never>;
+  };
   whisper: DocumentField<string[]> & {
     type: [typeof String];
     clean: (users: Array<{ id: string } | string>) => string[];
     required: true;
     default: string[];
   };
-  blind: typeof fields.BOOLEAN_FIELD;
-  roll: typeof fields.JSON_FIELD;
-  sound: typeof fields.AUDIO_FIELD;
-  emote: typeof fields.BOOLEAN_FIELD;
-  flags: typeof fields.OBJECT_FIELD;
+  blind: fields.BooleanField;
+  roll: fields.JsonField;
+  sound: fields.AudioField;
+  emote: fields.BooleanField;
+  flags: fields.ObjectField;
 }
 
 interface ChatMessageDataProperties {
   /**
    * The _id which uniquely identifies this ChatMessage document
+   * @defaultValue `null`
    */
   _id: string | null;
 
@@ -45,6 +55,7 @@ interface ChatMessageDataProperties {
 
   /**
    * The _id of the User document who generated this message
+   * @defaultValue `null`
    */
   user: string | null;
 
@@ -67,6 +78,7 @@ interface ChatMessageDataProperties {
 
   /**
    * A ChatSpeakerData object which describes the origin of the ChatMessage
+   * @defaultValue `new ChatSpeakerData({})`
    */
   speaker: ChatSpeakerData;
 
@@ -84,13 +96,11 @@ interface ChatMessageDataProperties {
 
   /**
    * The serialized content of a Roll instance which belongs to the ChatMessage
-   * @defaultValue `undefined`
    */
   roll: string | undefined;
 
   /**
    * The URL of an audio file which plays when this message is received
-   * @defaultValue `undefined`
    */
   sound: string | null | undefined;
 
@@ -107,9 +117,10 @@ interface ChatMessageDataProperties {
   flags: ConfiguredFlags<'ChatMessage'>;
 }
 
-export interface ChatMessageDataConstructorData {
+interface ChatMessageDataConstructorData {
   /**
    * The _id which uniquely identifies this ChatMessage document
+   * @defaultValue `null`
    */
   _id?: string | null | undefined;
 
@@ -121,8 +132,9 @@ export interface ChatMessageDataConstructorData {
 
   /**
    * The _id of the User document who generated this message
+   * @defaultValue `null`
    */
-  user?: string | null | undefined;
+  user?: InstanceType<ConfiguredDocumentClass<typeof documents.BaseUser>> | string | null | undefined;
 
   /**
    * The timestamp at which point this message was generated
@@ -143,6 +155,7 @@ export interface ChatMessageDataConstructorData {
 
   /**
    * A ChatSpeakerData object which describes the origin of the ChatMessage
+   * @defaultValue `new ChatSpeakerData({})`
    */
   speaker?: ChatSpeakerDataConstructorData | null | undefined;
 
@@ -160,13 +173,11 @@ export interface ChatMessageDataConstructorData {
 
   /**
    * The serialized content of a Roll instance which belongs to the ChatMessage
-   * @defaultValue `undefined`
    */
-  roll?: string | null | undefined;
+  roll?: string | object | null | undefined;
 
   /**
    * The URL of an audio file which plays when this message is received
-   * @defaultValue `undefined`
    */
   sound?: string | null | undefined;
 
@@ -186,18 +197,19 @@ export interface ChatMessageDataConstructorData {
 /**
  * An embedded data object which defines the properties of a light source animation
  */
-export declare class ChatMessageData extends DocumentData<
+export class ChatMessageData extends DocumentData<
   ChatMessageDataSchema,
   ChatMessageDataProperties,
   PropertiesToSource<ChatMessageDataProperties>,
   ChatMessageDataConstructorData,
   documents.BaseChatMessage
 > {
+  /** @override */
   static defineSchema(): ChatMessageDataSchema;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export declare interface ChatMessageData extends ChatMessageDataProperties {}
+export interface ChatMessageData extends ChatMessageDataProperties {}
 
 /**
  * Validate that a ChatMessage has a valid type

--- a/src/foundry/common/data/data.mjs/chatSpeakerData.d.ts
+++ b/src/foundry/common/data/data.mjs/chatSpeakerData.d.ts
@@ -1,29 +1,32 @@
-import { FieldReturnType, PropertiesToSource } from '../../../../types/helperTypes';
+import { ConfiguredDocumentClass, FieldReturnType, PropertiesToSource } from '../../../../types/helperTypes';
 import { DocumentData } from '../../abstract/module.mjs';
 import { BaseActor, BaseChatMessage, BaseScene } from '../../documents.mjs';
-import { ForeignDocumentField } from '../fields.mjs';
 import * as fields from '../fields.mjs';
+import { ForeignDocumentField } from '../fields.mjs';
 
 interface ChatSpeakerDataSchema extends DocumentSchema {
   scene: ForeignDocumentField<{ type: typeof BaseScene; required: false }>;
   actor: ForeignDocumentField<{ type: typeof BaseActor; required: false }>;
-  token: FieldReturnType<typeof fields.DOCUMENT_ID, { required: false }>;
-  alias: typeof fields.STRING_FIELD;
+  token: FieldReturnType<fields.DocumentId, { required: false }>;
+  alias: fields.StringField;
 }
 
 interface ChatSpeakerDataProperties {
   /**
    * The _id of the Scene where this message was created
+   * @defaultValue `null`
    */
   scene: string | null;
 
   /**
    * The _id of the Actor who generated this message
+   * @defaultValue `null`
    */
   actor: string | null;
 
   /**
    * The _id of the Token who generated this message
+   * @defaultValue `null`
    */
   token: string | null;
 
@@ -36,16 +39,19 @@ interface ChatSpeakerDataProperties {
 interface ChatSpeakerDataConstructorData {
   /**
    * The _id of the Scene where this message was created
+   * @defaultValue `null`
    */
-  scene?: string | null | undefined;
+  scene?: InstanceType<ConfiguredDocumentClass<typeof foundry.documents.BaseScene>> | string | null | undefined;
 
   /**
    * The _id of the Actor who generated this message
+   * @defaultValue `null`
    */
-  actor?: string | null | undefined;
+  actor?: InstanceType<ConfiguredDocumentClass<typeof foundry.documents.BaseActor>> | string | null | undefined;
 
   /**
    * The _id of the Token who generated this message
+   * @defaultValue `null`
    */
   token?: string | null | undefined;
 
@@ -58,15 +64,16 @@ interface ChatSpeakerDataConstructorData {
 /**
  * An embedded data object which defines the properties of a light source animation
  */
-export declare class ChatSpeakerData extends DocumentData<
+export class ChatSpeakerData extends DocumentData<
   ChatSpeakerDataSchema,
   ChatSpeakerDataProperties,
   PropertiesToSource<ChatSpeakerDataProperties>,
   ChatSpeakerDataConstructorData,
   BaseChatMessage
 > {
+  /** @override */
   static defineSchema(): ChatSpeakerDataSchema;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export declare interface ChatSpeakerData extends ChatSpeakerDataProperties {}
+export interface ChatSpeakerData extends ChatSpeakerDataProperties {}

--- a/src/foundry/common/data/data.mjs/combatData.d.ts
+++ b/src/foundry/common/data/data.mjs/combatData.d.ts
@@ -1,7 +1,6 @@
 import {
   ConfiguredDocumentClass,
   ConfiguredFlags,
-  ConstructorDataType,
   FieldReturnType,
   PropertiesToSource
 } from '../../../../types/helperTypes';
@@ -9,27 +8,36 @@ import EmbeddedCollection from '../../abstract/embedded-collection.mjs';
 import { DocumentData } from '../../abstract/module.mjs';
 import * as documents from '../../documents.mjs';
 import * as fields from '../fields.mjs';
-import { CombatantData } from './combatantData';
+import { CombatantDataConstructorData } from './combatantData';
 
 interface CombatDataSchema extends DocumentSchema {
-  _id: typeof fields.DOCUMENT_ID;
+  _id: fields.DocumentId;
   scene: fields.ForeignDocumentField<{ type: typeof documents.BaseScene }>;
   combatants: fields.EmbeddedCollectionField<typeof documents.BaseCombatant>;
-  active: typeof fields.BOOLEAN_FIELD;
-  round: FieldReturnType<typeof fields.NONNEGATIVE_INTEGER_FIELD, { default: 0; required: true }>;
-  turn: FieldReturnType<typeof fields.NONNEGATIVE_INTEGER_FIELD, { default: 0; required: true }>;
-  sort: typeof fields.INTEGER_SORT_FIELD;
-  flags: typeof fields.OBJECT_FIELD;
+  active: fields.BooleanField;
+  round: FieldReturnType<fields.NonnegativeIntegerField, { default: 0; required: true }>;
+  turn: FieldReturnType<fields.NonnegativeIntegerField, { default: 0; required: true }>;
+  sort: fields.IntegerSortField;
+  flags: fields.ObjectField;
 }
 
 interface CombatDataProperties {
-  /** The _id which uniquely identifies this Combat document */
+  /**
+   * The _id which uniquely identifies this Combat document
+   * @defaultValue `null`
+   */
   _id: string | null;
 
-  /** The _id of a Scene within which this Combat occurs */
+  /**
+   * The _id of a Scene within which this Combat occurs
+   * @defaultValue `null`
+   */
   scene: string | null;
 
-  /** A Collection of Combatant embedded Documents */
+  /**
+   * A Collection of Combatant embedded Documents
+   * @defaultValue `[]`
+   */
   combatants: EmbeddedCollection<ConfiguredDocumentClass<typeof documents.BaseCombatant>, CombatData>;
 
   /**
@@ -64,14 +72,23 @@ interface CombatDataProperties {
 }
 
 interface CombatDataConstructorData {
-  /** The _id which uniquely identifies this Combat document */
+  /**
+   * The _id which uniquely identifies this Combat document
+   * @defaultValue `null`
+   */
   _id?: string | null | undefined;
 
-  /** The _id of a Scene within which this Combat occurs */
-  scene?: string | null | undefined;
+  /**
+   * The _id of a Scene within which this Combat occurs
+   * @defaultValue `null`
+   */
+  scene?: InstanceType<ConfiguredDocumentClass<typeof documents.BaseScene>> | string | null | undefined;
 
-  /** A Collection of Combatant embedded Documents */
-  combatants?: ConstructorDataType<CombatantData>[] | null | undefined;
+  /**
+   * A Collection of Combatant embedded Documents
+   * @defaultValue `[]`
+   */
+  combatants?: CombatantDataConstructorData[] | null | undefined;
 
   /**
    * Is the Combat encounter currently active?
@@ -108,15 +125,16 @@ interface CombatDataConstructorData {
  * The data schema for an Combat document.
  * @see BaseCombat
  */
-export declare class CombatData extends DocumentData<
+export class CombatData extends DocumentData<
   CombatDataSchema,
   CombatDataProperties,
   PropertiesToSource<CombatDataProperties>,
   CombatDataConstructorData,
   documents.BaseCombat
 > {
+  /** @override */
   static defineSchema(): CombatDataSchema;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export declare interface CombatData extends CombatDataProperties {}
+export interface CombatData extends CombatDataProperties {}

--- a/src/foundry/common/data/data.mjs/combatData.d.ts
+++ b/src/foundry/common/data/data.mjs/combatData.d.ts
@@ -36,7 +36,7 @@ interface CombatDataProperties {
 
   /**
    * A Collection of Combatant embedded Documents
-   * @defaultValue `[]`
+   * @defaultValue `new EmbeddedCollection(CombatantData, [], BaseCombatant.implementation)`
    */
   combatants: EmbeddedCollection<ConfiguredDocumentClass<typeof documents.BaseCombatant>, CombatData>;
 
@@ -86,7 +86,7 @@ interface CombatDataConstructorData {
 
   /**
    * A Collection of Combatant embedded Documents
-   * @defaultValue `[]`
+   * @defaultValue `new EmbeddedCollection(CombatantData, [], BaseCombatant.implementation)`
    */
   combatants?: CombatantDataConstructorData[] | null | undefined;
 

--- a/src/foundry/common/data/data.mjs/combatantData.d.ts
+++ b/src/foundry/common/data/data.mjs/combatantData.d.ts
@@ -1,40 +1,47 @@
-import { ConfiguredFlags, PropertiesToSource } from '../../../../types/helperTypes';
+import { ConfiguredDocumentClass, ConfiguredFlags, PropertiesToSource } from '../../../../types/helperTypes';
 import { DocumentData } from '../../abstract/module.mjs';
 import * as documents from '../../documents.mjs';
 import * as fields from '../fields.mjs';
 
 interface CombatantDataSchema extends DocumentSchema {
-  _id: typeof fields.DOCUMENT_ID;
+  _id: fields.DocumentId;
   actorId: fields.ForeignDocumentField<{ type: typeof documents.BaseActor }>;
   tokenId: fields.ForeignDocumentField<{ type: typeof documents.BaseToken }>;
-  name: typeof fields.STRING_FIELD;
-  img: typeof fields.IMAGE_FIELD;
-  initiative: typeof fields.NUMERIC_FIELD;
-  hidden: typeof fields.BOOLEAN_FIELD;
-  defeated: typeof fields.BOOLEAN_FIELD;
-  flags: typeof fields.OBJECT_FIELD;
+  name: fields.StringField;
+  img: fields.ImageField;
+  initiative: fields.NumericField;
+  hidden: fields.BooleanField;
+  defeated: fields.BooleanField;
+  flags: fields.ObjectField;
 }
 
 interface CombatantDataProperties {
-  /** The _id which uniquely identifies this Combatant embedded document */
+  /**
+   * The _id which uniquely identifies this Combatant embedded document
+   * @defaultValue `null`
+   */
   _id: string | null;
 
   /**
    * The _id of an Actor associated with this Combatant
+   * @defaultValue `null`
    */
   actorId: string | null;
 
-  /** The _id of a Token associated with this Combatant */
+  /**
+   * The _id of a Token associated with this Combatant
+   * @defaultValue `null`
+   */
   tokenId: string | null;
 
   /** A customized name which replaces the name of the Token in the tracker */
   name: string | undefined;
 
   /** A customized image which replaces the Token image in the tracker */
-  img: string | undefined | null;
+  img: string | null | undefined;
 
   /** The initiative score for the Combatant which determines its turn order */
-  initiative: number | undefined | null;
+  initiative: number | null | undefined;
 
   /**
    * Is this Combatant currently hidden?
@@ -55,17 +62,24 @@ interface CombatantDataProperties {
   flags: ConfiguredFlags<'Combatant'>;
 }
 
-export interface CombatantDataConstructorData {
-  /** The _id which uniquely identifies this Combatant embedded document */
+interface CombatantDataConstructorData {
+  /**
+   * The _id which uniquely identifies this Combatant embedded document
+   * @defaultValue `null`
+   */
   _id?: string | null | undefined;
 
   /**
    * The _id of an Actor associated with this Combatant
+   * @defaultValue `null`
    */
-  actorId?: string | null | undefined;
+  actorId?: InstanceType<ConfiguredDocumentClass<typeof documents.BaseActor>> | string | null | undefined;
 
-  /** The _id of a Token associated with this Combatant */
-  tokenId?: string | null | undefined;
+  /**
+   * The _id of a Token associated with this Combatant
+   * @defaultValue `null`
+   */
+  tokenId?: InstanceType<ConfiguredDocumentClass<typeof documents.BaseToken>> | string | null | undefined;
 
   /** A customized name which replaces the name of the Token in the tracker */
   name?: string | null | undefined;
@@ -99,19 +113,16 @@ export interface CombatantDataConstructorData {
  * The data schema for a Combatant embedded document within a CombatEncounter document.
  * @see CombatantData
  */
-export declare class CombatantData extends DocumentData<
+export class CombatantData extends DocumentData<
   CombatantDataSchema,
   CombatantDataProperties,
   PropertiesToSource<CombatantDataProperties>,
   CombatantDataConstructorData,
   documents.BaseCombatant
 > {
-  /**
-   *  @remarks
-   *  This constructor only exists to restrict the type
-   */
+  /** @override */
   static defineSchema(): CombatantDataSchema;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export declare interface CombatantData extends CombatantDataProperties {}
+export interface CombatantData extends CombatantDataProperties {}

--- a/src/foundry/common/data/data.mjs/darknessActivation.d.ts
+++ b/src/foundry/common/data/data.mjs/darknessActivation.d.ts
@@ -4,8 +4,8 @@ import { BaseAmbientLight } from '../../documents.mjs';
 import * as fields from '../fields.mjs';
 
 interface DarknessActivationSchema extends DocumentSchema {
-  min: FieldReturnType<typeof fields.ALPHA_FIELD, { default: 0 }>;
-  max: typeof fields.ALPHA_FIELD;
+  min: FieldReturnType<fields.AlphaField, { default: 0 }>;
+  max: fields.AlphaField;
 }
 
 interface DarknessActivationProperties {
@@ -22,7 +22,7 @@ interface DarknessActivationProperties {
   max: number;
 }
 
-export interface DarknessActivationConstructorData {
+interface DarknessActivationConstructorData {
   /**
    * The minimum darkness level for which activation occurs
    * @defaultValue `0`
@@ -39,15 +39,16 @@ export interface DarknessActivationConstructorData {
 /**
  * An embedded data object which defines the darkness range during which some attribute is active
  */
-export declare class DarknessActivation extends DocumentData<
+export class DarknessActivation extends DocumentData<
   DarknessActivationSchema,
   DarknessActivationProperties,
   PropertiesToSource<DarknessActivationProperties>,
   DarknessActivationConstructorData,
   BaseAmbientLight
 > {
+  /** @override */
   static defineSchema(): DarknessActivationSchema;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export declare interface DarknessActivation extends DarknessActivationProperties {}
+export interface DarknessActivation extends DarknessActivationProperties {}

--- a/src/foundry/common/data/data.mjs/drawingData.d.ts
+++ b/src/foundry/common/data/data.mjs/drawingData.d.ts
@@ -13,11 +13,11 @@ import { ForeignDocumentField } from '../fields.mjs';
 interface DrawingDataSchema extends DocumentSchema {
   _id: fields.DocumentId;
   author: ForeignDocumentField<{ type: typeof documents.BaseUser; required: true }>;
-  type: DocumentField<foundry.CONST.MACRO_TYPES> & {
+  type: DocumentField<foundry.CONST.DRAWING_TYPES> & {
     type: typeof String;
     required: true;
     default: typeof CONST.DRAWING_TYPES.POLYGON;
-    validate: (t: unknown) => t is foundry.CONST.MACRO_TYPES;
+    validate: (t: unknown) => t is foundry.CONST.DRAWING_TYPES;
     validationError: 'Invalid {name} {field} which must be a value in CONST.DRAWING_TYPES';
   };
   x: fields.RequiredNumber;
@@ -82,7 +82,7 @@ interface DrawingDataProperties {
    * The value in CONST.DRAWING_TYPES which defines the geometry type of this drawing
    * @defaultValue `CONST.DRAWING_TYPES.POLYGON`
    */
-  type: foundry.CONST.MACRO_TYPES;
+  type: foundry.CONST.DRAWING_TYPES;
 
   /**
    * The x-coordinate position of the top-left corner of the drawn shape

--- a/src/foundry/common/data/data.mjs/drawingData.d.ts
+++ b/src/foundry/common/data/data.mjs/drawingData.d.ts
@@ -16,7 +16,7 @@ interface DrawingDataSchema extends DocumentSchema {
   type: DocumentField<foundry.CONST.DRAWING_TYPES> & {
     type: typeof String;
     required: true;
-    default: typeof CONST.DRAWING_TYPES.POLYGON;
+    default: typeof foundry.CONST.DRAWING_TYPES.POLYGON;
     validate: (t: unknown) => t is foundry.CONST.DRAWING_TYPES;
     validationError: 'Invalid {name} {field} which must be a value in CONST.DRAWING_TYPES';
   };
@@ -37,7 +37,7 @@ interface DrawingDataSchema extends DocumentSchema {
   fillType: FieldReturnType<
     fields.RequiredNumber,
     {
-      default: typeof CONST.DRAWING_FILL_TYPES.NONE;
+      default: typeof foundry.CONST.DRAWING_FILL_TYPES.NONE;
       validate: (v: unknown) => v is foundry.CONST.DRAWING_FILL_TYPES;
       validationError: 'Invalid {name} {field} which must be a value in CONST.DRAWING_FILL_TYPES';
     }

--- a/src/foundry/common/data/data.mjs/drawingData.d.ts
+++ b/src/foundry/common/data/data.mjs/drawingData.d.ts
@@ -1,17 +1,17 @@
-import DocumentData from '../../abstract/data.mjs';
-import { BaseUser } from '../../documents.mjs';
-import { ForeignDocumentField } from '../fields.mjs';
-import * as fields from '../fields.mjs';
-import * as documents from '../../documents.mjs';
 import {
   ConfiguredDocumentClass,
   ConfiguredFlags,
   FieldReturnType,
   PropertiesToSource
 } from '../../../../types/helperTypes';
+import DocumentData from '../../abstract/data.mjs';
+import * as documents from '../../documents.mjs';
+import { BaseUser } from '../../documents.mjs';
+import * as fields from '../fields.mjs';
+import { ForeignDocumentField } from '../fields.mjs';
 
 interface DrawingDataSchema extends DocumentSchema {
-  _id: typeof fields.DOCUMENT_ID;
+  _id: fields.DocumentId;
   author: ForeignDocumentField<{ type: typeof documents.BaseUser; required: true }>;
   type: DocumentField<foundry.CONST.MACRO_TYPES> & {
     type: typeof String;
@@ -20,12 +20,12 @@ interface DrawingDataSchema extends DocumentSchema {
     validate: (t: unknown) => t is foundry.CONST.MACRO_TYPES;
     validationError: 'Invalid {name} {field} which must be a value in CONST.DRAWING_TYPES';
   };
-  x: typeof fields.REQUIRED_NUMBER;
-  y: typeof fields.REQUIRED_NUMBER;
-  width: typeof fields.REQUIRED_NUMBER;
-  height: typeof fields.REQUIRED_NUMBER;
-  rotation: FieldReturnType<typeof fields.ANGLE_FIELD, { default: 0 }>;
-  z: typeof fields.REQUIRED_NUMBER;
+  x: fields.RequiredNumber;
+  y: fields.RequiredNumber;
+  width: fields.RequiredNumber;
+  height: fields.RequiredNumber;
+  rotation: FieldReturnType<fields.AngleField, { default: 0 }>;
+  z: fields.RequiredNumber;
   points: DocumentField<Array<[x: number, y: number]>> & {
     type: [typeof Array];
     required: true;
@@ -33,36 +33,36 @@ interface DrawingDataSchema extends DocumentSchema {
     validate: typeof _validateDrawingPoints;
     validationError: 'Invalid {name} {field} which must be an array of points [x,y]';
   };
-  bezierFactor: FieldReturnType<typeof fields.ALPHA_FIELD, { default: 0 }>;
+  bezierFactor: FieldReturnType<fields.AlphaField, { default: 0 }>;
   fillType: FieldReturnType<
-    typeof fields.REQUIRED_NUMBER,
+    fields.RequiredNumber,
     {
       default: typeof CONST.DRAWING_FILL_TYPES.NONE;
       validate: (v: unknown) => v is foundry.CONST.DRAWING_FILL_TYPES;
       validationError: 'Invalid {name} {field} which must be a value in CONST.DRAWING_FILL_TYPES';
     }
   >;
-  fillColor: typeof fields.COLOR_FIELD;
-  fillAlpha: FieldReturnType<typeof fields.ALPHA_FIELD, { default: 0.5 }>;
-  strokeWidth: FieldReturnType<typeof fields.NONNEGATIVE_INTEGER_FIELD, { default: 8 }>;
-  strokeColor: typeof fields.COLOR_FIELD;
-  strokeAlpha: typeof fields.ALPHA_FIELD;
-  texture: typeof fields.IMAGE_FIELD;
-  text: typeof fields.STRING_FIELD;
-  fontFamily: FieldReturnType<typeof fields.REQUIRED_STRING, { default: 'Signika' }>;
+  fillColor: fields.ColorField;
+  fillAlpha: FieldReturnType<fields.AlphaField, { default: 0.5 }>;
+  strokeWidth: FieldReturnType<fields.NonnegativeIntegerField, { default: 8 }>;
+  strokeColor: fields.ColorField;
+  strokeAlpha: fields.AlphaField;
+  texture: fields.ImageField;
+  text: fields.StringField;
+  fontFamily: FieldReturnType<fields.RequiredString, { default: 'Signika' }>;
   fontSize: FieldReturnType<
-    typeof fields.POSITIVE_INTEGER_FIELD,
+    fields.PositiveIntegerField,
     {
       default: 48;
       validate: (n: unknown) => boolean;
       validationError: 'Invalid {name} {field} which must be an integer between 8 and 256';
     }
   >;
-  textColor: FieldReturnType<typeof fields.COLOR_FIELD, { default: '#FFFFFF' }>;
-  textAlpha: typeof fields.ALPHA_FIELD;
-  hidden: typeof fields.BOOLEAN_FIELD;
-  locked: typeof fields.BOOLEAN_FIELD;
-  flags: typeof fields.OBJECT_FIELD;
+  textColor: FieldReturnType<fields.ColorField, { default: '#FFFFFF' }>;
+  textAlpha: fields.AlphaField;
+  hidden: fields.BooleanField;
+  locked: fields.BooleanField;
+  flags: fields.ObjectField;
 }
 
 interface DrawingDataProperties {
@@ -380,13 +380,14 @@ interface DrawingDataConstructorData {
  * @param data     - Initial data used to construct the data object
  * @param document - The embedded document to which this data object belongs
  */
-export declare class DrawingData extends DocumentData<
+export class DrawingData extends DocumentData<
   DrawingDataSchema,
   DrawingDataProperties,
   PropertiesToSource<DrawingDataProperties>,
   DrawingDataConstructorData,
   documents.BaseFolder
 > {
+  /** @override */
   static defineSchema(): DrawingDataSchema;
 
   /** @override */
@@ -397,7 +398,7 @@ export declare class DrawingData extends DocumentData<
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export declare interface DrawingData extends DrawingDataProperties {}
+export interface DrawingData extends DrawingDataProperties {}
 
 /**
  * Validate the array of points which comprises a polygon drawing

--- a/src/foundry/common/data/data.mjs/effectChangeData.d.ts
+++ b/src/foundry/common/data/data.mjs/effectChangeData.d.ts
@@ -1,6 +1,5 @@
 import { PropertiesToSource } from '../../../../types/helperTypes';
 import { DocumentData } from '../../abstract/module.mjs';
-import * as CONST from '../../constants.mjs';
 import { BaseActiveEffect } from '../../documents.mjs';
 import * as fields from '../fields.mjs';
 
@@ -10,7 +9,7 @@ interface EffectChangeDataSchema extends DocumentSchema {
   mode: DocumentField<number> & {
     type: typeof Number;
     required: true;
-    default: typeof CONST.ACTIVE_EFFECT_MODES.ADD;
+    default: typeof foundry.CONST.ACTIVE_EFFECT_MODES.ADD;
     validate: (m: unknown) => boolean;
     validationError: 'Invalid mode specified for change in ActiveEffectData';
   };
@@ -34,7 +33,7 @@ interface EffectChangeDataProperties {
    * The modification mode with which the change is applied
    * @defaultValue `CONST.ACTIVE_EFFECT_MODES.ADD`
    */
-  mode: CONST.ACTIVE_EFFECT_MODES;
+  mode: foundry.CONST.ACTIVE_EFFECT_MODES;
 
   /**
    * The priority level with which this change is applied
@@ -59,7 +58,7 @@ interface EffectChangeDataConstructorData {
    * The modification mode with which the change is applied
    * @defaultValue `CONST.ACTIVE_EFFECT_MODES.ADD`
    */
-  mode?: CONST.ACTIVE_EFFECT_MODES | null | undefined;
+  mode?: foundry.CONST.ACTIVE_EFFECT_MODES | null | undefined;
 
   /**
    * The priority level with which this change is applied

--- a/src/foundry/common/data/data.mjs/effectChangeData.d.ts
+++ b/src/foundry/common/data/data.mjs/effectChangeData.d.ts
@@ -1,12 +1,12 @@
+import { PropertiesToSource } from '../../../../types/helperTypes';
 import { DocumentData } from '../../abstract/module.mjs';
+import * as CONST from '../../constants.mjs';
 import { BaseActiveEffect } from '../../documents.mjs';
 import * as fields from '../fields.mjs';
-import * as CONST from '../../constants.mjs';
-import { PropertiesToSource } from '../../../../types/helperTypes';
 
 interface EffectChangeDataSchema extends DocumentSchema {
-  key: typeof fields.BLANK_STRING;
-  value: typeof fields.BLANK_STRING;
+  key: fields.BlankString;
+  value: fields.BlankString;
   mode: DocumentField<number> & {
     type: typeof Number;
     required: true;
@@ -14,24 +14,25 @@ interface EffectChangeDataSchema extends DocumentSchema {
     validate: (m: unknown) => boolean;
     validationError: 'Invalid mode specified for change in ActiveEffectData';
   };
-  priority: typeof fields.NUMERIC_FIELD;
+  priority: fields.NumericField;
 }
 
 interface EffectChangeDataProperties {
   /**
    * The attribute path in the Actor or Item data which the change modifies
-   * @defaultValue `''`
+   * @defaultValue `""`
    */
   key: string;
 
   /**
    * The value of the change effect
-   * @defaultValue `''`
+   * @defaultValue `""`
    */
   value: string;
 
   /**
    * The modification mode with which the change is applied
+   * @defaultValue `CONST.ACTIVE_EFFECT_MODES.ADD`
    */
   mode: CONST.ACTIVE_EFFECT_MODES;
 
@@ -41,21 +42,22 @@ interface EffectChangeDataProperties {
   priority: number | null | undefined;
 }
 
-export interface EffectChangeDataConstructorData {
+interface EffectChangeDataConstructorData {
   /**
    * The attribute path in the Actor or Item data which the change modifies
-   * @defaultValue `''`
+   * @defaultValue `""`
    */
   key?: string | null | undefined;
 
   /**
    * The value of the change effect
-   * @defaultValue `''`
+   * @defaultValue `""`
    */
   value?: string | null | undefined;
 
   /**
    * The modification mode with which the change is applied
+   * @defaultValue `CONST.ACTIVE_EFFECT_MODES.ADD`
    */
   mode?: CONST.ACTIVE_EFFECT_MODES | null | undefined;
 
@@ -69,15 +71,16 @@ export interface EffectChangeDataConstructorData {
  * An embedded data structure which defines the structure of a change applied by an ActiveEffect.
  * @see ActiveEffectData
  */
-export declare class EffectChangeData extends DocumentData<
+export class EffectChangeData extends DocumentData<
   EffectChangeDataSchema,
   EffectChangeDataProperties,
   PropertiesToSource<EffectChangeDataProperties>,
   EffectChangeDataConstructorData,
   BaseActiveEffect
 > {
+  /** @override */
   static defineSchema(): EffectChangeDataSchema;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export declare interface EffectChangeData extends EffectChangeDataProperties {}
+export interface EffectChangeData extends EffectChangeDataProperties {}

--- a/src/foundry/common/data/data.mjs/effectDurationData.d.ts
+++ b/src/foundry/common/data/data.mjs/effectDurationData.d.ts
@@ -4,13 +4,13 @@ import { BaseActiveEffect } from '../../documents.mjs';
 import * as fields from '../fields.mjs';
 
 interface EffectDurationDataSchema extends DocumentSchema {
-  startTime: FieldReturnType<typeof fields.NUMERIC_FIELD, { default: null }>;
-  seconds: typeof fields.NONNEGATIVE_INTEGER_FIELD;
-  combat: typeof fields.STRING_FIELD;
-  rounds: typeof fields.NONNEGATIVE_INTEGER_FIELD;
-  turns: typeof fields.NONNEGATIVE_INTEGER_FIELD;
-  startRound: typeof fields.NONNEGATIVE_INTEGER_FIELD;
-  startTurn: typeof fields.NONNEGATIVE_INTEGER_FIELD;
+  startTime: FieldReturnType<fields.NumericField, { default: null }>;
+  seconds: fields.NonnegativeIntegerField;
+  combat: fields.StringField;
+  rounds: fields.NonnegativeIntegerField;
+  turns: fields.NonnegativeIntegerField;
+  startRound: fields.NonnegativeIntegerField;
+  startTurn: fields.NonnegativeIntegerField;
 }
 
 interface EffectDurationDataProperties {
@@ -51,7 +51,7 @@ interface EffectDurationDataProperties {
   startTurn: number | undefined;
 }
 
-export interface EffectDurationDataConstructorData {
+interface EffectDurationDataConstructorData {
   /**
    * The world time when the active effect first started
    * @defaultValue `null`
@@ -93,15 +93,16 @@ export interface EffectDurationDataConstructorData {
  * An embedded data structure which tracks the duration of an ActiveEffect.
  * @see ActiveEffectData
  */
-export declare class EffectDurationData extends DocumentData<
+export class EffectDurationData extends DocumentData<
   EffectDurationDataSchema,
   EffectDurationDataProperties,
   PropertiesToSource<EffectDurationDataProperties>,
   EffectDurationDataConstructorData,
   BaseActiveEffect
 > {
+  /** @override */
   static defineSchema(): EffectDurationDataSchema;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export declare interface EffectDurationData extends EffectDurationDataProperties {}
+export interface EffectDurationData extends EffectDurationDataProperties {}

--- a/src/foundry/common/data/data.mjs/fogExplorationData.d.ts
+++ b/src/foundry/common/data/data.mjs/fogExplorationData.d.ts
@@ -1,12 +1,12 @@
-import DocumentData from '../../abstract/data.mjs';
-import { ForeignDocumentField } from '../fields.mjs';
-import * as fields from '../fields.mjs';
-import * as documents from '../../documents.mjs';
 import { ConfiguredDocumentClass, FieldReturnType, PropertiesToSource } from '../../../../types/helperTypes';
+import DocumentData from '../../abstract/data.mjs';
+import * as documents from '../../documents.mjs';
+import * as fields from '../fields.mjs';
+import { ForeignDocumentField } from '../fields.mjs';
 import { isBase64Image } from '../validators.mjs';
 
 interface FogExplorationDataSchema extends DocumentSchema {
-  _id: typeof fields.DOCUMENT_ID;
+  _id: fields.DocumentId;
   scene: ForeignDocumentField<{ type: typeof documents.BaseScene }>;
   user: ForeignDocumentField<{ type: typeof documents.BaseUser }>;
   explored: DocumentField<string> & {
@@ -17,8 +17,8 @@ interface FogExplorationDataSchema extends DocumentSchema {
     validate: typeof isBase64Image;
     validationError: 'The provided FogExploration explored image is not a valid base64 image string';
   };
-  positions: typeof fields.OBJECT_FIELD;
-  timestamp: FieldReturnType<typeof fields.TIMESTAMP_FIELD, { required: true }>;
+  positions: fields.ObjectField;
+  timestamp: FieldReturnType<fields.TimestampField, { required: true }>;
 }
 
 interface FogExplorationDataProperties {
@@ -52,7 +52,10 @@ interface FogExplorationDataProperties {
    */
   positions: Record<string, { radius: number; limit: boolean }>;
 
-  /** The timestamp at which this fog exploration was last updated */
+  /**
+   * The timestamp at which this fog exploration was last updated
+   * @defaultValue `Date.now()`
+   */
   timestamp: number;
 }
 
@@ -67,13 +70,13 @@ interface FogExplorationDataConstructorData {
    * The _id of the Scene document to which this fog applies
    * @defaultValue `null`
    */
-  scene?: string | InstanceType<ConfiguredDocumentClass<typeof foundry.documents.BaseScene>> | null | undefined;
+  scene?: InstanceType<ConfiguredDocumentClass<typeof foundry.documents.BaseScene>> | string | null | undefined;
 
   /**
    * The _id of the User document to which this fog applies
    * @defaultValue `null`
    */
-  user?: string | null | undefined;
+  user?: InstanceType<ConfiguredDocumentClass<typeof foundry.documents.BaseUser>> | string | null | undefined;
 
   /**
    * The base64 png image of the explored fog polygon
@@ -87,21 +90,25 @@ interface FogExplorationDataConstructorData {
    */
   positions?: Record<string, { radius: number; limit: boolean }> | null | undefined;
 
-  /** The timestamp at which this fog exploration was last updated */
+  /**
+   * The timestamp at which this fog exploration was last updated
+   * @defaultValue `Date.now()`
+   */
   timestamp?: number | null | undefined;
 }
 
 /**
  * The data schema for a FogExploration document.
  */
-export declare class FogExplorationData extends DocumentData<
+export class FogExplorationData extends DocumentData<
   FogExplorationDataSchema,
   FogExplorationDataProperties,
   PropertiesToSource<FogExplorationDataProperties>,
   FogExplorationDataConstructorData
 > {
+  /** @override */
   static defineSchema(): FogExplorationDataSchema;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export declare interface FogExplorationData extends FogExplorationDataProperties {}
+export interface FogExplorationData extends FogExplorationDataProperties {}

--- a/src/foundry/common/data/data.mjs/folderData.d.ts
+++ b/src/foundry/common/data/data.mjs/folderData.d.ts
@@ -1,18 +1,18 @@
+import { ConfiguredDocumentClass, ConfiguredFlags, PropertiesToSource } from '../../../../types/helperTypes';
 import DocumentData from '../../abstract/data.mjs';
-import * as fields from '../fields.mjs';
 import * as documents from '../../documents.mjs';
-import { ConfiguredFlags, PropertiesToSource } from '../../../../types/helperTypes';
+import * as fields from '../fields.mjs';
 
 interface FolderDataSchema extends DocumentSchema {
-  _id: typeof fields.DOCUMENT_ID;
-  name: typeof fields.REQUIRED_STRING;
+  _id: fields.DocumentId;
+  name: fields.RequiredString;
   type: DocumentField<foundry.CONST.FOLDER_DOCUMENT_TYPES> & {
     type: String;
     required: true;
     validate: (t: unknown) => t is foundry.CONST.FOLDER_DOCUMENT_TYPES;
     validationError: 'Invalid Folder type provided';
   };
-  description: typeof fields.STRING_FIELD;
+  description: fields.StringField;
   parent: fields.ForeignDocumentField<{ type: typeof documents.BaseFolder }>;
   sorting: DocumentField<SortingModes> & {
     type: String;
@@ -21,14 +21,15 @@ interface FolderDataSchema extends DocumentSchema {
     validate: (mode: unknown) => mode is SortingModes;
     validationError: 'Invalid Folder sorting mode';
   };
-  sort: typeof fields.INTEGER_SORT_FIELD;
-  color: typeof fields.COLOR_FIELD;
-  flags: typeof fields.OBJECT_FIELD;
+  sort: fields.IntegerSortField;
+  color: fields.ColorField;
+  flags: fields.ObjectField;
 }
 
 interface FolderDataProperties {
   /**
    * The _id which uniquely identifies this Folder document
+   * @defaultValue `null`
    */
   _id: string | null;
 
@@ -45,7 +46,7 @@ interface FolderDataProperties {
   /**
    * An HTML description of the contents of this folder
    */
-  description?: string;
+  description?: string | undefined;
 
   /**
    * The _id of a parent Folder which contains this Folder
@@ -80,6 +81,7 @@ interface FolderDataProperties {
 interface FolderDataConstructorData {
   /**
    * The _id which uniquely identifies this Folder document
+   * @defaultValue `null`
    */
   _id?: string | null | undefined;
 
@@ -102,7 +104,7 @@ interface FolderDataConstructorData {
    * The _id of a parent Folder which contains this Folder
    * @defaultValue `null`
    */
-  parent?: string | null | undefined;
+  parent?: InstanceType<ConfiguredDocumentClass<typeof foundry.documents.BaseFolder>> | string | null | undefined;
 
   /**
    * The sorting mode used to organize documents within this Folder, in ["a", "m"]
@@ -131,7 +133,7 @@ interface FolderDataConstructorData {
 /**
  * The data schema for a Folder document.
  */
-export declare class FolderData extends DocumentData<
+export class FolderData extends DocumentData<
   FolderDataSchema,
   FolderDataProperties,
   PropertiesToSource<FolderDataProperties>,
@@ -140,6 +142,7 @@ export declare class FolderData extends DocumentData<
 > {
   constructor(data: FolderDataConstructorData, document?: documents.BaseFolder | null);
 
+  /** @override */
   static defineSchema(): FolderDataSchema;
 
   static SORTING_MODES: ['a', 'm'];
@@ -148,4 +151,4 @@ export declare class FolderData extends DocumentData<
 export type SortingModes = ValueOf<typeof FolderData.SORTING_MODES>;
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export declare interface FolderData extends FolderDataProperties {}
+export interface FolderData extends FolderDataProperties {}

--- a/src/foundry/common/data/data.mjs/itemData.d.ts
+++ b/src/foundry/common/data/data.mjs/itemData.d.ts
@@ -60,7 +60,7 @@ interface ItemDataBaseProperties {
 
   /**
    * A collection of ActiveEffect embedded Documents
-   * @defaultValue `[]`
+   * @defaultValue `new EmbeddedCollection(ActiveEffectData, [], BaseActiveEffect.implementation)`
    */
   effects: EmbeddedCollection<ConfiguredDocumentClass<typeof documents.BaseActiveEffect>, ItemData>;
 
@@ -120,7 +120,7 @@ interface ItemDataConstructorData {
 
   /**
    * A collection of ActiveEffect embedded Documents
-   * @defaultValue `[]`
+   * @defaultValue `new EmbeddedCollection(ActiveEffectData, [], BaseActiveEffect.implementation)`
    */
   effects?: ConstructorParameters<ConfiguredDocumentClass<typeof documents.BaseActiveEffect>>[0][] | null | undefined;
 

--- a/src/foundry/common/data/data.mjs/itemData.d.ts
+++ b/src/foundry/common/data/data.mjs/itemData.d.ts
@@ -20,7 +20,7 @@ interface ItemDataSchema extends DocumentSchema {
     validate: (t: unknown) => boolean;
     validationError: 'The provided Item type must be in the array of types defined by the game system';
   };
-  img: FieldReturnType<fields.ImageField, { default: () => string }>;
+  img: FieldReturnType<fields.ImageField, { default: () => typeof ItemData.DEFAULT_ICON }>;
   data: FieldReturnType<fields.ObjectField, { default: (data: { type: string }) => any }>; // TODO
   effects: fields.EmbeddedCollectionField<typeof documents.BaseActiveEffect>;
   folder: fields.ForeignDocumentField<{ type: typeof documents.BaseFolder }>;

--- a/src/foundry/common/data/data.mjs/itemData.d.ts
+++ b/src/foundry/common/data/data.mjs/itemData.d.ts
@@ -1,4 +1,3 @@
-import EmbeddedCollection from '../../abstract/embedded-collection.mjs';
 import {
   ConfiguredData,
   ConfiguredDocumentClass,
@@ -7,31 +6,33 @@ import {
   FieldReturnType,
   PropertiesToSource
 } from '../../../../types/helperTypes';
+import EmbeddedCollection from '../../abstract/embedded-collection.mjs';
 import { DocumentData } from '../../abstract/module.mjs';
 import * as documents from '../../documents.mjs';
 import * as fields from '../fields.mjs';
 
 interface ItemDataSchema extends DocumentSchema {
-  _id: typeof fields.DOCUMENT_ID;
-  name: typeof fields.REQUIRED_STRING;
+  _id: fields.DocumentId;
+  name: fields.RequiredString;
   type: DocumentField<string> & {
     type: typeof String;
     required: true;
     validate: (t: unknown) => boolean;
     validationError: 'The provided Item type must be in the array of types defined by the game system';
   };
-  img: FieldReturnType<typeof fields.IMAGE_FIELD, { default: () => string }>;
-  data: FieldReturnType<typeof fields.OBJECT_FIELD, { default: (data: { type: string }) => any }>; // TODO
+  img: FieldReturnType<fields.ImageField, { default: () => string }>;
+  data: FieldReturnType<fields.ObjectField, { default: (data: { type: string }) => any }>; // TODO
   effects: fields.EmbeddedCollectionField<typeof documents.BaseActiveEffect>;
   folder: fields.ForeignDocumentField<{ type: typeof documents.BaseFolder }>;
-  sort: typeof fields.INTEGER_SORT_FIELD;
-  permission: typeof fields.DOCUMENT_PERMISSIONS;
-  flags: typeof fields.OBJECT_FIELD;
+  sort: fields.IntegerSortField;
+  permission: fields.DocumentPermissions;
+  flags: fields.ObjectField;
 }
 
 interface ItemDataBaseProperties {
   /**
    * The _id which uniquely identifies this Item document
+   * @defaultValue `null`
    */
   _id: string | null;
 
@@ -53,11 +54,13 @@ interface ItemDataBaseProperties {
 
   /**
    * The system data object which is defined by the system template.json model
+   * @defaultValue template from template.json for type or `{}`
    */
   data: object;
 
   /**
    * A collection of ActiveEffect embedded Documents
+   * @defaultValue `[]`
    */
   effects: EmbeddedCollection<ConfiguredDocumentClass<typeof documents.BaseActiveEffect>, ItemData>;
 
@@ -89,6 +92,7 @@ interface ItemDataBaseProperties {
 interface ItemDataConstructorData {
   /**
    * The _id which uniquely identifies this Item document
+   * @defaultValue `null`
    */
   _id?: string | null | undefined;
 
@@ -110,11 +114,13 @@ interface ItemDataConstructorData {
 
   /**
    * The system data object which is defined by the system template.json model
+   * @defaultValue template from template.json for type or `{}`
    */
   data?: DeepPartial<ItemDataSource['data']> | null | undefined;
 
   /**
    * A collection of ActiveEffect embedded Documents
+   * @defaultValue `[]`
    */
   effects?: ConstructorParameters<ConfiguredDocumentClass<typeof documents.BaseActiveEffect>>[0][] | null | undefined;
 
@@ -122,7 +128,7 @@ interface ItemDataConstructorData {
    * The _id of a Folder which contains this Item
    * @defaultValue `null`
    */
-  folder?: string | null | undefined;
+  folder?: InstanceType<ConfiguredDocumentClass<typeof documents.BaseFolder>> | string | null | undefined;
 
   /**
    * The numeric sort value which orders this Item relative to its siblings
@@ -152,6 +158,7 @@ type DocumentDataConstructor = Pick<typeof DocumentData, keyof typeof DocumentDa
 interface ItemDataConstructor extends DocumentDataConstructor {
   new (data: ItemDataConstructorData, document?: documents.BaseItem | null): ItemData;
 
+  /** @override */
   defineSchema(): ItemDataSchema;
 
   /**
@@ -173,6 +180,7 @@ export type ItemData = DocumentData<
   documents.BaseItem
 > &
   ItemDataProperties & {
+    /** @override */
     _initializeSource(data: ItemDataConstructorData): ItemDataSource;
   };
-export declare const ItemData: ItemDataConstructor;
+export const ItemData: ItemDataConstructor;

--- a/src/foundry/common/data/data.mjs/journalEntryData.d.ts
+++ b/src/foundry/common/data/data.mjs/journalEntryData.d.ts
@@ -1,17 +1,17 @@
+import { ConfiguredDocumentClass, ConfiguredFlags, PropertiesToSource } from '../../../../types/helperTypes';
 import { DocumentData } from '../../abstract/module.mjs';
-import * as fields from '../fields.mjs';
 import * as documents from '../../documents.mjs';
-import { ConfiguredFlags, PropertiesToSource } from '../../../../types/helperTypes';
+import * as fields from '../fields.mjs';
 
 interface JournalEntryDataSchema extends DocumentSchema {
-  _id: typeof fields.DOCUMENT_ID;
-  name: typeof fields.REQUIRED_STRING;
-  content: typeof fields.BLANK_STRING;
-  img: typeof fields.IMAGE_FIELD;
+  _id: fields.DocumentId;
+  name: fields.RequiredString;
+  content: fields.BlankString;
+  img: fields.ImageField;
   folder: fields.ForeignDocumentField<{ type: typeof documents.BaseFolder }>;
-  sort: typeof fields.INTEGER_SORT_FIELD;
-  permission: typeof fields.DOCUMENT_PERMISSIONS;
-  flags: typeof fields.OBJECT_FIELD;
+  sort: fields.IntegerSortField;
+  permission: fields.DocumentPermissions;
+  flags: fields.ObjectField;
 }
 
 interface JournalEntryDataProperties {
@@ -28,7 +28,7 @@ interface JournalEntryDataProperties {
 
   /**
    * The HTML content of the JournalEntry
-   * @defaultValue `''`
+   * @defaultValue `""`
    */
   content: string;
 
@@ -76,7 +76,7 @@ interface JournalEntryConstructorData {
 
   /**
    * The HTML content of the JournalEntry
-   * @defaultValue `''`
+   * @defaultValue `""`
    */
   content?: string | null | undefined;
 
@@ -89,7 +89,7 @@ interface JournalEntryConstructorData {
    * The _id of a Folder which contains this JournalEntry
    * @defaultValue `null`
    */
-  folder?: string | null | undefined;
+  folder?: InstanceType<ConfiguredDocumentClass<typeof documents.BaseFolder>> | string | null | undefined;
 
   /**
    * The numeric sort value which orders this JournalEntry relative to its siblings
@@ -114,7 +114,7 @@ interface JournalEntryConstructorData {
  * The data schema for a JournalEntry document.
  * @see BaseJournalEntry
  */
-export declare class JournalEntryData extends DocumentData<
+export class JournalEntryData extends DocumentData<
   JournalEntryDataSchema,
   JournalEntryDataProperties,
   PropertiesToSource<JournalEntryDataProperties>,
@@ -123,6 +123,7 @@ export declare class JournalEntryData extends DocumentData<
 > {
   constructor(data: JournalEntryConstructorData, document?: documents.BaseJournalEntry | null);
 
+  /** @override */
   static defineSchema(): JournalEntryDataSchema;
 }
 

--- a/src/foundry/common/data/data.mjs/lightData.d.ts
+++ b/src/foundry/common/data/data.mjs/lightData.d.ts
@@ -6,26 +6,26 @@ import type { AnimationData, AnimationDataConstructorData } from './animationDat
 import type { DarknessActivation, DarknessActivationConstructorData } from './darknessActivation.js';
 
 interface LightDataSchema extends DocumentSchema {
-  alpha: FieldReturnType<typeof fields.ALPHA_FIELD, { default: 0.5 }>;
-  angle: typeof fields.ANGLE_FIELD;
-  bright: typeof fields.NONNEGATIVE_NUMBER_FIELD;
-  color: typeof fields.COLOR_FIELD;
-  coloration: FieldReturnType<typeof fields.NONNEGATIVE_INTEGER_FIELD, { default: 1 }>;
-  dim: typeof fields.NONNEGATIVE_NUMBER_FIELD;
-  gradual: FieldReturnType<typeof fields.BOOLEAN_FIELD, { default: true }>;
-  luminosity: FieldReturnType<typeof LightData.LIGHT_UNIFORM_FIELD, { default: 0.5 }>;
-  saturation: typeof LightData.LIGHT_UNIFORM_FIELD;
-  contrast: typeof LightData.LIGHT_UNIFORM_FIELD;
-  shadows: typeof LightData.LIGHT_UNIFORM_FIELD;
+  alpha: FieldReturnType<fields.AlphaField, { default: 0.5 }>;
+  angle: fields.AngleField;
+  bright: fields.NonnegativeNumberField;
+  color: fields.ColorField;
+  coloration: FieldReturnType<fields.NonnegativeIntegerField, { default: 1 }>;
+  dim: fields.NonnegativeNumberField;
+  gradual: FieldReturnType<fields.BooleanField, { default: true }>;
+  luminosity: FieldReturnType<LightData.LightUniformField, { default: 0.5 }>;
+  saturation: LightData.LightUniformField;
+  contrast: LightData.LightUniformField;
+  shadows: LightData.LightUniformField;
   animation: DocumentField<AnimationData> & {
     type: typeof AnimationData;
     required: true;
-    default: {};
+    default: Record<string, never>;
   };
   darkness: DocumentField<DarknessActivation> & {
     type: typeof DarknessActivation;
     required: true;
-    default: {};
+    default: Record<string, never>;
   };
 }
 
@@ -49,7 +49,7 @@ interface LightDataProperties {
   bright: number;
 
   /** A tint color for the emitted light, if any */
-  color: string | undefined | null;
+  color: string | null | undefined;
 
   /**
    * The coloration technique applied in the shader
@@ -111,109 +111,117 @@ interface LightDataConstructorData {
    * An opacity for the emitted light, if any
    * @defaultValue `0.5`
    */
-  alpha?: number | undefined | null;
+  alpha?: number | null | undefined;
 
   /**
    * The angle of emission for this point source
    * @defaultValue `360`
    */
-  angle?: number | undefined | null;
+  angle?: number | null | undefined;
 
   /**
    * The allowed radius of bright vision or illumination
    * @defaultValue `0`
    */
-  bright?: number | undefined | null;
+  bright?: number | null | undefined;
 
   /** A tint color for the emitted light, if any */
-  color?: string | undefined | null;
+  color?: string | null | undefined;
 
   /**
    * The coloration technique applied in the shader
    * @defaultValue `1`
    */
-  coloration?: number | undefined | null;
+  coloration?: number | null | undefined;
 
   /**
    * The allowed radius of dim vision or illumination
    * @defaultValue `0`
    */
-  dim?: number | undefined | null;
+  dim?: number | null | undefined;
 
   /**
    * Fade the difference between bright, dim, and dark gradually?
    * @defaultValue `true`
    */
-  gradual?: boolean | undefined | null;
+  gradual?: boolean | null | undefined;
 
   /**
    * The luminosity applied in the shader
    * @defaultValue `0.5`
    */
-  luminosity?: number | undefined | null;
+  luminosity?: number | null | undefined;
 
   /**
    * The amount of color saturation this light applies to the background texture
    * @defaultValue `0`
    */
-  saturation?: number | undefined | null;
+  saturation?: number | null | undefined;
 
   /**
    * The amount of contrast this light applies to the background texture
    * @defaultValue `0`
    */
-  contrast?: number | undefined | null;
+  contrast?: number | null | undefined;
 
   /**
    * The depth of shadows this light applies to the background texture
    * @defaultValue `0`
    */
-  shadows?: number | undefined | null;
+  shadows?: number | null | undefined;
 
   /**
    * An animation configuration for the source
    * @defaultValue `new AnimationData({})`
    */
-  animation?: AnimationDataConstructorData | undefined | null;
+  animation?: AnimationDataConstructorData | null | undefined;
 
   /**
    * A darkness range (min and max) for which the source should be active
    * @defaultValue `new DarknessActivation({})`
    */
-  darkness?: DarknessActivationConstructorData | undefined | null;
+  darkness?: DarknessActivationConstructorData | null | undefined;
 }
 
 /**
  * A reusable document structure for the internal data used to render the appearance of a light source.
  * This is re-used by both the AmbientLightData and TokenData classes.
  */
-export declare class LightData extends DocumentData<
+export class LightData extends DocumentData<
   LightDataSchema,
   LightDataProperties,
   PropertiesToSource<LightDataProperties>,
   LightDataConstructorData,
   documents.BaseAmbientLight | documents.BaseToken
 > {
+  /** @override */
   static defineSchema(): LightDataSchema;
 
   /**
    * A reusable field definition for uniform fields used by LightData
-   * @remarks
+   */
+  static LIGHT_UNIFORM_FIELD: LightData.LightUniformField;
+
+  /** @override */
+  _initializeSource(data: LightDataConstructorData): PropertiesToSource<LightDataProperties>;
+
+  /** @override */
+  protected _initialize(): void;
+}
+
+declare namespace LightData {
+  /**
    * Property type: `number`
-   * Constructor type: `number | undefined | null`
+   * Constructor type: `number | null | undefined`
    * Default: `0`
    */
-  static LIGHT_UNIFORM_FIELD: {
+  interface LightUniformField {
     type: typeof Number;
     required: true;
     default: 0;
     validate: (n: number) => boolean;
     validationError: '{name} {field} "{value}" is not a number between -1 and 1';
-  };
-
-  _initializeSource(data: LightDataConstructorData): PropertiesToSource<LightDataProperties>;
-
-  _initialize(): void;
+  }
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/src/foundry/common/data/data.mjs/macroData.d.ts
+++ b/src/foundry/common/data/data.mjs/macroData.d.ts
@@ -5,30 +5,29 @@ import {
   PropertiesToSource
 } from '../../../../types/helperTypes';
 import { DocumentData } from '../../abstract/module.mjs';
-import * as CONST from '../../constants.mjs';
 import * as documents from '../../documents.mjs';
 import * as fields from '../fields.mjs';
 
 interface MacroDataSchema extends DocumentSchema {
   _id: fields.DocumentId;
   name: fields.RequiredString;
-  type: DocumentField<CONST.MACRO_TYPES> & {
+  type: DocumentField<foundry.CONST.MACRO_TYPES> & {
     type: String;
     required: true;
-    default: typeof CONST.MACRO_TYPES.CHAT;
-    validate: (t: unknown) => t is CONST.MACRO_TYPES;
+    default: typeof foundry.CONST.MACRO_TYPES.CHAT;
+    validate: (t: unknown) => t is foundry.CONST.MACRO_TYPES;
     validationError: 'The provided Macro type must be in CONST.MACRO_TYPES';
   };
   author: fields.ForeignDocumentField<{
     type: typeof documents.BaseUser;
     default: () => Game['user'];
   }>;
-  img: FieldReturnType<fields.ImageField, { required: true; default: typeof CONST.DEFAULT_MACRO_ICON }>;
-  scope: DocumentField<CONST.MACRO_SCOPES> & {
+  img: FieldReturnType<fields.ImageField, { required: true; default: typeof foundry.CONST.DEFAULT_MACRO_ICON }>;
+  scope: DocumentField<foundry.CONST.MACRO_SCOPES> & {
     type: String;
     required: true;
-    default: typeof CONST.MACRO_SCOPES[0];
-    validate: (t: unknown) => t is CONST.MACRO_SCOPES;
+    default: typeof foundry.CONST.MACRO_SCOPES[0];
+    validate: (t: unknown) => t is foundry.CONST.MACRO_SCOPES;
     validationError: 'The provided Macro scope must be in CONST.MACRO_SCOPES';
   };
   command: fields.BlankString;
@@ -70,7 +69,7 @@ interface MacroDataProperties {
 
   /**
    * The scope of this Macro application from CONST.MACRO_SCOPES
-   * @defaultValue `'global'`
+   * @defaultValue `CONST.MACRO_SCOPES[0]` ("global")
    */
   scope: foundry.CONST.MACRO_SCOPES;
 
@@ -137,7 +136,7 @@ interface MacroDataConstructorData {
 
   /**
    * The scope of this Macro application from CONST.MACRO_SCOPES
-   * @defaultValue `'global'`
+   * @defaultValue `CONST.MACRO_SCOPES[0]` ("global")
    */
   scope?: foundry.CONST.MACRO_SCOPES | null | undefined;
 

--- a/src/foundry/common/data/data.mjs/macroData.d.ts
+++ b/src/foundry/common/data/data.mjs/macroData.d.ts
@@ -12,11 +12,11 @@ import * as fields from '../fields.mjs';
 interface MacroDataSchema extends DocumentSchema {
   _id: fields.DocumentId;
   name: fields.RequiredString;
-  type: DocumentField<string> & {
+  type: DocumentField<CONST.MACRO_TYPES> & {
     type: String;
     required: true;
     default: typeof CONST.MACRO_TYPES.CHAT;
-    validate: (t: unknown) => boolean;
+    validate: (t: unknown) => t is CONST.MACRO_TYPES;
     validationError: 'The provided Macro type must be in CONST.MACRO_TYPES';
   };
   author: fields.ForeignDocumentField<{
@@ -24,11 +24,11 @@ interface MacroDataSchema extends DocumentSchema {
     default: () => Game['user'];
   }>;
   img: FieldReturnType<fields.ImageField, { required: true; default: typeof CONST.DEFAULT_MACRO_ICON }>;
-  scope: DocumentField<string> & {
+  scope: DocumentField<CONST.MACRO_SCOPES> & {
     type: String;
     required: true;
     default: typeof CONST.MACRO_SCOPES[0];
-    validate: (t: unknown) => boolean;
+    validate: (t: unknown) => t is CONST.MACRO_SCOPES;
     validationError: 'The provided Macro scope must be in CONST.MACRO_SCOPES';
   };
   command: fields.BlankString;

--- a/src/foundry/common/data/data.mjs/macroData.d.ts
+++ b/src/foundry/common/data/data.mjs/macroData.d.ts
@@ -1,12 +1,17 @@
-import { ConfiguredFlags, FieldReturnType, PropertiesToSource } from '../../../../types/helperTypes';
+import {
+  ConfiguredDocumentClass,
+  ConfiguredFlags,
+  FieldReturnType,
+  PropertiesToSource
+} from '../../../../types/helperTypes';
 import { DocumentData } from '../../abstract/module.mjs';
-import * as fields from '../fields.mjs';
-import * as documents from '../../documents.mjs';
 import * as CONST from '../../constants.mjs';
+import * as documents from '../../documents.mjs';
+import * as fields from '../fields.mjs';
 
 interface MacroDataSchema extends DocumentSchema {
-  _id: typeof fields.DOCUMENT_ID;
-  name: typeof fields.REQUIRED_STRING;
+  _id: fields.DocumentId;
+  name: fields.RequiredString;
   type: DocumentField<string> & {
     type: String;
     required: true;
@@ -18,7 +23,7 @@ interface MacroDataSchema extends DocumentSchema {
     type: typeof documents.BaseUser;
     default: () => Game['user'];
   }>;
-  img: FieldReturnType<typeof fields.IMAGE_FIELD, { required: true; default: typeof CONST.DEFAULT_MACRO_ICON }>;
+  img: FieldReturnType<fields.ImageField, { required: true; default: typeof CONST.DEFAULT_MACRO_ICON }>;
   scope: DocumentField<string> & {
     type: String;
     required: true;
@@ -26,16 +31,17 @@ interface MacroDataSchema extends DocumentSchema {
     validate: (t: unknown) => boolean;
     validationError: 'The provided Macro scope must be in CONST.MACRO_SCOPES';
   };
-  command: typeof fields.BLANK_STRING;
+  command: fields.BlankString;
   folder: fields.ForeignDocumentField<{ type: typeof documents.BaseFolder }>;
-  sort: typeof fields.INTEGER_SORT_FIELD;
-  permission: typeof fields.DOCUMENT_PERMISSIONS;
-  flags: typeof fields.OBJECT_FIELD;
+  sort: fields.IntegerSortField;
+  permission: fields.DocumentPermissions;
+  flags: fields.ObjectField;
 }
 
 interface MacroDataProperties {
   /**
    * The _id which uniquely identifies this Macro document
+   * @defaultValue `null`
    */
   _id: string | null;
 
@@ -46,11 +52,13 @@ interface MacroDataProperties {
 
   /**
    * A Macro subtype from CONST.MACRO_TYPES
+   * @defaultValue `foundry.CONST.MACRO_TYPES.CHAT`
    */
   type: foundry.CONST.MACRO_TYPES;
 
   /**
    * The _id of a User document which created this Macro *
+   * @defaultValue `game?.user`
    */
   author: string;
 
@@ -68,7 +76,7 @@ interface MacroDataProperties {
 
   /**
    * The string content of the macro command
-   * @defaultValue `''`
+   * @defaultValue `""`
    */
   command: string;
 
@@ -100,6 +108,7 @@ interface MacroDataProperties {
 interface MacroDataConstructorData {
   /**
    * The _id which uniquely identifies this Macro document
+   * @defaultValue `null`
    */
   _id?: string | null | undefined;
 
@@ -110,13 +119,15 @@ interface MacroDataConstructorData {
 
   /**
    * A Macro subtype from CONST.MACRO_TYPES
+   * @defaultValue `foundry.CONST.MACRO_TYPES.CHAT`
    */
   type?: foundry.CONST.MACRO_TYPES | null | undefined;
 
   /**
    * The _id of a User document which created this Macro *
+   * @defaultValue `game?.user`
    */
-  author?: string | null | undefined;
+  author?: InstanceType<ConfiguredDocumentClass<typeof documents.BaseUser>> | string | null | undefined;
 
   /**
    * An image file path which provides the thumbnail artwork for this Macro
@@ -132,7 +143,7 @@ interface MacroDataConstructorData {
 
   /**
    * The string content of the macro command
-   * @defaultValue `''`
+   * @defaultValue `""`
    */
   command?: string | null | undefined;
 
@@ -140,7 +151,7 @@ interface MacroDataConstructorData {
    * The _id of a Folder which contains this Macro
    * @defaultValue `null`
    */
-  folder?: string | null | undefined;
+  folder?: InstanceType<ConfiguredDocumentClass<typeof documents.BaseFolder>> | string | null | undefined;
 
   /**
    * The numeric sort value which orders this Macro relative to its siblings
@@ -165,7 +176,7 @@ interface MacroDataConstructorData {
  * The data schema for a Macro document.
  * @see BaseMacro
  */
-export declare class MacroData extends DocumentData<
+export class MacroData extends DocumentData<
   MacroDataSchema,
   MacroDataProperties,
   PropertiesToSource<MacroDataProperties>,
@@ -174,8 +185,9 @@ export declare class MacroData extends DocumentData<
 > {
   constructor(data: MacroDataConstructorData, document?: documents.BaseMacro | null);
 
+  /** @override */
   static defineSchema(): MacroDataSchema;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export declare interface MacroData extends MacroDataProperties {}
+export interface MacroData extends MacroDataProperties {}

--- a/src/foundry/common/data/data.mjs/measuredTemplateData.d.ts
+++ b/src/foundry/common/data/data.mjs/measuredTemplateData.d.ts
@@ -11,11 +11,11 @@ import * as fields from '../fields.mjs';
 interface MeasuredTemplateDataSchema extends DocumentSchema {
   _id: fields.DocumentId;
   user: fields.ForeignDocumentField<{ type: typeof documents.BaseUser; required: true }>;
-  t: {
+  t: DocumentField<typeof CONST.MEASURED_TEMPLATE_TYPES> & {
     type: typeof String;
     required: true;
     default: typeof CONST.MEASURED_TEMPLATE_TYPES.CIRCLE;
-    validate: (t: unknown) => boolean;
+    validate: (t: unknown) => t is typeof CONST.MEASURED_TEMPLATE_TYPES;
     validationError: 'Invalid {name} {field} which must be a value in CONST.MEASURED_TEMPLATE_TYPES';
   };
   x: fields.RequiredNumber;
@@ -118,7 +118,7 @@ interface MeasuredTemplateDataConstructorData {
    * The value in CONST.MEASURED_TEMPLATE_TYPES which defines the geometry type of this template
    * @defaultValue `foundry.CONST.MEASURED_TEMPLATE_TYPES.CIRCLE`
    */
-  t?: ValueOf<foundry.CONST.MEASURED_TEMPLATE_TYPES> | null | undefined;
+  t?: foundry.CONST.MEASURED_TEMPLATE_TYPES | null | undefined;
 
   /**
    * The x-coordinate position of the origin of the template effect

--- a/src/foundry/common/data/data.mjs/measuredTemplateData.d.ts
+++ b/src/foundry/common/data/data.mjs/measuredTemplateData.d.ts
@@ -5,11 +5,11 @@ import {
   PropertiesToSource
 } from '../../../../types/helperTypes';
 import { DocumentData } from '../../abstract/module.mjs';
-import * as fields from '../fields.mjs';
 import * as documents from '../../documents.mjs';
+import * as fields from '../fields.mjs';
 
 interface MeasuredTemplateDataSchema extends DocumentSchema {
-  _id: typeof fields.DOCUMENT_ID;
+  _id: fields.DocumentId;
   user: fields.ForeignDocumentField<{ type: typeof documents.BaseUser; required: true }>;
   t: {
     type: typeof String;
@@ -18,21 +18,22 @@ interface MeasuredTemplateDataSchema extends DocumentSchema {
     validate: (t: unknown) => boolean;
     validationError: 'Invalid {name} {field} which must be a value in CONST.MEASURED_TEMPLATE_TYPES';
   };
-  x: typeof fields.REQUIRED_NUMBER;
-  y: typeof fields.REQUIRED_NUMBER;
-  distance: FieldReturnType<typeof fields.REQUIRED_POSITIVE_NUMBER, { default: 1 }>;
-  direction: FieldReturnType<typeof fields.ANGLE_FIELD, { default: 0 }>;
-  angle: typeof fields.ANGLE_FIELD;
-  width: FieldReturnType<typeof fields.REQUIRED_POSITIVE_NUMBER, { default: 1 }>;
-  borderColor: FieldReturnType<typeof fields.COLOR_FIELD, { required: true; default: '#000000' }>;
-  fillColor: FieldReturnType<typeof fields.COLOR_FIELD, { required: true; default: '#FF0000' }>;
-  texture: typeof fields.VIDEO_FIELD;
-  flags: typeof fields.OBJECT_FIELD;
+  x: fields.RequiredNumber;
+  y: fields.RequiredNumber;
+  distance: FieldReturnType<fields.RequiredPositiveNumber, { default: 1 }>;
+  direction: FieldReturnType<fields.AngleField, { default: 0 }>;
+  angle: fields.AngleField;
+  width: FieldReturnType<fields.RequiredPositiveNumber, { default: 1 }>;
+  borderColor: FieldReturnType<fields.ColorField, { required: true; default: '#000000' }>;
+  fillColor: FieldReturnType<fields.ColorField, { required: true; default: '#FF0000' }>;
+  texture: fields.VideoField;
+  flags: fields.ObjectField;
 }
 
 interface MeasuredTemplateDataProperties {
   /**
-   The _id which uniquely identifies this BaseMeasuredTemplate embedded document
+   * The _id which uniquely identifies this BaseMeasuredTemplate embedded document
+   * @defaultValue `null`
    */
   _id: string | null;
 
@@ -40,7 +41,7 @@ interface MeasuredTemplateDataProperties {
 
   /**
    * The value in CONST.MEASURED_TEMPLATE_TYPES which defines the geometry type of this template
-   * @defaultValue `'circle'`
+   * @defaultValue `foundry.CONST.MEASURED_TEMPLATE_TYPES.CIRCLE`
    */
   t: foundry.CONST.MEASURED_TEMPLATE_TYPES;
 
@@ -70,7 +71,7 @@ interface MeasuredTemplateDataProperties {
 
   /**
    * The angle of effect of the measured template, applies to cone types
-   * @defaultValue `0`
+   * @defaultValue `360`
    */
   angle: number;
 
@@ -95,7 +96,7 @@ interface MeasuredTemplateDataProperties {
   /**
    * A repeatable tiling texture used to add a texture fill to the template shape
    */
-  texture: string | undefined | null;
+  texture: string | null | undefined;
 
   /**
    * An object of optional key/value flags
@@ -106,15 +107,16 @@ interface MeasuredTemplateDataProperties {
 
 interface MeasuredTemplateDataConstructorData {
   /**
-   The _id which uniquely identifies this BaseMeasuredTemplate embedded document
+   * The _id which uniquely identifies this BaseMeasuredTemplate embedded document
+   * @defaultValue `null`
    */
   _id?: string | null | undefined;
 
-  user?: string | null | undefined;
+  user?: InstanceType<ConfiguredDocumentClass<typeof documents.BaseUser>> | string | null | undefined;
 
   /**
    * The value in CONST.MEASURED_TEMPLATE_TYPES which defines the geometry type of this template
-   * @defaultValue `'circle'`
+   * @defaultValue `foundry.CONST.MEASURED_TEMPLATE_TYPES.CIRCLE`
    */
   t?: ValueOf<foundry.CONST.MEASURED_TEMPLATE_TYPES> | null | undefined;
 
@@ -144,7 +146,7 @@ interface MeasuredTemplateDataConstructorData {
 
   /**
    * The angle of effect of the measured template, applies to cone types
-   * @defaultValue `0`
+   * @defaultValue `360`
    */
   angle?: number | null | undefined;
 
@@ -182,7 +184,7 @@ interface MeasuredTemplateDataConstructorData {
  * The data schema for a MeasuredTemplate embedded document.
  * @see BaseMeasuredTemplate
  */
-export declare class MeasuredTemplateData extends DocumentData<
+export class MeasuredTemplateData extends DocumentData<
   MeasuredTemplateDataSchema,
   MeasuredTemplateDataProperties,
   PropertiesToSource<MeasuredTemplateDataProperties>,
@@ -197,6 +199,7 @@ export declare class MeasuredTemplateData extends DocumentData<
     document: InstanceType<ConfiguredDocumentClass<typeof foundry.documents.BaseScene>>
   );
 
+  /** @override */
   static defineSchema(): MeasuredTemplateDataSchema;
 
   /** @override */
@@ -207,4 +210,4 @@ export declare class MeasuredTemplateData extends DocumentData<
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export declare interface MeasuredTemplateData extends MeasuredTemplateDataProperties {}
+export interface MeasuredTemplateData extends MeasuredTemplateDataProperties {}

--- a/src/foundry/common/data/data.mjs/measuredTemplateData.d.ts
+++ b/src/foundry/common/data/data.mjs/measuredTemplateData.d.ts
@@ -11,11 +11,11 @@ import * as fields from '../fields.mjs';
 interface MeasuredTemplateDataSchema extends DocumentSchema {
   _id: fields.DocumentId;
   user: fields.ForeignDocumentField<{ type: typeof documents.BaseUser; required: true }>;
-  t: DocumentField<typeof CONST.MEASURED_TEMPLATE_TYPES> & {
+  t: DocumentField<typeof foundry.CONST.MEASURED_TEMPLATE_TYPES> & {
     type: typeof String;
     required: true;
-    default: typeof CONST.MEASURED_TEMPLATE_TYPES.CIRCLE;
-    validate: (t: unknown) => t is typeof CONST.MEASURED_TEMPLATE_TYPES;
+    default: typeof foundry.CONST.MEASURED_TEMPLATE_TYPES.CIRCLE;
+    validate: (t: unknown) => t is typeof foundry.CONST.MEASURED_TEMPLATE_TYPES;
     validationError: 'Invalid {name} {field} which must be a value in CONST.MEASURED_TEMPLATE_TYPES';
   };
   x: fields.RequiredNumber;

--- a/src/foundry/common/data/data.mjs/noteData.d.ts
+++ b/src/foundry/common/data/data.mjs/noteData.d.ts
@@ -44,7 +44,7 @@ interface NoteDataSchema extends DocumentSchema {
       validationError: 'Invalid {name} {field} which must be an integer between 8 and 128';
     }
   >;
-  textAnchor: DocumentField<number> & {
+  textAnchor: DocumentField<typeof CONST.TEXT_ANCHOR_POINTS> & {
     type: typeof Number;
     required: true;
     default: typeof CONST.TEXT_ANCHOR_POINTS.BOTTOM;

--- a/src/foundry/common/data/data.mjs/noteData.d.ts
+++ b/src/foundry/common/data/data.mjs/noteData.d.ts
@@ -17,7 +17,7 @@ interface NoteDataSchema extends DocumentSchema {
     fields.ImageField,
     {
       required: true;
-      default: typeof CONST.DEFAULT_NOTE_ICON;
+      default: typeof foundry.CONST.DEFAULT_NOTE_ICON;
     }
   >;
   iconSize: FieldReturnType<
@@ -44,10 +44,10 @@ interface NoteDataSchema extends DocumentSchema {
       validationError: 'Invalid {name} {field} which must be an integer between 8 and 128';
     }
   >;
-  textAnchor: DocumentField<typeof CONST.TEXT_ANCHOR_POINTS> & {
+  textAnchor: DocumentField<typeof foundry.CONST.TEXT_ANCHOR_POINTS> & {
     type: typeof Number;
     required: true;
-    default: typeof CONST.TEXT_ANCHOR_POINTS.BOTTOM;
+    default: typeof foundry.CONST.TEXT_ANCHOR_POINTS.BOTTOM;
     validate: (p: unknown) => p is foundry.CONST.TEXT_ANCHOR_POINTS;
     validationError: 'Invalid {name} {field} which must be a value in CONST.TEXT_ANCHOR_POINTS';
   };

--- a/src/foundry/common/data/data.mjs/noteData.d.ts
+++ b/src/foundry/common/data/data.mjs/noteData.d.ts
@@ -1,38 +1,43 @@
-import { ConfiguredFlags, FieldReturnType, PropertiesToSource } from '../../../../types/helperTypes';
+import {
+  ConfiguredDocumentClass,
+  ConfiguredFlags,
+  FieldReturnType,
+  PropertiesToSource
+} from '../../../../types/helperTypes';
 import DocumentData from '../../abstract/data.mjs';
 import * as documents from '../../documents.mjs';
 import * as fields from '../fields.mjs';
 
 interface NoteDataSchema extends DocumentSchema {
-  _id: typeof fields.DOCUMENT_ID;
+  _id: fields.DocumentId;
   entryId: fields.ForeignDocumentField<{ type: typeof documents.BaseJournalEntry; required: false }>;
-  x: typeof fields.REQUIRED_NUMBER;
-  y: typeof fields.REQUIRED_NUMBER;
+  x: fields.RequiredNumber;
+  y: fields.RequiredNumber;
   icon: FieldReturnType<
-    typeof fields.IMAGE_FIELD,
+    fields.ImageField,
     {
       required: true;
       default: typeof CONST.DEFAULT_NOTE_ICON;
     }
   >;
   iconSize: FieldReturnType<
-    typeof fields.REQUIRED_NUMBER,
+    fields.RequiredNumber,
     {
       default: 40;
       validate: (n: unknown) => n is number;
       validationError: 'Invalid {name} {field} which must be an integer greater than 32';
     }
   >;
-  iconTint: typeof fields.COLOR_FIELD;
-  text: typeof fields.STRING_FIELD;
+  iconTint: fields.ColorField;
+  text: fields.StringField;
   fontFamily: FieldReturnType<
-    typeof fields.REQUIRED_STRING,
+    fields.RequiredString,
     {
       default: () => typeof CONFIG['defaultFontFamily'];
     }
   >;
   fontSize: FieldReturnType<
-    typeof fields.REQUIRED_NUMBER,
+    fields.RequiredNumber,
     {
       default: 48;
       validate: (n: unknown) => n is number;
@@ -46,13 +51,14 @@ interface NoteDataSchema extends DocumentSchema {
     validate: (p: unknown) => p is foundry.CONST.TEXT_ANCHOR_POINTS;
     validationError: 'Invalid {name} {field} which must be a value in CONST.TEXT_ANCHOR_POINTS';
   };
-  textColor: FieldReturnType<typeof fields.COLOR_FIELD, { default: '#FFFFFF' }>;
-  flags: typeof fields.OBJECT_FIELD;
+  textColor: FieldReturnType<fields.ColorField, { default: '#FFFFFF' }>;
+  flags: fields.ObjectField;
 }
 
 interface NoteDataProperties {
   /**
    * The _id which uniquely identifies this BaseNote embedded document
+   * @defaultValue `null`
    */
   _id: string | null;
 
@@ -76,6 +82,7 @@ interface NoteDataProperties {
 
   /**
    * An image icon path used to represent this note
+   * @defaultValue `CONST.DEFAULT_NOTE_ICON`
    */
   icon: string | null;
 
@@ -130,6 +137,7 @@ interface NoteDataProperties {
 interface NoteDataConstructorData {
   /**
    * The _id which uniquely identifies this BaseNote embedded document
+   * @defaultValue `null`
    */
   _id?: string | null | undefined;
 
@@ -137,7 +145,7 @@ interface NoteDataConstructorData {
    * The _id of a JournalEntry document which this Note represents
    * @defaultValue `null`
    */
-  entryId?: string | null | undefined;
+  entryId?: InstanceType<ConfiguredDocumentClass<typeof documents.BaseJournalEntry>> | string | null | undefined;
 
   /**
    * The x-coordinate position of the center of the note icon
@@ -153,6 +161,7 @@ interface NoteDataConstructorData {
 
   /**
    * An image icon path used to represent this note
+   * @defaultValue `CONST.DEFAULT_NOTE_ICON`
    */
   icon?: string | null | undefined;
 
@@ -208,15 +217,16 @@ interface NoteDataConstructorData {
  * The data schema for a Note embedded document.
  * @see BaseNote
  */
-export declare class NoteData extends DocumentData<
+export class NoteData extends DocumentData<
   NoteDataSchema,
   NoteDataProperties,
   PropertiesToSource<NoteDataProperties>,
   NoteDataConstructorData,
   documents.BaseNote
 > {
+  /** @override */
   static defineSchema(): NoteDataSchema;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export declare interface NoteData extends NoteDataProperties {}
+export interface NoteData extends NoteDataProperties {}

--- a/src/foundry/common/data/data.mjs/playlistData.d.ts
+++ b/src/foundry/common/data/data.mjs/playlistData.d.ts
@@ -12,7 +12,7 @@ interface PlaylistDataSchema extends DocumentSchema {
   mode: DocumentField<foundry.CONST.PLAYLIST_MODES> & {
     type: typeof Number;
     required: true;
-    default: typeof CONST.PLAYLIST_MODES.SEQUENTIAL;
+    default: typeof foundry.CONST.PLAYLIST_MODES.SEQUENTIAL;
     validate: (m: unknown) => m is foundry.CONST.PLAYLIST_MODES;
     validationError: 'Invalid {name} {field} provided which must be a value from CONST.PLAYLIST_MODES';
   };

--- a/src/foundry/common/data/data.mjs/playlistData.d.ts
+++ b/src/foundry/common/data/data.mjs/playlistData.d.ts
@@ -44,7 +44,7 @@ interface PlaylistDataProperties {
 
   /**
    * A Collection of PlaylistSounds embedded documents which belong to this playlist
-   * @defaultValue `[]`
+   * @defaultValue `new EmbeddedCollection(PlaylistSoundData, [], BasePlaylistSound.implementation)`
    */
   sounds: EmbeddedCollection<ConfiguredDocumentClass<typeof documents.BasePlaylistSound>, PlaylistData>;
 
@@ -108,7 +108,7 @@ interface PlaylistDataConstructorData {
 
   /**
    * A Collection of PlaylistSounds embedded documents which belong to this playlist
-   * @defaultValue `[]`
+   * @defaultValue `new EmbeddedCollection(PlaylistSoundData, [], BasePlaylistSound.implementation)`
    */
   sounds?:
     | EmbeddedCollection<ConfiguredDocumentClass<typeof documents.BasePlaylistSound>, PlaylistData>

--- a/src/foundry/common/data/data.mjs/playlistData.d.ts
+++ b/src/foundry/common/data/data.mjs/playlistData.d.ts
@@ -1,14 +1,13 @@
+import type { ConfiguredDocumentClass, ConfiguredFlags, PropertiesToSource } from '../../../../types/helperTypes';
+import type DocumentData from '../../abstract/data.mjs';
+import type EmbeddedCollection from '../../abstract/embedded-collection.mjs';
 import * as documents from '../../documents.mjs';
 import * as fields from '../fields.mjs';
 
-import type { ConfiguredDocumentClass, ConfiguredFlags, PropertiesToSource } from '../../../../types/helperTypes';
-import type EmbeddedCollection from '../../abstract/embedded-collection.mjs';
-import type DocumentData from '../../abstract/data.mjs';
-
 interface PlaylistDataSchema extends DocumentSchema {
-  _id: typeof fields.DOCUMENT_ID;
-  name: typeof fields.REQUIRED_STRING;
-  description: typeof fields.BLANK_STRING;
+  _id: fields.DocumentId;
+  name: fields.RequiredString;
+  description: fields.BlankString;
   sounds: fields.EmbeddedCollectionField<typeof documents.BasePlaylistSound>;
   mode: DocumentField<foundry.CONST.PLAYLIST_MODES> & {
     type: typeof Number;
@@ -17,18 +16,19 @@ interface PlaylistDataSchema extends DocumentSchema {
     validate: (m: unknown) => m is foundry.CONST.PLAYLIST_MODES;
     validationError: 'Invalid {name} {field} provided which must be a value from CONST.PLAYLIST_MODES';
   };
-  playing: typeof fields.BOOLEAN_FIELD;
-  fade: typeof fields.INTEGER_FIELD;
+  playing: fields.BooleanField;
+  fade: fields.IntegerField;
   folder: fields.ForeignDocumentField<{ type: typeof documents.BaseFolder }>;
-  sort: typeof fields.INTEGER_SORT_FIELD;
-  seed: typeof fields.NONNEGATIVE_INTEGER_FIELD;
-  permission: typeof fields.DOCUMENT_PERMISSIONS;
-  flags: typeof fields.OBJECT_FIELD;
+  sort: fields.IntegerSortField;
+  seed: fields.NonnegativeIntegerField;
+  permission: fields.DocumentPermissions;
+  flags: fields.ObjectField;
 }
 
 interface PlaylistDataProperties {
   /**
    * The _id which uniquely identifies this Playlist document
+   * @defaultValue `null`
    */
   _id: string | null;
 
@@ -38,12 +38,13 @@ interface PlaylistDataProperties {
   name: string;
 
   /**
-   * @defaultValue `''`
+   * @defaultValue `""`
    */
   description: string;
 
   /**
    * A Collection of PlaylistSounds embedded documents which belong to this playlist
+   * @defaultValue `[]`
    */
   sounds: EmbeddedCollection<ConfiguredDocumentClass<typeof documents.BasePlaylistSound>, PlaylistData>;
 
@@ -91,6 +92,7 @@ interface PlaylistDataProperties {
 interface PlaylistDataConstructorData {
   /**
    * The _id which uniquely identifies this Playlist document
+   * @defaultValue `null`
    */
   _id?: string | null | undefined;
 
@@ -100,12 +102,13 @@ interface PlaylistDataConstructorData {
   name: string;
 
   /**
-   * @defaultValue `''`
+   * @defaultValue `""`
    */
   description?: string | null | undefined;
 
   /**
    * A Collection of PlaylistSounds embedded documents which belong to this playlist
+   * @defaultValue `[]`
    */
   sounds?:
     | EmbeddedCollection<ConfiguredDocumentClass<typeof documents.BasePlaylistSound>, PlaylistData>
@@ -124,13 +127,13 @@ interface PlaylistDataConstructorData {
    */
   playing?: boolean | null | undefined;
 
-  fade?: number | undefined | null;
+  fade?: number | null | undefined;
 
   /**
    * The _id of a Folder which contains this playlist
    * @defaultValue `null`
    */
-  folder?: string | null | undefined;
+  folder?: InstanceType<ConfiguredDocumentClass<typeof documents.BaseFolder>> | string | null | undefined;
 
   /**
    * The numeric sort value which orders this playlist relative to its siblings
@@ -138,13 +141,13 @@ interface PlaylistDataConstructorData {
    */
   sort?: number | null | undefined;
 
-  seed?: number | undefined | null;
+  seed?: number | null | undefined;
 
   /**
    * An object which configures user permissions to this playlist
    * @defaultValue `{ default: CONST.ENTITY_PERMISSIONS.NONE }`
    */
-  permission?: Record<string, foundry.CONST.DOCUMENT_PERMISSION_LEVELS> | undefined | null;
+  permission?: Record<string, foundry.CONST.DOCUMENT_PERMISSION_LEVELS> | null | undefined;
 
   /**
    * An object of optional key/value flags
@@ -157,13 +160,14 @@ interface PlaylistDataConstructorData {
  * The data schema for a Playlist document.
  * @see BasePlaylist
  */
-export declare class PlaylistData extends DocumentData<
+export class PlaylistData extends DocumentData<
   PlaylistDataSchema,
   PlaylistDataProperties,
   PropertiesToSource<PlaylistDataProperties>,
   PlaylistDataConstructorData,
   documents.BasePlaylist
 > {
+  /** @override */
   static defineSchema(): PlaylistDataSchema;
 }
 

--- a/src/foundry/common/data/data.mjs/playlistSoundData.d.ts
+++ b/src/foundry/common/data/data.mjs/playlistSoundData.d.ts
@@ -1,24 +1,25 @@
-import * as fields from '../fields.mjs';
 import type { ConfiguredFlags, FieldReturnType, PropertiesToSource } from '../../../../types/helperTypes';
 import type DocumentData from '../../abstract/data.mjs';
 import type { documents } from '../../module.mjs';
+import * as fields from '../fields.mjs';
 
 interface PlaylistSoundDataSchema extends DocumentSchema {
-  _id: typeof fields.DOCUMENT_ID;
-  name: typeof fields.REQUIRED_STRING;
-  description: typeof fields.BLANK_STRING;
-  path: typeof fields.AUDIO_FIELD;
-  playing: typeof fields.BOOLEAN_FIELD;
-  pausedTime: FieldReturnType<typeof fields.NUMERIC_FIELD, { default: null }>;
-  repeat: typeof fields.BOOLEAN_FIELD;
-  volume: FieldReturnType<typeof fields.ALPHA_FIELD, { default: 0.5 }>;
-  fade: typeof fields.INTEGER_FIELD;
-  flags: typeof fields.OBJECT_FIELD;
+  _id: fields.DocumentId;
+  name: fields.RequiredString;
+  description: fields.BlankString;
+  path: fields.AudioField;
+  playing: fields.BooleanField;
+  pausedTime: FieldReturnType<fields.NumericField, { default: null }>;
+  repeat: fields.BooleanField;
+  volume: FieldReturnType<fields.AlphaField, { default: 0.5 }>;
+  fade: fields.IntegerField;
+  flags: fields.ObjectField;
 }
 
 interface PlaylistSoundDataProperties {
   /**
    * The _id which uniquely identifies this PlaylistSound document
+   * @defaultValue `null`
    */
   _id: string | null;
 
@@ -28,14 +29,14 @@ interface PlaylistSoundDataProperties {
   name: string;
 
   /**
-   * @defaultValue `''`
+   * @defaultValue `""`
    */
   description: string;
 
   /**
    * The audio file path that is played by this sound
    */
-  path: string | undefined | null;
+  path: string | null | undefined;
 
   /**
    * Is this sound currently playing?
@@ -72,6 +73,7 @@ interface PlaylistSoundDataProperties {
 interface PlaylistSoundDataConstructorData {
   /**
    * The _id which uniquely identifies this PlaylistSound document
+   * @defaultValue `null`
    */
   _id?: string | null | undefined;
 
@@ -81,14 +83,14 @@ interface PlaylistSoundDataConstructorData {
   name: string;
 
   /**
-   * @defaultValue `''`
+   * @defaultValue `""`
    */
   description?: string | null | undefined;
 
   /**
    * The audio file path that is played by this sound
    */
-  path?: string | undefined | null;
+  path?: string | null | undefined;
 
   /**
    * Is this sound currently playing?
@@ -126,13 +128,14 @@ interface PlaylistSoundDataConstructorData {
  * The data schema for a PlaylistSound embedded document.
  * @see BasePlaylistSound
  */
-export declare class PlaylistSoundData extends DocumentData<
+export class PlaylistSoundData extends DocumentData<
   PlaylistSoundDataSchema,
   PlaylistSoundDataProperties,
   PropertiesToSource<PlaylistSoundDataProperties>,
   PlaylistSoundDataConstructorData,
   documents.BasePlaylistSound
 > {
+  /** @override */
   static defineSchema(): PlaylistSoundDataSchema;
 
   /** @override */

--- a/src/foundry/common/data/data.mjs/prototypeTokenData.d.ts
+++ b/src/foundry/common/data/data.mjs/prototypeTokenData.d.ts
@@ -17,9 +17,9 @@ type FieldExclusions =
   | 'hidden';
 
 interface PrototypeTokenDataSchema extends Omit<TokenDataSchema, FieldExclusions> {
-  randomImg: typeof fields.BOOLEAN_FIELD;
+  randomImg: fields.BooleanField;
   img: FieldReturnType<
-    typeof fields.VIDEO_FIELD,
+    fields.VideoField,
     { default: typeof foundry.CONST.DEFAULT_TOKEN; validate: (src: unknown) => boolean }
   >;
 }
@@ -38,7 +38,7 @@ interface PrototypeTokenDataProperties extends Omit<TokenDataProperties, FieldEx
   img: string | null;
 }
 
-export interface PrototypeTokenDataConstructorData extends Omit<TokenDataConstructorData, FieldExclusions> {
+interface PrototypeTokenDataConstructorData extends Omit<TokenDataConstructorData, FieldExclusions> {
   /**
    * Uses a random "wildcard" image path which is resolved with a Token is created
    * @defaultValue `false`
@@ -59,14 +59,10 @@ export class PrototypeTokenData extends DocumentData<
   PrototypeTokenDataConstructorData,
   documents.BaseActor
 > {
-  /**
-   * @override
-   */
+  /** @override */
   _initialize(): void;
 
-  /**
-   * @override
-   */
+  /** @override */
   toObject(source?: true): ReturnType<this['toJSON']> & { actorId: documents.BaseActor['id'] };
   toObject(source: false): {
     [Key in keyof PrototypeTokenDataSchema as string extends Key ? never : Key]: Key extends keyof this

--- a/src/foundry/common/data/data.mjs/rollTableData.d.ts
+++ b/src/foundry/common/data/data.mjs/rollTableData.d.ts
@@ -10,23 +10,24 @@ import * as documents from '../../documents.mjs';
 import * as fields from '../fields.mjs';
 
 interface RollTableDataSchema extends DocumentSchema {
-  _id: typeof fields.DOCUMENT_ID;
-  name: typeof fields.REQUIRED_STRING;
-  img: FieldReturnType<typeof fields.IMAGE_FIELD, { default: () => string }>;
-  description: typeof fields.STRING_FIELD;
+  _id: fields.DocumentId;
+  name: fields.RequiredString;
+  img: FieldReturnType<fields.ImageField, { default: () => typeof RollTableData.DEFAULT_ICON }>;
+  description: fields.StringField;
   results: fields.EmbeddedCollectionField<typeof documents.BaseTableResult>;
-  formula: typeof fields.STRING_FIELD;
-  replacement: FieldReturnType<typeof fields.BOOLEAN_FIELD, { default: true }>;
-  displayRoll: FieldReturnType<typeof fields.BOOLEAN_FIELD, { default: true }>;
+  formula: fields.StringField;
+  replacement: FieldReturnType<fields.BooleanField, { default: true }>;
+  displayRoll: FieldReturnType<fields.BooleanField, { default: true }>;
   folder: fields.ForeignDocumentField<{ type: typeof documents.BaseFolder }>;
-  sort: typeof fields.INTEGER_SORT_FIELD;
-  permission: typeof fields.DOCUMENT_PERMISSIONS;
-  flags: typeof fields.OBJECT_FIELD;
+  sort: fields.IntegerSortField;
+  permission: fields.DocumentPermissions;
+  flags: fields.ObjectField;
 }
 
 interface RollTableDataProperties {
   /**
    * The _id which uniquely identifies this RollTable document
+   * @defaultValue `null`
    */
   _id: string | null;
 
@@ -37,6 +38,7 @@ interface RollTableDataProperties {
 
   /**
    * An image file path which provides the thumbnail artwork for this RollTable
+   * @defaultValue `RollTableData.DEFAULT_ICON`
    */
   img: string;
 
@@ -47,6 +49,7 @@ interface RollTableDataProperties {
 
   /**
    * A Collection of TableResult embedded documents which belong to this RollTable
+   * @defaultValue `[]`
    */
   results: EmbeddedCollection<ConfiguredDocumentClass<typeof documents.BaseTableResult>, RollTableData>;
 
@@ -104,6 +107,7 @@ interface RollTableDataConstructorData {
 
   /**
    * An image file path which provides the thumbnail artwork for this RollTable
+   * @defaultValue `RollTableData.DEFAULT_ICON`
    */
   img?: string | null | undefined;
 
@@ -114,6 +118,7 @@ interface RollTableDataConstructorData {
 
   /**
    * A Collection of TableResult embedded documents which belong to this RollTable
+   * @defaultValue `[]`
    */
   results?: ConstructorParameters<ConfiguredDocumentClass<typeof documents.BaseTableResult>>[0][] | null | undefined;
 
@@ -137,7 +142,7 @@ interface RollTableDataConstructorData {
   /**
    * The _id of a Folder which contains this RollTable
    */
-  folder?: string | null | undefined;
+  folder?: InstanceType<ConfiguredDocumentClass<typeof documents.BaseFolder>> | string | null | undefined;
 
   /**
    * The numeric sort value which orders this RollTable relative to its siblings
@@ -161,13 +166,14 @@ interface RollTableDataConstructorData {
  * The data schema for an RollTable document.
  * @see BaseRollTable
  */
-export declare class RollTableData extends DocumentData<
+export class RollTableData extends DocumentData<
   RollTableDataSchema,
   RollTableDataProperties,
   PropertiesToSource<RollTableDataProperties>,
   RollTableDataConstructorData,
   documents.BaseRollTable
 > {
+  /** @override */
   static defineSchema(): RollTableDataSchema;
 
   /**
@@ -179,4 +185,4 @@ export declare class RollTableData extends DocumentData<
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export declare interface RollTableData extends RollTableDataProperties {}
+export interface RollTableData extends RollTableDataProperties {}

--- a/src/foundry/common/data/data.mjs/rollTableData.d.ts
+++ b/src/foundry/common/data/data.mjs/rollTableData.d.ts
@@ -49,7 +49,7 @@ interface RollTableDataProperties {
 
   /**
    * A Collection of TableResult embedded documents which belong to this RollTable
-   * @defaultValue `[]`
+   * @defaultValue `new EmbeddedCollection(TableResultData, [], BaseTableResult.implementation)`
    */
   results: EmbeddedCollection<ConfiguredDocumentClass<typeof documents.BaseTableResult>, RollTableData>;
 
@@ -118,7 +118,7 @@ interface RollTableDataConstructorData {
 
   /**
    * A Collection of TableResult embedded documents which belong to this RollTable
-   * @defaultValue `[]`
+   * @defaultValue `new EmbeddedCollection(TableResultData, [], BaseTableResult.implementation)`
    */
   results?: ConstructorParameters<ConfiguredDocumentClass<typeof documents.BaseTableResult>>[0][] | null | undefined;
 

--- a/src/foundry/common/data/data.mjs/sceneData.d.ts
+++ b/src/foundry/common/data/data.mjs/sceneData.d.ts
@@ -267,49 +267,49 @@ interface SceneDataProperties {
 
   /**
    * A collection of embedded Drawing objects.
-   * @defaultValue `[]`
+   * @defaultValue `new EmbeddedCollection(DrawingData, [], BaseDrawing.implementation)`
    */
   drawings: EmbeddedCollection<ConfiguredDocumentClass<typeof documents.BaseDrawing>, SceneData>;
 
   /**
    * A collection of embedded Token objects.
-   * @defaultValue `[]`
+   * @defaultValue `new EmbeddedCollection(TokenData, [], BaseToken.implementation)`
    */
   tokens: EmbeddedCollection<ConfiguredDocumentClass<typeof documents.BaseToken>, SceneData>;
 
   /**
    * A collection of embedded AmbientLight objects.
-   * @defaultValue `[]`
+   * @defaultValue `new EmbeddedCollection(AmbientLightData, [], BaseAmbientLight.implementation)`
    */
   lights: EmbeddedCollection<ConfiguredDocumentClass<typeof documents.BaseAmbientLight>, SceneData>;
 
   /**
    * A collection of embedded Note objects.
-   * @defaultValue `[]`
+   * @defaultValue `new EmbeddedCollection(NoteData, [], BaseNote.implementation)`
    */
   notes: EmbeddedCollection<ConfiguredDocumentClass<typeof documents.BaseNote>, SceneData>;
 
   /**
    * A collection of embedded AmbientSound objects.
-   * @defaultValue `[]`
+   * @defaultValue `new EmbeddedCollection(AmbientSoundData, [], BaseAmbientSound.implementation)`
    */
   sounds: EmbeddedCollection<ConfiguredDocumentClass<typeof documents.BaseAmbientSound>, SceneData>;
 
   /**
    * A collection of embedded MeasuredTemplate objects.
-   * @defaultValue `[]`
+   * @defaultValue `new EmbeddedCollection(MeasuredTemplateData, [], BaseMeasuredTemplate.implementation)`
    */
   templates: EmbeddedCollection<ConfiguredDocumentClass<typeof documents.BaseMeasuredTemplate>, SceneData>;
 
   /**
    * A collection of embedded Tile objects.
-   * @defaultValue `[]`
+   * @defaultValue `new EmbeddedCollection(TileData, [], BaseTile.implementation)`
    */
   tiles: EmbeddedCollection<ConfiguredDocumentClass<typeof documents.BaseTile>, SceneData>;
 
   /**
    * A collection of embedded Wall objects
-   * @defaultValue `[]`
+   * @defaultValue `new EmbeddedCollection(WallData, [], BaseWall.implementation)`
    */
   walls: EmbeddedCollection<ConfiguredDocumentClass<typeof documents.BaseWall>, SceneData>;
 
@@ -531,49 +531,49 @@ interface SceneDataConstructorData {
 
   /**
    * A collection of embedded Drawing objects.
-   * @defaultValue `[]`
+   * @defaultValue `new EmbeddedCollection(DrawingData, [], BaseDrawing.implementation)`
    */
   drawings?: DrawingDataConstructorData[] | null | undefined;
 
   /**
    * A collection of embedded Token objects.
-   * @defaultValue `[]`
+   * @defaultValue `new EmbeddedCollection(TokenData, [], BaseToken.implementation)`
    */
   tokens?: TokenDataConstructorData[] | null | undefined;
 
   /**
    * A collection of embedded AmbientLight objects.
-   * @defaultValue `[]`
+   * @defaultValue `new EmbeddedCollection(AmbientLightData, [], BaseAmbientLight.implementation)`
    */
   lights?: AmbientLightDataConstructorData[] | null | undefined;
 
   /**
    * A collection of embedded Note objects.
-   * @defaultValue `[]`
+   * @defaultValue `new EmbeddedCollection(NoteData, [], BaseNote.implementation)`
    */
   notes?: NoteDataConstructorData[] | null | undefined;
 
   /**
    * A collection of embedded AmbientSound objects.
-   * @defaultValue `[]`
+   * @defaultValue `new EmbeddedCollection(AmbientSoundData, [], BaseAmbientSound.implementation)`
    */
   sounds?: AmbientSoundDataConstructorData[] | null | undefined;
 
   /**
    * A collection of embedded MeasuredTemplate objects.
-   * @defaultValue `[]`
+   * @defaultValue `new EmbeddedCollection(MeasuredTemplateData, [], BaseMeasuredTemplate.implementation)`
    */
   templates?: MeasuredTemplateDataConstructorData[] | null | undefined;
 
   /**
    * A collection of embedded Tile objects.
-   * @defaultValue `[]`
+   * @defaultValue `new EmbeddedCollection(TileData, [], BaseTile.implementation)`
    */
   tiles?: TileDataConstructorData[] | null | undefined;
 
   /**
    * A collection of embedded Wall objects
-   * @defaultValue `[]`
+   * @defaultValue `new EmbeddedCollection(WallData, [], BaseWall.implementation)`
    */
   walls?: WallDataConstructorData[] | null | undefined;
 

--- a/src/foundry/common/data/data.mjs/sceneData.d.ts
+++ b/src/foundry/common/data/data.mjs/sceneData.d.ts
@@ -6,7 +6,6 @@ import {
 } from '../../../../types/helperTypes';
 import EmbeddedCollection from '../../abstract/embedded-collection.mjs';
 import { DocumentData } from '../../abstract/module.mjs';
-import * as CONST from '../../constants.mjs';
 import * as documents from '../../documents.mjs';
 import * as fields from '../fields.mjs';
 import { AmbientLightDataConstructorData } from './ambientLightData';
@@ -49,8 +48,8 @@ interface SceneDataSchema extends DocumentSchema {
   gridType: FieldReturnType<
     fields.RequiredNumber,
     {
-      default: typeof CONST.GRID_TYPES.SQUARE;
-      validate: (t: unknown) => t is CONST.GRID_TYPES;
+      default: typeof foundry.CONST.GRID_TYPES.SQUARE;
+      validate: (t: unknown) => t is foundry.CONST.GRID_TYPES;
       validationError: 'Invalid {name } {field} which must be a value in CONST.GRID_TYPES';
     }
   >;
@@ -59,7 +58,7 @@ interface SceneDataSchema extends DocumentSchema {
     required: true;
     default: 100;
     validate: (n: unknown) => boolean;
-    validationError: `Invalid {name} {field} which must be an integer number of pixels, ${typeof CONST.GRID_MIN_SIZE} or greater`;
+    validationError: `Invalid {name} {field} which must be an integer number of pixels, ${typeof foundry.CONST.GRID_MIN_SIZE} or greater`;
   };
   shiftX: FieldReturnType<fields.IntegerField, { required: true; default: 0 }>;
   shiftY: FieldReturnType<fields.IntegerField, { required: true; default: 0 }>;
@@ -184,7 +183,7 @@ interface SceneDataProperties {
    * The type of grid used in this scene, a number from CONST.GRID_TYPES
    * @defaultValue `CONST.GRID_TYPES.SQUARE`
    */
-  gridType: CONST.GRID_TYPES;
+  gridType: foundry.CONST.GRID_TYPES;
 
   /**
    * The grid size which represents the width (or height) of a single grid space
@@ -448,7 +447,7 @@ interface SceneDataConstructorData {
    * The type of grid used in this scene, a number from CONST.GRID_TYPES
    * @defaultValue `CONST.GRID_TYPES.SQUARE`
    */
-  gridType?: CONST.GRID_TYPES | null | undefined;
+  gridType?: foundry.CONST.GRID_TYPES | null | undefined;
 
   /**
    * The grid size which represents the width (or height) of a single grid space

--- a/src/foundry/common/data/data.mjs/sceneData.d.ts
+++ b/src/foundry/common/data/data.mjs/sceneData.d.ts
@@ -1,36 +1,35 @@
 import {
   ConfiguredDocumentClass,
   ConfiguredFlags,
-  ConstructorDataType,
   FieldReturnType,
   PropertiesToSource
 } from '../../../../types/helperTypes';
 import EmbeddedCollection from '../../abstract/embedded-collection.mjs';
 import { DocumentData } from '../../abstract/module.mjs';
-import * as fields from '../fields.mjs';
-import * as documents from '../../documents.mjs';
 import * as CONST from '../../constants.mjs';
-import { AmbientLightData } from './ambientLightData';
-import { AmbientSoundData } from './ambientSoundData';
-import { DrawingData } from './drawingData';
-import { MeasuredTemplateData } from './measuredTemplateData';
-import { NoteData } from './noteData';
-import { TileData } from './tileData';
-import { TokenData } from './tokenData';
-import { WallData } from './wallData';
+import * as documents from '../../documents.mjs';
+import * as fields from '../fields.mjs';
+import { AmbientLightDataConstructorData } from './ambientLightData';
+import { AmbientSoundDataConstructorData } from './ambientSoundData';
+import { DrawingDataConstructorData } from './drawingData';
+import { MeasuredTemplateDataConstructorData } from './measuredTemplateData';
+import { NoteDataConstructorData } from './noteData';
+import { TileDataConstructorData } from './tileData';
+import { TokenDataConstructorData } from './tokenData';
+import { WallDataConstructorData } from './wallData';
 
 interface SceneDataSchema extends DocumentSchema {
-  _id: typeof fields.DOCUMENT_ID;
-  name: typeof fields.REQUIRED_STRING;
-  active: typeof fields.BOOLEAN_FIELD;
-  navigation: FieldReturnType<typeof fields.BOOLEAN_FIELD, { default: true }>;
-  navOrder: typeof fields.INTEGER_SORT_FIELD;
-  navName: typeof fields.BLANK_STRING;
-  img: typeof fields.VIDEO_FIELD;
-  foreground: typeof fields.VIDEO_FIELD;
-  thumb: typeof fields.IMAGE_FIELD;
-  width: FieldReturnType<typeof fields.POSITIVE_INTEGER_FIELD, { required: true; default: 4000 }>;
-  height: FieldReturnType<typeof fields.POSITIVE_INTEGER_FIELD, { required: true; default: 3000 }>;
+  _id: fields.DocumentId;
+  name: fields.RequiredString;
+  active: fields.BooleanField;
+  navigation: FieldReturnType<fields.BooleanField, { default: true }>;
+  navOrder: fields.IntegerSortField;
+  navName: fields.BlankString;
+  img: fields.VideoField;
+  foreground: fields.VideoField;
+  thumb: fields.ImageField;
+  width: FieldReturnType<fields.PositiveIntegerField, { required: true; default: 4000 }>;
+  height: FieldReturnType<fields.PositiveIntegerField, { required: true; default: 3000 }>;
   padding: {
     type: typeof Number;
     required: true;
@@ -46,9 +45,9 @@ interface SceneDataSchema extends DocumentSchema {
     validate: typeof _validateInitialViewPosition;
     validationError: 'Invalid initial view position object provided for Scene';
   };
-  backgroundColor: FieldReturnType<typeof fields.COLOR_FIELD, { required: true; default: '#999999' }>;
+  backgroundColor: FieldReturnType<fields.ColorField, { required: true; default: '#999999' }>;
   gridType: FieldReturnType<
-    typeof fields.REQUIRED_NUMBER,
+    fields.RequiredNumber,
     {
       default: typeof CONST.GRID_TYPES.SQUARE;
       validate: (t: unknown) => t is CONST.GRID_TYPES;
@@ -62,16 +61,16 @@ interface SceneDataSchema extends DocumentSchema {
     validate: (n: unknown) => boolean;
     validationError: `Invalid {name} {field} which must be an integer number of pixels, ${typeof CONST.GRID_MIN_SIZE} or greater`;
   };
-  shiftX: FieldReturnType<typeof fields.INTEGER_FIELD, { required: true; default: 0 }>;
-  shiftY: FieldReturnType<typeof fields.INTEGER_FIELD, { required: true; default: 0 }>;
-  gridColor: FieldReturnType<typeof fields.COLOR_FIELD, { required: true; default: '#000000' }>;
-  gridAlpha: FieldReturnType<typeof fields.ALPHA_FIELD, { required: true; default: 0.2 }>;
-  gridDistance: FieldReturnType<typeof fields.REQUIRED_POSITIVE_NUMBER, { default: () => number }>;
-  gridUnits: FieldReturnType<typeof fields.BLANK_STRING, { default: () => string }>;
-  tokenVision: FieldReturnType<typeof fields.BOOLEAN_FIELD, { default: true }>;
-  fogExploration: FieldReturnType<typeof fields.BOOLEAN_FIELD, { default: true }>;
-  fogReset: typeof fields.TIMESTAMP_FIELD;
-  globalLight: typeof fields.BOOLEAN_FIELD;
+  shiftX: FieldReturnType<fields.IntegerField, { required: true; default: 0 }>;
+  shiftY: FieldReturnType<fields.IntegerField, { required: true; default: 0 }>;
+  gridColor: FieldReturnType<fields.ColorField, { required: true; default: '#000000' }>;
+  gridAlpha: FieldReturnType<fields.AlphaField, { required: true; default: 0.2 }>;
+  gridDistance: FieldReturnType<fields.RequiredPositiveNumber, { default: () => number }>;
+  gridUnits: FieldReturnType<fields.BlankString, { default: () => string }>;
+  tokenVision: FieldReturnType<fields.BooleanField, { default: true }>;
+  fogExploration: FieldReturnType<fields.BooleanField, { default: true }>;
+  fogReset: fields.TimestampField;
+  globalLight: fields.BooleanField;
   globalLightThreshold: {
     type: typeof Number;
     required: true;
@@ -80,7 +79,7 @@ interface SceneDataSchema extends DocumentSchema {
     validate: (n: unknown) => boolean;
     validationError: 'Invalid {name} {field} which must be null, or a number between 0 and 1';
   };
-  darkness: FieldReturnType<typeof fields.ALPHA_FIELD, { default: 0 }>;
+  darkness: FieldReturnType<fields.AlphaField, { default: 0 }>;
   drawings: fields.EmbeddedCollectionField<typeof documents.BaseDrawing>;
   tokens: fields.EmbeddedCollectionField<typeof documents.BaseToken>;
   lights: fields.EmbeddedCollectionField<typeof documents.BaseAmbientLight>;
@@ -92,16 +91,17 @@ interface SceneDataSchema extends DocumentSchema {
   playlist: fields.ForeignDocumentField<{ type: typeof documents.BasePlaylist; required: false }>;
   playlistSound: fields.ForeignDocumentField<{ type: typeof documents.BasePlaylistSound; required: false }>;
   journal: fields.ForeignDocumentField<{ type: typeof documents.BaseJournalEntry; required: false }>;
-  weather: typeof fields.BLANK_STRING;
+  weather: fields.BlankString;
   folder: fields.ForeignDocumentField<{ type: typeof documents.BaseFolder }>;
-  sort: typeof fields.INTEGER_SORT_FIELD;
-  permission: typeof fields.DOCUMENT_PERMISSIONS;
-  flags: typeof fields.BLANK_STRING;
+  sort: fields.IntegerSortField;
+  permission: fields.DocumentPermissions;
+  flags: fields.BlankString;
 }
 
 interface SceneDataProperties {
   /**
    * The _id which uniquely identifies this Scene document
+   * @defaultValue `null`
    */
   _id: string | null;
 
@@ -124,32 +124,30 @@ interface SceneDataProperties {
 
   /**
    * The integer sorting order of this Scene in the navigation bar relative to others
+   * @defaultValue `0`
    */
   navOrder: number;
 
   /**
    * A string which overrides the canonical Scene name which is displayed in the navigation bar
-   * @defaultValue `''`
+   * @defaultValue `""`
    */
   navName: string;
 
   /**
    * An image or video file path which provides the background media for the scene
-   * @defaultValue `undefined`
    */
-  img: string | undefined | null;
+  img: string | null | undefined;
 
   /**
    * An image or video file path which is drawn on top of all other elements in the scene
-   * @defaultValue `undefined`
    */
-  foreground: string | undefined | null;
+  foreground: string | null | undefined;
 
   /**
    * A thumbnail image (base64) or file path which visually summarizes the scene
-   * @defaultValue `undefined`
    */
-  thumb: string | undefined | null;
+  thumb: string | null | undefined;
 
   /**
    * The width of the scene canvas, this should normally be the width of the background media
@@ -220,11 +218,13 @@ interface SceneDataProperties {
 
   /**
    * The number of distance units which are represented by a single grid space.
+   * @defaultValue `game.system.data.gridDistance || 1`
    */
   gridDistance: number;
 
   /**
    * A label for the units of measure which are used for grid distance.
+   * @defaultValue `game.system.data.gridUnits ?? ""`
    */
   gridUnits: string;
 
@@ -242,6 +242,7 @@ interface SceneDataProperties {
 
   /**
    * The timestamp at which fog of war was last reset for this Scene.
+   * @defaultValue `Date.now()`
    */
   fogReset: number;
 
@@ -267,42 +268,49 @@ interface SceneDataProperties {
 
   /**
    * A collection of embedded Drawing objects.
+   * @defaultValue `[]`
    */
   drawings: EmbeddedCollection<ConfiguredDocumentClass<typeof documents.BaseDrawing>, SceneData>;
 
   /**
    * A collection of embedded Token objects.
+   * @defaultValue `[]`
    */
   tokens: EmbeddedCollection<ConfiguredDocumentClass<typeof documents.BaseToken>, SceneData>;
 
   /**
-   *
    * A collection of embedded AmbientLight objects.
+   * @defaultValue `[]`
    */
   lights: EmbeddedCollection<ConfiguredDocumentClass<typeof documents.BaseAmbientLight>, SceneData>;
 
   /**
    * A collection of embedded Note objects.
+   * @defaultValue `[]`
    */
   notes: EmbeddedCollection<ConfiguredDocumentClass<typeof documents.BaseNote>, SceneData>;
 
   /**
    * A collection of embedded AmbientSound objects.
+   * @defaultValue `[]`
    */
   sounds: EmbeddedCollection<ConfiguredDocumentClass<typeof documents.BaseAmbientSound>, SceneData>;
 
   /**
    * A collection of embedded MeasuredTemplate objects.
+   * @defaultValue `[]`
    */
   templates: EmbeddedCollection<ConfiguredDocumentClass<typeof documents.BaseMeasuredTemplate>, SceneData>;
 
   /**
    * A collection of embedded Tile objects.
+   * @defaultValue `[]`
    */
   tiles: EmbeddedCollection<ConfiguredDocumentClass<typeof documents.BaseTile>, SceneData>;
 
   /**
    * A collection of embedded Wall objects
+   * @defaultValue `[]`
    */
   walls: EmbeddedCollection<ConfiguredDocumentClass<typeof documents.BaseWall>, SceneData>;
 
@@ -326,7 +334,7 @@ interface SceneDataProperties {
 
   /**
    * A named weather effect which should be rendered in this Scene.
-   * @defaultValue `''`
+   * @defaultValue `""`
    */
   weather: string;
 
@@ -357,6 +365,7 @@ interface SceneDataProperties {
 interface SceneDataConstructorData {
   /**
    * The _id which uniquely identifies this Scene document
+   * @defaultValue `null`
    */
   _id?: string | null | undefined;
 
@@ -379,32 +388,30 @@ interface SceneDataConstructorData {
 
   /**
    * The integer sorting order of this Scene in the navigation bar relative to others
+   * @defaultValue `0`
    */
   navOrder?: number | null | undefined;
 
   /**
    * A string which overrides the canonical Scene name which is displayed in the navigation bar
-   * @defaultValue `''`
+   * @defaultValue `""`
    */
   navName?: string | null | undefined;
 
   /**
    * An image or video file path which provides the background media for the scene
-   * @defaultValue `undefined`
    */
-  img?: string | undefined | null | undefined;
+  img?: string | null | undefined;
 
   /**
    * An image or video file path which is drawn on top of all other elements in the scene
-   * @defaultValue `undefined`
    */
-  foreground?: string | undefined | null | undefined;
+  foreground?: string | null | undefined;
 
   /**
    * A thumbnail image (base64) or file path which visually summarizes the scene
-   * @defaultValue `undefined`
    */
-  thumb?: string | undefined | null | undefined;
+  thumb?: string | null | undefined;
 
   /**
    * The width of the scene canvas, this should normally be the width of the background media
@@ -475,11 +482,13 @@ interface SceneDataConstructorData {
 
   /**
    * The number of distance units which are represented by a single grid space.
+   * @defaultValue `game.system.data.gridDistance || 1`
    */
   gridDistance?: number | null | undefined;
 
   /**
    * A label for the units of measure which are used for grid distance.
+   * @defaultValue `game.system.data.gridUnits ?? ""`
    */
   gridUnits?: string | null | undefined;
 
@@ -497,6 +506,7 @@ interface SceneDataConstructorData {
 
   /**
    * The timestamp at which fog of war was last reset for this Scene.
+   * @defaultValue `Date.now()`
    */
   fogReset?: number | null | undefined;
 
@@ -522,66 +532,73 @@ interface SceneDataConstructorData {
 
   /**
    * A collection of embedded Drawing objects.
+   * @defaultValue `[]`
    */
-  drawings?: ConstructorDataType<DrawingData>[] | null | undefined;
+  drawings?: DrawingDataConstructorData[] | null | undefined;
 
   /**
    * A collection of embedded Token objects.
+   * @defaultValue `[]`
    */
-  tokens?: ConstructorDataType<TokenData>[] | null | undefined;
+  tokens?: TokenDataConstructorData[] | null | undefined;
 
   /**
-   *
    * A collection of embedded AmbientLight objects.
+   * @defaultValue `[]`
    */
-  lights?: ConstructorDataType<AmbientLightData>[] | null | undefined;
+  lights?: AmbientLightDataConstructorData[] | null | undefined;
 
   /**
    * A collection of embedded Note objects.
+   * @defaultValue `[]`
    */
-  notes?: ConstructorDataType<NoteData>[] | null | undefined;
+  notes?: NoteDataConstructorData[] | null | undefined;
 
   /**
    * A collection of embedded AmbientSound objects.
+   * @defaultValue `[]`
    */
-  sounds?: ConstructorDataType<AmbientSoundData>[] | null | undefined;
+  sounds?: AmbientSoundDataConstructorData[] | null | undefined;
 
   /**
    * A collection of embedded MeasuredTemplate objects.
+   * @defaultValue `[]`
    */
-  templates?: ConstructorDataType<MeasuredTemplateData>[] | null | undefined;
+  templates?: MeasuredTemplateDataConstructorData[] | null | undefined;
 
   /**
    * A collection of embedded Tile objects.
+   * @defaultValue `[]`
    */
-  tiles?: ConstructorDataType<TileData>[] | null | undefined;
+  tiles?: TileDataConstructorData[] | null | undefined;
 
   /**
    * A collection of embedded Wall objects
+   * @defaultValue `[]`
    */
-  walls?: ConstructorDataType<WallData>[] | null | undefined;
+  walls?: WallDataConstructorData[] | null | undefined;
 
   /**
    * A linked Playlist document which should begin automatically playing when this
    * Scene becomes active.
    * @defaultValue `null`
    */
-  playlist?: string | null | undefined;
+  playlist?: InstanceType<ConfiguredDocumentClass<typeof documents.BasePlaylist>> | string | null | undefined;
 
   /**
    * @defaultValue `null`
    */
-  playlistSound?: string | null | undefined;
+  playlistSound?: InstanceType<ConfiguredDocumentClass<typeof documents.BasePlaylistSound>> | string | null | undefined;
 
   /**
    * A linked JournalEntry document which provides narrative details about this Scene.
    * @defaultValue `null`
    */
-  journal?: string | null | undefined;
+  journal?: InstanceType<ConfiguredDocumentClass<typeof documents.BaseJournalEntry>> | string | null | undefined;
 
   /**
    * A named weather effect which should be rendered in this Scene.
-   * @defaultValue `''`
+   * @defaultValue `""`
    */
   weather?: string | null | undefined;
 
@@ -589,7 +606,7 @@ interface SceneDataConstructorData {
    * The _id of a Folder which contains this Actor
    * @defaultValue `null`
    */
-  folder?: string | null | undefined;
+  folder?: InstanceType<ConfiguredDocumentClass<typeof documents.BaseFolder>> | string | null | undefined;
 
   /**
    * The numeric sort value which orders this Actor relative to its siblings
@@ -613,7 +630,7 @@ interface SceneDataConstructorData {
  * The data schema for a Scene document.
  * @see BaseScene
  */
-export declare class SceneData extends DocumentData<
+export class SceneData extends DocumentData<
   SceneDataSchema,
   SceneDataProperties,
   PropertiesToSource<SceneDataProperties>,
@@ -625,6 +642,7 @@ export declare class SceneData extends DocumentData<
    */
   constructor(data: SceneDataConstructorData, document?: documents.BaseScene | null);
 
+  /** @override */
   static defineSchema(): SceneDataSchema;
 
   /** @override */
@@ -634,7 +652,7 @@ export declare class SceneData extends DocumentData<
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export declare interface SceneData extends SceneDataProperties {}
+export interface SceneData extends SceneDataProperties {}
 
 /**
  * Verify that the initial view position for a Scene is valid

--- a/src/foundry/common/data/data.mjs/sceneData.d.ts
+++ b/src/foundry/common/data/data.mjs/sceneData.d.ts
@@ -30,14 +30,14 @@ interface SceneDataSchema extends DocumentSchema {
   thumb: fields.ImageField;
   width: FieldReturnType<fields.PositiveIntegerField, { required: true; default: 4000 }>;
   height: FieldReturnType<fields.PositiveIntegerField, { required: true; default: 3000 }>;
-  padding: {
+  padding: DocumentField<Number> & {
     type: typeof Number;
     required: true;
     default: 0.25;
     validate: (p: unknown) => boolean;
     validation: 'Invalid {name} {field} which must be a number between 0 and 0.5';
   };
-  initial: {
+  initial: DocumentField<Object> & {
     type: typeof Object;
     required: false;
     nullable: true;
@@ -54,7 +54,7 @@ interface SceneDataSchema extends DocumentSchema {
       validationError: 'Invalid {name } {field} which must be a value in CONST.GRID_TYPES';
     }
   >;
-  grid: {
+  grid: DocumentField<Number> & {
     type: typeof Number;
     required: true;
     default: 100;
@@ -71,7 +71,7 @@ interface SceneDataSchema extends DocumentSchema {
   fogExploration: FieldReturnType<fields.BooleanField, { default: true }>;
   fogReset: fields.TimestampField;
   globalLight: fields.BooleanField;
-  globalLightThreshold: {
+  globalLightThreshold: DocumentField<Number> & {
     type: typeof Number;
     required: true;
     nullable: true;
@@ -86,7 +86,7 @@ interface SceneDataSchema extends DocumentSchema {
   notes: fields.EmbeddedCollectionField<typeof documents.BaseNote>;
   sounds: fields.EmbeddedCollectionField<typeof documents.BaseAmbientSound>;
   templates: fields.EmbeddedCollectionField<typeof documents.BaseMeasuredTemplate>;
-  tiles: fields.EmbeddedCollectionField<typeof documents.BaseToken>;
+  tiles: fields.EmbeddedCollectionField<typeof documents.BaseTile>;
   walls: fields.EmbeddedCollectionField<typeof documents.BaseWall>;
   playlist: fields.ForeignDocumentField<{ type: typeof documents.BasePlaylist; required: false }>;
   playlistSound: fields.ForeignDocumentField<{ type: typeof documents.BasePlaylistSound; required: false }>;
@@ -95,7 +95,7 @@ interface SceneDataSchema extends DocumentSchema {
   folder: fields.ForeignDocumentField<{ type: typeof documents.BaseFolder }>;
   sort: fields.IntegerSortField;
   permission: fields.DocumentPermissions;
-  flags: fields.BlankString;
+  flags: fields.ObjectField;
 }
 
 interface SceneDataProperties {

--- a/src/foundry/common/data/data.mjs/settingData.d.ts
+++ b/src/foundry/common/data/data.mjs/settingData.d.ts
@@ -4,26 +4,27 @@ import * as documents from '../../documents.mjs';
 import * as fields from '../fields.mjs';
 
 interface SettingDataSchema extends DocumentSchema {
-  _id: typeof fields.DOCUMENT_ID;
+  _id: fields.DocumentId;
   key: DocumentField<string> & {
     type: typeof String;
     required: true;
     validate: typeof _validateKeyFormat;
     validationError: 'Invalid setting key format which should be {scope}.{field}';
   };
-  value: FieldReturnType<typeof fields.JSON_FIELD, { required: true }>;
+  value: FieldReturnType<fields.JsonField, { required: true }>;
 }
 
 interface SettingDataProperties {
   /**
    * The _id which uniquely identifies this Setting document
+   * @defaultValue `null`
    */
   _id: string | null;
 
   /**
    * The setting key, a composite of \{scope\}.\{name\}
    */
-  key: string;
+  key: `${string}.${string}`;
 
   /**
    * The setting value, which may be any type of data
@@ -35,26 +36,27 @@ interface SettingDataProperties {
 interface SettingDataConstructorData {
   /**
    * The _id which uniquely identifies this Setting document
+   * @defaultValue `null`
    */
   _id?: string | null | undefined;
 
   /**
    * The setting key, a composite of \{scope\}.\{name\}
    */
-  key: string;
+  key: `${string}.${string}`;
 
   /**
    * The setting value, which may be any type of data
    * @remarks This is the stringified data
    */
-  value: string;
+  value: string | object;
 }
 
 /**
  * The data schema for a Setting document.
  * @see BaseSetting
  */
-export declare class SettingData extends DocumentData<
+export class SettingData extends DocumentData<
   SettingDataSchema,
   SettingDataProperties,
   PropertiesToSource<SettingDataProperties>,
@@ -68,11 +70,12 @@ export declare class SettingData extends DocumentData<
    */
   constructor(data: SettingDataConstructorData, document?: documents.BaseSetting | null);
 
+  /** @override */
   static defineSchema(): SettingDataSchema;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export declare interface SettingData extends SettingDataProperties {}
+export interface SettingData extends SettingDataProperties {}
 
 /**
  * Validate that each setting key matches the expected format

--- a/src/foundry/common/data/data.mjs/tableResultData.d.ts
+++ b/src/foundry/common/data/data.mjs/tableResultData.d.ts
@@ -16,7 +16,7 @@ interface TableResultDataSchema extends DocumentSchema {
   collection: fields.StringField;
   resultId: fields.StringField;
   weight: fields.PositiveIntegerField;
-  range: {
+  range: DocumentField<[number, number]> & {
     type: [typeof Number];
     required: true;
     default: [];

--- a/src/foundry/common/data/data.mjs/tableResultData.d.ts
+++ b/src/foundry/common/data/data.mjs/tableResultData.d.ts
@@ -7,7 +7,7 @@ interface TableResultDataSchema extends DocumentSchema {
   _id: fields.DocumentId;
   type: DocumentField<foundry.CONST.TABLE_RESULT_TYPES> & {
     type: typeof Number;
-    default: typeof CONST.TABLE_RESULT_TYPES.TEXT;
+    default: typeof foundry.CONST.TABLE_RESULT_TYPES.TEXT;
     validate: (t: unknown) => t is foundry.CONST.TABLE_RESULT_TYPES;
     validationError: 'Invalid TableResult type provided';
   };

--- a/src/foundry/common/data/data.mjs/tableResultData.d.ts
+++ b/src/foundry/common/data/data.mjs/tableResultData.d.ts
@@ -4,18 +4,18 @@ import { BaseTableResult } from '../../documents.mjs';
 import { fields } from '../module.mjs';
 
 interface TableResultDataSchema extends DocumentSchema {
-  _id: typeof fields.DOCUMENT_ID;
+  _id: fields.DocumentId;
   type: DocumentField<foundry.CONST.TABLE_RESULT_TYPES> & {
     type: typeof Number;
     default: typeof CONST.TABLE_RESULT_TYPES.TEXT;
     validate: (t: unknown) => t is foundry.CONST.TABLE_RESULT_TYPES;
     validationError: 'Invalid TableResult type provided';
   };
-  text: typeof fields.BLANK_STRING;
-  img: typeof fields.IMAGE_FIELD;
-  collection: typeof fields.STRING_FIELD;
-  resultId: typeof fields.STRING_FIELD;
-  weight: typeof fields.POSITIVE_INTEGER_FIELD;
+  text: fields.BlankString;
+  img: fields.ImageField;
+  collection: fields.StringField;
+  resultId: fields.StringField;
+  weight: fields.PositiveIntegerField;
   range: {
     type: [typeof Number];
     required: true;
@@ -23,8 +23,8 @@ interface TableResultDataSchema extends DocumentSchema {
     validate: typeof _isValidResultRange;
     validationError: 'Invalid TableResult range which must be a length-2 array of ascending integers';
   };
-  drawn: typeof fields.BOOLEAN_FIELD;
-  flags: typeof fields.OBJECT_FIELD;
+  drawn: fields.BooleanField;
+  flags: fields.ObjectField;
 }
 
 /**
@@ -50,13 +50,14 @@ interface TableResultDataProperties {
 
   /**
    * The text which describes the table result
+   * @defaultValue `""`
    */
   text: string;
 
   /**
    * An image file url that represents the table result
    */
-  img: string | undefined;
+  img: string | null | undefined;
 
   /**
    * A named collection from which this result is drawn
@@ -70,7 +71,6 @@ interface TableResultDataProperties {
 
   /**
    * The probabilistic weight of this result relative to other results
-   * @defaultValue `1`
    */
   weight: number | undefined;
 
@@ -108,29 +108,29 @@ interface TableResultDataConstructorData {
 
   /**
    * The text which describes the table result
+   * @defaultValue `""`
    */
   text?: string | null | undefined;
 
   /**
    * An image file url that represents the table result
    */
-  img?: string | undefined | null;
+  img?: string | null | undefined;
 
   /**
    * A named collection from which this result is drawn
    */
-  collection?: string | undefined | null;
+  collection?: string | null | undefined;
 
   /**
    * The _id of a Document within the collection this result references
    */
-  resultId?: string | undefined | null;
+  resultId?: string | null | undefined;
 
   /**
    * The probabilistic weight of this result relative to other results
-   * @defaultValue `1`
    */
-  weight?: number | undefined | null;
+  weight?: number | null | undefined;
 
   /**
    * A length 2 array of ascending integers which defines the range of dice roll
@@ -142,21 +142,22 @@ interface TableResultDataConstructorData {
    * Has this result already been drawn (without replacement)
    * @defaultValue `false`
    */
-  drawn?: boolean | undefined | null;
+  drawn?: boolean | null | undefined;
 
   /**
    * An object of optional key/value flags
    * @defaultValue `{}`
    */
-  flags?: ConfiguredFlags<'TableResult'> | undefined | null;
+  flags?: ConfiguredFlags<'TableResult'> | null | undefined;
 }
 
-export declare class TableResultData extends DocumentData<
+export class TableResultData extends DocumentData<
   TableResultDataSchema,
   TableResultDataProperties,
   PropertiesToSource<TableResultDataProperties>,
   TableResultDataConstructorData,
   BaseTableResult
 > {
+  /** @override */
   static defineSchema(): TableResultDataSchema;
 }

--- a/src/foundry/common/data/data.mjs/tileData.d.ts
+++ b/src/foundry/common/data/data.mjs/tileData.d.ts
@@ -1,40 +1,41 @@
-import { TileOcclusion, TileOcclusionConstructorData } from './tileOcclusion';
-import { VideoData, VideoDataConstructorData } from './videoData';
 import { ConfiguredFlags, FieldReturnType, PropertiesToSource } from '../../../../types/helperTypes';
 import DocumentData from '../../abstract/data.mjs';
 import * as documents from '../../documents.mjs';
 import * as fields from '../fields.mjs';
+import { TileOcclusion, TileOcclusionConstructorData } from './tileOcclusion';
+import { VideoData, VideoDataConstructorData } from './videoData';
 
 interface TileDataSchema extends DocumentSchema {
-  _id: typeof fields.DOCUMENT_ID;
-  img: typeof fields.VIDEO_FIELD;
-  width: typeof fields.REQUIRED_NUMBER;
-  height: typeof fields.REQUIRED_NUMBER;
-  x: typeof fields.REQUIRED_NUMBER;
-  y: typeof fields.REQUIRED_NUMBER;
-  z: FieldReturnType<typeof fields.INTEGER_FIELD, { required: true; default: 100 }>;
-  rotation: FieldReturnType<typeof fields.ANGLE_FIELD, { default: 0 }>;
-  alpha: typeof fields.ALPHA_FIELD;
-  tint: typeof fields.COLOR_FIELD;
-  hidden: typeof fields.BOOLEAN_FIELD;
-  locked: typeof fields.BOOLEAN_FIELD;
-  overhead: FieldReturnType<typeof fields.BOOLEAN_FIELD, { default: false }>;
+  _id: fields.DocumentId;
+  img: fields.VideoField;
+  width: fields.RequiredNumber;
+  height: fields.RequiredNumber;
+  x: fields.RequiredNumber;
+  y: fields.RequiredNumber;
+  z: FieldReturnType<fields.IntegerField, { required: true; default: 100 }>;
+  rotation: FieldReturnType<fields.AngleField, { default: 0 }>;
+  alpha: fields.AlphaField;
+  tint: fields.ColorField;
+  hidden: fields.BooleanField;
+  locked: fields.BooleanField;
+  overhead: FieldReturnType<fields.BooleanField, { default: false }>;
   occlusion: DocumentField<TileOcclusion> & {
     type: typeof TileOcclusion;
     required: false;
-    default: {};
+    default: Record<string, never>;
   };
   video: DocumentField<VideoData> & {
     type: typeof VideoData;
     required: false;
-    default: {};
+    default: Record<string, never>;
   };
-  flags: typeof fields.OBJECT_FIELD;
+  flags: fields.ObjectField;
 }
 
 interface TileDataProperties {
   /**
    * The _id which uniquely identifies this Tile embedded document
+   * @defaultValue `null`
    */
   _id: string | null;
 
@@ -110,11 +111,13 @@ interface TileDataProperties {
 
   /**
    * The tile's occlusion settings
+   * @defaultValue `new TileOcclusion({})`
    */
   occlusion: TileOcclusion;
 
   /**
    * The tile's video settings
+   * @defaultValue `new VideoData({})`
    */
   video: VideoData;
 
@@ -128,6 +131,7 @@ interface TileDataProperties {
 interface TileDataConstructorData {
   /**
    * The _id which uniquely identifies this Tile embedded document
+   * @defaultValue `null`
    */
   _id?: string | null | undefined;
 
@@ -203,11 +207,13 @@ interface TileDataConstructorData {
 
   /**
    * The tile's occlusion settings
+   * @defaultValue `new TileOcclusion({})`
    */
   occlusion?: TileOcclusionConstructorData | null | undefined;
 
   /**
    * The tile's video settings
+   * @defaultValue `new VideoData({})`
    */
   video?: VideoDataConstructorData | null | undefined;
 
@@ -222,13 +228,14 @@ interface TileDataConstructorData {
  * The data schema for a Tile embedded document.
  * @see BaseTile
  */
-export declare class TileData extends DocumentData<
+export class TileData extends DocumentData<
   TileDataSchema,
   TileDataProperties,
   PropertiesToSource<TileDataProperties>,
   TileDataConstructorData,
   documents.BaseTile
 > {
+  /** @override */
   static defineSchema(): TileDataSchema;
 
   /** @override */
@@ -236,4 +243,4 @@ export declare class TileData extends DocumentData<
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export declare interface TileData extends TileDataProperties {}
+export interface TileData extends TileDataProperties {}

--- a/src/foundry/common/data/data.mjs/tileOcclusion.d.ts
+++ b/src/foundry/common/data/data.mjs/tileOcclusion.d.ts
@@ -7,7 +7,7 @@ interface TileOcclusionSchema extends DocumentSchema {
   mode: FieldReturnType<
     fields.RequiredNumber,
     {
-      default: typeof CONST.TILE_OCCLUSION_MODES.FADE;
+      default: typeof foundry.CONST.TILE_OCCLUSION_MODES.FADE;
       validate: (m: unknown) => m is foundry.CONST.TILE_OCCLUSION_MODES;
       validationError: 'Invalid {name} {field} which must be a value in CONST.TILE_OCCLUSION_MODES';
     }

--- a/src/foundry/common/data/data.mjs/tileOcclusion.d.ts
+++ b/src/foundry/common/data/data.mjs/tileOcclusion.d.ts
@@ -5,14 +5,14 @@ import * as fields from '../fields.mjs';
 
 interface TileOcclusionSchema extends DocumentSchema {
   mode: FieldReturnType<
-    typeof fields.REQUIRED_NUMBER,
+    fields.RequiredNumber,
     {
       default: typeof CONST.TILE_OCCLUSION_MODES.FADE;
       validate: (m: unknown) => m is foundry.CONST.TILE_OCCLUSION_MODES;
       validationError: 'Invalid {name} {field} which must be a value in CONST.TILE_OCCLUSION_MODES';
     }
   >;
-  alpha: FieldReturnType<typeof fields.ALPHA_FIELD, { default: 0 }>;
+  alpha: FieldReturnType<fields.AlphaField, { default: 0 }>;
 }
 
 interface TileOcclusionProperties {
@@ -29,7 +29,7 @@ interface TileOcclusionProperties {
   alpha: number;
 }
 
-export interface TileOcclusionConstructorData {
+interface TileOcclusionConstructorData {
   /**
    * The occlusion mode from CONST.TILE_OCCLUSION_MODES
    * @defaultValue `CONST.TILE_OCCLUSION_MODES.FADE`
@@ -46,13 +46,14 @@ export interface TileOcclusionConstructorData {
 /**
  * An inner-object which defines the schema for how Tile occlusion settings are defined
  */
-export declare class TileOcclusion extends DocumentData<
+export class TileOcclusion extends DocumentData<
   TileOcclusionSchema,
   TileOcclusionProperties,
   PropertiesToSource<TileOcclusionProperties>,
   TileOcclusionConstructorData,
   documents.BaseTile
 > {
+  /** @override */
   static defineSchema(): TileOcclusionSchema;
 }
 

--- a/src/foundry/common/data/data.mjs/tokenBarData.d.ts
+++ b/src/foundry/common/data/data.mjs/tokenBarData.d.ts
@@ -19,7 +19,7 @@ interface TokenBarDataProperties {
   attribute: string | null;
 }
 
-export interface TokenBarDataConstructorData {
+interface TokenBarDataConstructorData {
   /**
    * The attribute path within the Token's Actor data which should be displayed
    * @defaultValue `null`
@@ -31,13 +31,14 @@ export interface TokenBarDataConstructorData {
  * An embedded data structure for the contents of a Token attribute bar.
  * @see TokenData
  */
-export declare class TokenBarData extends DocumentData<
+export class TokenBarData extends DocumentData<
   TokenBarDataSchema,
   TokenBarDataProperties,
   PropertiesToSource<TokenBarDataProperties>,
   TokenBarDataConstructorData,
   documents.BaseToken
 > {
+  /** @override */
   static defineSchema(): TokenBarDataSchema;
 }
 

--- a/src/foundry/common/data/data.mjs/tokenData.d.ts
+++ b/src/foundry/common/data/data.mjs/tokenData.d.ts
@@ -5,7 +5,7 @@ import {
   PropertiesToSource
 } from '../../../../types/helperTypes';
 import DocumentData from '../../abstract/data.mjs';
-import { CONST, documents } from '../../module.mjs';
+import { documents } from '../../module.mjs';
 import * as fields from '../fields.mjs';
 import { ActorDataSource } from './actorData.js';
 import { AnimationData, AnimationDataConstructorData } from './animationData';
@@ -19,10 +19,10 @@ interface VisionFieldOptions {
 interface TokenDataSchema extends DocumentSchema {
   _id: fields.DocumentId;
   name: fields.StringField;
-  displayName: DocumentField<CONST.TOKEN_DISPLAY_MODES> & {
+  displayName: DocumentField<foundry.CONST.TOKEN_DISPLAY_MODES> & {
     type: typeof Number;
     required: true;
-    default: typeof CONST.TOKEN_DISPLAY_MODES.NONE;
+    default: typeof foundry.CONST.TOKEN_DISPLAY_MODES.NONE;
     validate: (m: any) => boolean;
     validationError: 'Invalid {name} {field} which must be a value in CONST.TOKEN_DISPLAY_MODES';
   };
@@ -73,17 +73,17 @@ interface TokenDataSchema extends DocumentSchema {
     required: true;
     default: Record<string, never>;
   };
-  disposition: DocumentField<CONST.TOKEN_DISPOSITIONS> & {
+  disposition: DocumentField<foundry.CONST.TOKEN_DISPOSITIONS> & {
     type: typeof Number;
     required: true;
-    default: typeof CONST.TOKEN_DISPOSITIONS.HOSTILE;
+    default: typeof foundry.CONST.TOKEN_DISPOSITIONS.HOSTILE;
     validate: (n: any) => boolean;
     validationError: 'Invalid {name} {field} which must be a value in CONST.TOKEN_DISPOSITIONS';
   };
-  displayBars: DocumentField<CONST.TOKEN_DISPLAY_MODES> & {
+  displayBars: DocumentField<foundry.CONST.TOKEN_DISPLAY_MODES> & {
     type: typeof Number;
     required: true;
-    default: typeof CONST.TOKEN_DISPLAY_MODES.NONE;
+    default: typeof foundry.CONST.TOKEN_DISPLAY_MODES.NONE;
     validate: (m: any) => boolean;
     validationError: 'Invalid {name} {field} which must be a value in CONST.TOKEN_DISPLAY_MODES';
   };
@@ -116,7 +116,7 @@ interface TokenDataProperties {
    * The display mode of the Token nameplate, from CONST.TOKEN_DISPLAY_MODES
    * @defaultValue `CONST.TOKEN_DISPLAY_MODES.NONE`
    */
-  displayName: CONST.TOKEN_DISPLAY_MODES;
+  displayName: foundry.CONST.TOKEN_DISPLAY_MODES;
 
   /**
    * The _id of an Actor document which this Token represents
@@ -293,13 +293,13 @@ interface TokenDataProperties {
    * A displayed Token disposition from CONST.TOKEN_DISPOSITIONS
    * @defaultValue `CONST.TOKEN_DISPOSITIONS.HOSTILE`
    */
-  disposition: CONST.TOKEN_DISPOSITIONS;
+  disposition: foundry.CONST.TOKEN_DISPOSITIONS;
 
   /**
    * The display mode of Token resource bars, from CONST.TOKEN_DISPLAY_MODES
    * @defaultValue `CONST.TOKEN_DISPLAY_MODES.NONE`
    */
-  displayBars: CONST.TOKEN_DISPLAY_MODES;
+  displayBars: foundry.CONST.TOKEN_DISPLAY_MODES;
 
   /**
    * The configuration of the Token's primary resource bar
@@ -336,7 +336,7 @@ interface TokenDataConstructorData {
    * The display mode of the Token nameplate, from CONST.TOKEN_DISPLAY_MODES
    * @defaultValue `CONST.TOKEN_DISPLAY_MODES.NONE`
    */
-  displayName?: CONST.TOKEN_DISPLAY_MODES | null | undefined;
+  displayName?: foundry.CONST.TOKEN_DISPLAY_MODES | null | undefined;
 
   /**
    * The _id of an Actor document which this Token represents
@@ -513,13 +513,13 @@ interface TokenDataConstructorData {
    * A displayed Token disposition from CONST.TOKEN_DISPOSITIONS
    * @defaultValue `CONST.TOKEN_DISPOSITIONS.HOSTILE`
    */
-  disposition?: CONST.TOKEN_DISPOSITIONS | null | undefined;
+  disposition?: foundry.CONST.TOKEN_DISPOSITIONS | null | undefined;
 
   /**
    * The display mode of Token resource bars, from CONST.TOKEN_DISPLAY_MODES
    * @defaultValue `CONST.TOKEN_DISPLAY_MODES.NONE`
    */
-  displayBars?: CONST.TOKEN_DISPLAY_MODES | null | undefined;
+  displayBars?: foundry.CONST.TOKEN_DISPLAY_MODES | null | undefined;
 
   /**
    * The configuration of the Token's primary resource bar

--- a/src/foundry/common/data/data.mjs/tokenData.d.ts
+++ b/src/foundry/common/data/data.mjs/tokenData.d.ts
@@ -1,19 +1,24 @@
+import {
+  ConfiguredDocumentClass,
+  ConfiguredFlags,
+  FieldReturnType,
+  PropertiesToSource
+} from '../../../../types/helperTypes';
 import DocumentData from '../../abstract/data.mjs';
-import { ConfiguredFlags, FieldReturnType, PropertiesToSource } from '../../../../types/helperTypes';
 import { CONST, documents } from '../../module.mjs';
 import * as fields from '../fields.mjs';
+import { ActorDataSource } from './actorData.js';
 import { AnimationData, AnimationDataConstructorData } from './animationData';
 import { TokenBarData, TokenBarDataConstructorData } from './tokenBarData';
-import { ActorDataSource } from './actorData.js';
 
 interface VisionFieldOptions {
   validate: (d: number) => boolean;
   validationError: 'Invalid {name} {field} distance which must be a number with absolute value less than 1000';
 }
 
-export interface TokenDataSchema extends DocumentSchema {
-  _id: typeof fields.DOCUMENT_ID;
-  name: typeof fields.STRING_FIELD;
+interface TokenDataSchema extends DocumentSchema {
+  _id: fields.DocumentId;
+  name: fields.StringField;
   displayName: DocumentField<CONST.TOKEN_DISPLAY_MODES> & {
     type: typeof Number;
     required: true;
@@ -22,12 +27,12 @@ export interface TokenDataSchema extends DocumentSchema {
     validationError: 'Invalid {name} {field} which must be a value in CONST.TOKEN_DISPLAY_MODES';
   };
   actorId: fields.ForeignDocumentField<{ type: documents.BaseActor; required: true }>;
-  actorLink: typeof fields.BOOLEAN_FIELD;
-  actorData: typeof fields.OBJECT_FIELD;
-  img: FieldReturnType<typeof fields.VIDEO_FIELD, { default: () => string }>;
-  tint: typeof fields.COLOR_FIELD;
-  width: FieldReturnType<typeof fields.REQUIRED_POSITIVE_NUMBER, { default: number }>;
-  height: FieldReturnType<typeof fields.REQUIRED_POSITIVE_NUMBER, { default: number }>;
+  actorLink: fields.BooleanField;
+  actorData: fields.ObjectField;
+  img: FieldReturnType<fields.VideoField, { default: () => typeof TokenData.DEFAULT_ICON }>;
+  tint: fields.ColorField;
+  width: FieldReturnType<fields.RequiredPositiveNumber, { default: 1 }>;
+  height: FieldReturnType<fields.RequiredPositiveNumber, { default: 1 }>;
   scale: DocumentField<number> & {
     type: typeof Number;
     required: true;
@@ -35,38 +40,38 @@ export interface TokenDataSchema extends DocumentSchema {
     validate: (s: unknown) => boolean;
     validationError: 'Invalid {name} {field} which must be a number between 0.25 and 10';
   };
-  mirrorX: typeof fields.BOOLEAN_FIELD;
-  mirrorY: typeof fields.BOOLEAN_FIELD;
-  x: typeof fields.REQUIRED_NUMBER;
-  y: typeof fields.REQUIRED_NUMBER;
-  elevation: typeof fields.REQUIRED_NUMBER;
-  lockRotation: typeof fields.BOOLEAN_FIELD;
-  rotation: FieldReturnType<typeof fields.ANGLE_FIELD, { default: number }>;
+  mirrorX: fields.BooleanField;
+  mirrorY: fields.BooleanField;
+  x: fields.RequiredNumber;
+  y: fields.RequiredNumber;
+  elevation: fields.RequiredNumber;
+  lockRotation: fields.BooleanField;
+  rotation: FieldReturnType<fields.AngleField, { default: 0 }>;
   effects: DocumentField<string[]> & {
     type: [typeof String];
     required: true;
     default: string[];
   };
-  overlayEffect: typeof fields.STRING_FIELD;
-  alpha: typeof fields.ALPHA_FIELD;
-  hidden: typeof fields.BOOLEAN_FIELD;
+  overlayEffect: fields.StringField;
+  alpha: fields.AlphaField;
+  hidden: fields.BooleanField;
   vision: DocumentField<boolean> & {
     type: typeof Boolean;
     required: true;
     default: (data: { readonly dimSight?: number; readonly brightSight?: number }) => boolean;
   };
-  dimSight: FieldReturnType<typeof fields.REQUIRED_NUMBER, VisionFieldOptions>;
-  brightSight: FieldReturnType<typeof fields.REQUIRED_NUMBER, VisionFieldOptions>;
-  dimLight: FieldReturnType<typeof fields.REQUIRED_NUMBER, VisionFieldOptions>;
-  brightLight: FieldReturnType<typeof fields.REQUIRED_NUMBER, VisionFieldOptions>;
-  sightAngle: typeof fields.ANGLE_FIELD;
-  lightAngle: typeof fields.ANGLE_FIELD;
-  lightColor: typeof fields.COLOR_FIELD;
-  lightAlpha: FieldReturnType<typeof fields.ALPHA_FIELD, { default: 0.25 }>;
+  dimSight: FieldReturnType<fields.RequiredNumber, VisionFieldOptions>;
+  brightSight: FieldReturnType<fields.RequiredNumber, VisionFieldOptions>;
+  dimLight: FieldReturnType<fields.RequiredNumber, VisionFieldOptions>;
+  brightLight: FieldReturnType<fields.RequiredNumber, VisionFieldOptions>;
+  sightAngle: fields.AngleField;
+  lightAngle: fields.AngleField;
+  lightColor: fields.ColorField;
+  lightAlpha: FieldReturnType<fields.AlphaField, { default: 0.25 }>;
   lightAnimation: DocumentField<AnimationData> & {
     type: typeof AnimationData;
     required: true;
-    default: {};
+    default: Record<string, never>;
   };
   disposition: DocumentField<CONST.TOKEN_DISPOSITIONS> & {
     type: typeof Number;
@@ -92,10 +97,10 @@ export interface TokenDataSchema extends DocumentSchema {
     required: true;
     default: () => { attribute: Game['system']['data']['secondaryTokenAttribute'] | null };
   };
-  flags: typeof fields.OBJECT_FIELD;
+  flags: fields.ObjectField;
 }
 
-export interface TokenDataProperties {
+interface TokenDataProperties {
   /**
    * The Token _id which uniquely identifies it within its parent Scene
    * @defaultValue `null`
@@ -133,14 +138,14 @@ export interface TokenDataProperties {
 
   /**
    * A file path to an image or video file used to depict the Token
-   * @defaultValue `this.DEFAULT_ICON`
+   * @defaultValue `TokenData.DEFAULT_ICON`
    */
   img: string | null;
 
   /**
    * An optional color tint applied to the Token image
    */
-  tint?: string | null;
+  tint: string | null | undefined;
 
   /**
    * The width of the Token in grid units
@@ -211,7 +216,7 @@ export interface TokenDataProperties {
   /**
    * A single icon path which is displayed as an overlay on the Token
    */
-  overlayEffect?: string;
+  overlayEffect: string | undefined;
 
   /**
    * The opacity of the token image
@@ -270,7 +275,7 @@ export interface TokenDataProperties {
   /**
    * The color of the token's emitted light as an HTML hexadecimal color string
    */
-  lightColor: string | undefined | null;
+  lightColor: string | null | undefined;
 
   /**
    * The intensity of any light emitted by the token
@@ -280,7 +285,7 @@ export interface TokenDataProperties {
 
   /**
    * A data object which configures token light animation settings
-   * @defaultValue `{}`
+   * @defaultValue `new AnimationData({})`
    */
   lightAnimation: AnimationData;
 
@@ -298,13 +303,13 @@ export interface TokenDataProperties {
 
   /**
    * The configuration of the Token's primary resource bar
-   * @defaultValue `{ attribute: game?.system.data.primaryTokenAttribute || null }`
+   * @defaultValue `new TokenBarData({ attribute: game?.system.data.primaryTokenAttribute || null })`
    */
   bar1: TokenBarData;
 
   /**
    * The configuration of the Token's secondary resource bar
-   * @defaultValue `{ attribute: game?.system.data.secondaryTokenAttribute || null }`
+   * @defaultValue `new TokenBarData({ attribute: game?.system.data.secondaryTokenAttribute || null })`
    */
   bar2: TokenBarData;
 
@@ -315,7 +320,7 @@ export interface TokenDataProperties {
   flags: ConfiguredFlags<'Token'>;
 }
 
-export interface TokenDataConstructorData {
+interface TokenDataConstructorData {
   /**
    * The Token _id which uniquely identifies it within its parent Scene
    * @defaultValue `null`
@@ -337,7 +342,7 @@ export interface TokenDataConstructorData {
    * The _id of an Actor document which this Token represents
    * @defaultValue `null`
    */
-  actorId?: string | null | undefined;
+  actorId?: InstanceType<ConfiguredDocumentClass<typeof documents.BaseActor>> | string | null | undefined;
 
   /**
    * Does this Token uniquely represent a singular Actor, or is it one of many?
@@ -353,7 +358,7 @@ export interface TokenDataConstructorData {
 
   /**
    * A file path to an image or video file used to depict the Token
-   * @defaultValue `this.DEFAULT_ICON`
+   * @defaultValue `TokenData.DEFAULT_ICON`
    */
   img?: string | null | undefined;
 
@@ -500,7 +505,7 @@ export interface TokenDataConstructorData {
 
   /**
    * A data object which configures token light animation settings
-   * @defaultValue `{}`
+   * @defaultValue `new AnimationData({})`
    */
   lightAnimation?: AnimationDataConstructorData | null | undefined;
 
@@ -518,13 +523,13 @@ export interface TokenDataConstructorData {
 
   /**
    * The configuration of the Token's primary resource bar
-   * @defaultValue `{ attribute: game?.system.data.primaryTokenAttribute || null }`
+   * @defaultValue `new TokenBarData({ attribute: game?.system.data.primaryTokenAttribute || null })`
    */
   bar1?: TokenBarDataConstructorData | null | undefined;
 
   /**
    * The configuration of the Token's secondary resource bar
-   * @defaultValue `{ attribute: game?.system.data.secondaryTokenAttribute || null }`
+   * @defaultValue `new TokenBarData({ attribute: game?.system.data.secondaryTokenAttribute || null })`
    */
   bar2?: TokenBarDataConstructorData | null | undefined;
 
@@ -545,6 +550,7 @@ export class TokenData extends DocumentData<
   TokenDataConstructorData,
   documents.BaseToken
 > {
+  /** @override */
   static defineSchema(): TokenDataSchema;
 
   /**
@@ -555,4 +561,4 @@ export class TokenData extends DocumentData<
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export declare interface TokenData extends TokenDataProperties {}
+export interface TokenData extends TokenDataProperties {}

--- a/src/foundry/common/data/data.mjs/userData.d.ts
+++ b/src/foundry/common/data/data.mjs/userData.d.ts
@@ -1,26 +1,31 @@
-import { ConfiguredFlags, FieldReturnType, PropertiesToSource } from '../../../../types/helperTypes';
+import {
+  ConfiguredDocumentClass,
+  ConfiguredFlags,
+  FieldReturnType,
+  PropertiesToSource
+} from '../../../../types/helperTypes';
 import DocumentData from '../../abstract/data.mjs';
-import * as fields from '../fields.mjs';
 import * as documents from '../../documents.mjs';
+import * as fields from '../fields.mjs';
 
 interface UserDataSchema extends DocumentSchema {
-  _id: typeof fields.DOCUMENT_ID;
-  avatar: typeof fields.IMAGE_FIELD;
+  _id: fields.DocumentId;
+  avatar: fields.ImageField;
   character: fields.ForeignDocumentField<{ type: typeof documents.BaseActor; required: false }>;
-  color: FieldReturnType<typeof fields.COLOR_FIELD, { required: true }>;
-  hotbar: DocumentField<Record<number | string, string>> & {
+  color: FieldReturnType<fields.ColorField, { required: true }>;
+  hotbar: DocumentField<Record<number | `${number}`, string>> & {
     required: true;
-    default: Record<never, never>;
+    default: Record<number | `${number}`, never>;
     validate: typeof _validateHotbar;
     validationError: 'Invalid User hotbar data structure';
   };
-  name: typeof fields.REQUIRED_STRING;
-  password: typeof fields.BLANK_STRING;
-  passwordSalt: typeof fields.STRING_FIELD;
+  name: fields.RequiredString;
+  password: fields.BlankString;
+  passwordSalt: fields.StringField;
   permissions: FieldReturnType<
-    typeof fields.DOCUMENT_PERMISSIONS,
+    fields.DocumentPermissions,
     {
-      default: Record<never, never>;
+      default: Record<string, never>;
       validate: typeof _validatePermissions;
     }
   >;
@@ -29,41 +34,73 @@ interface UserDataSchema extends DocumentSchema {
     nullable: false;
     default: typeof CONST.USER_ROLES.PLAYER;
   };
-  flags: typeof fields.OBJECT_FIELD;
+  flags: fields.ObjectField;
 }
 
 interface UserDataProperties {
+  /** @defaultValue `null` */
   _id: string | null;
+
   avatar: string | null | undefined;
+
   character: string | null;
-  color: string | null;
-  hotbar: Record<number | string, string>;
+
+  color: string | null | undefined;
+
+  /** @defaultValue `{}` */
+  hotbar: Record<number | `${number}`, string>;
+
   name: string;
+
+  /** @defaultValue `""` */
   password: string;
+
   passwordSalt: string | undefined;
+
+  /** @defaultValue `{}` */
   permissions: Partial<Record<keyof typeof CONST.USER_PERMISSIONS, boolean>>;
+
+  /** @defaultValue `foundry.CONST.USER_ROLES.PLAYER` */
   role: foundry.CONST.USER_ROLES;
+
+  /** @defaultValue `{}` */
   flags: ConfiguredFlags<'User'>;
 }
 
 interface UserDataConstructorData {
+  /** @defaultValue `null` */
   _id?: string | null | undefined;
+
   avatar?: string | null | undefined;
-  character?: string | null | undefined;
+
+  character?: InstanceType<ConfiguredDocumentClass<typeof documents.BaseActor>> | string | null | undefined;
+
   color?: string | null | undefined;
-  hotbar?: Record<number | string, string> | null | undefined;
+
+  /** @defaultValue `{}` */
+  hotbar?: Record<number | `${number}`, string> | null | undefined;
+
   name: string;
+
+  /** @defaultValue `""` */
   password?: string | null | undefined;
+
   passwordSalt?: string | null | undefined;
+
+  /** @defaultValue `{}` */
   permissions?: Partial<Record<keyof typeof CONST.USER_PERMISSIONS, boolean>> | null | undefined;
+
+  /** @defaultValue `foundry.CONST.USER_ROLES.PLAYER` */
   role?: foundry.CONST.USER_ROLES | null | undefined;
+
+  /** @defaultValue `{}` */
   flags?: ConfiguredFlags<'User'> | null | undefined;
 }
 
 /**
  * The data schema for a User document
  */
-export declare class UserData extends DocumentData<
+export class UserData extends DocumentData<
   UserDataSchema,
   UserDataProperties,
   PropertiesToSource<UserDataProperties>,
@@ -72,11 +109,12 @@ export declare class UserData extends DocumentData<
 > {
   constructor(data: UserDataConstructorData, document?: documents.BaseUser | null);
 
+  /** @override */
   static defineSchema(): UserDataSchema;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export declare interface UserData extends UserDataProperties {}
+export interface UserData extends UserDataProperties {}
 
 /**
  * Validate the structure of the User hotbar object

--- a/src/foundry/common/data/data.mjs/userData.d.ts
+++ b/src/foundry/common/data/data.mjs/userData.d.ts
@@ -32,7 +32,7 @@ interface UserDataSchema extends DocumentSchema {
   role: DocumentField<foundry.CONST.USER_ROLES> & {
     required: true;
     nullable: false;
-    default: typeof CONST.USER_ROLES.PLAYER;
+    default: typeof foundry.CONST.USER_ROLES.PLAYER;
   };
   flags: fields.ObjectField;
 }
@@ -58,7 +58,7 @@ interface UserDataProperties {
   passwordSalt: string | undefined;
 
   /** @defaultValue `{}` */
-  permissions: Partial<Record<keyof typeof CONST.USER_PERMISSIONS, boolean>>;
+  permissions: Partial<Record<keyof typeof foundry.CONST.USER_PERMISSIONS, boolean>>;
 
   /** @defaultValue `foundry.CONST.USER_ROLES.PLAYER` */
   role: foundry.CONST.USER_ROLES;
@@ -88,7 +88,7 @@ interface UserDataConstructorData {
   passwordSalt?: string | null | undefined;
 
   /** @defaultValue `{}` */
-  permissions?: Partial<Record<keyof typeof CONST.USER_PERMISSIONS, boolean>> | null | undefined;
+  permissions?: Partial<Record<keyof typeof foundry.CONST.USER_PERMISSIONS, boolean>> | null | undefined;
 
   /** @defaultValue `foundry.CONST.USER_ROLES.PLAYER` */
   role?: foundry.CONST.USER_ROLES | null | undefined;

--- a/src/foundry/common/data/data.mjs/userData.d.ts
+++ b/src/foundry/common/data/data.mjs/userData.d.ts
@@ -29,7 +29,7 @@ interface UserDataSchema extends DocumentSchema {
       validate: typeof _validatePermissions;
     }
   >;
-  role: DocumentField<number> & {
+  role: DocumentField<foundry.CONST.USER_ROLES> & {
     required: true;
     nullable: false;
     default: typeof CONST.USER_ROLES.PLAYER;

--- a/src/foundry/common/data/data.mjs/videoData.d.ts
+++ b/src/foundry/common/data/data.mjs/videoData.d.ts
@@ -4,9 +4,9 @@ import { documents } from '../../module.mjs';
 import * as fields from '../fields.mjs';
 
 interface VideoDataSchema extends DocumentSchema {
-  loop: FieldReturnType<typeof fields.BOOLEAN_FIELD, { default: true }>;
-  autoplay: FieldReturnType<typeof fields.BOOLEAN_FIELD, { default: true }>;
-  volume: FieldReturnType<typeof fields.ALPHA_FIELD, { default: 0 }>;
+  loop: FieldReturnType<fields.BooleanField, { default: true }>;
+  autoplay: FieldReturnType<fields.BooleanField, { default: true }>;
+  volume: FieldReturnType<fields.AlphaField, { default: 0 }>;
 }
 
 interface VideoDataProperties {
@@ -29,7 +29,7 @@ interface VideoDataProperties {
   volume: number;
 }
 
-export interface VideoDataConstructorData {
+interface VideoDataConstructorData {
   /**
    * Automatically loop the video?
    * @defaultValue `true`
@@ -52,13 +52,14 @@ export interface VideoDataConstructorData {
 /**
  * An inner-object which defines the schema for how Tile video backgrounds are managed
  */
-export declare class VideoData extends DocumentData<
+export class VideoData extends DocumentData<
   VideoDataSchema,
   VideoDataProperties,
   PropertiesToSource<VideoDataProperties>,
   VideoDataConstructorData,
   documents.BaseTile
 > {
+  /** @override */
   static defineSchema(): VideoDataSchema;
 
   /** @override */

--- a/src/foundry/common/data/data.mjs/wallData.d.ts
+++ b/src/foundry/common/data/data.mjs/wallData.d.ts
@@ -14,7 +14,7 @@ interface WallDataSchema extends DocumentSchema {
   move: FieldReturnType<
     fields.RequiredNumber,
     {
-      default: typeof CONST.WALL_MOVEMENT_TYPES.NORMAL;
+      default: typeof foundry.CONST.WALL_MOVEMENT_TYPES.NORMAL;
       validate: (v: unknown) => v is foundry.CONST.WALL_MOVEMENT_TYPES;
       validationError: 'Invalid {name} {field} which must be a value in CONST.WALL_MOVEMENT_TYPES';
     }
@@ -22,7 +22,7 @@ interface WallDataSchema extends DocumentSchema {
   sense: FieldReturnType<
     fields.RequiredNumber,
     {
-      default: typeof CONST.WALL_SENSE_TYPES.NORMAL;
+      default: typeof foundry.CONST.WALL_SENSE_TYPES.NORMAL;
       validate: (v: unknown) => v is foundry.CONST.WALL_SENSE_TYPES;
       validationError: 'Invalid {name} {field} which must be a value in CONST.WALL_SENSE_TYPES';
     }
@@ -30,7 +30,7 @@ interface WallDataSchema extends DocumentSchema {
   sound: FieldReturnType<
     fields.RequiredNumber,
     {
-      default: typeof CONST.WALL_SENSE_TYPES.NORMAL;
+      default: typeof foundry.CONST.WALL_SENSE_TYPES.NORMAL;
       validate: (v: unknown) => v is foundry.CONST.WALL_SENSE_TYPES;
       validationError: 'Invalid {name} {field} which must be a value in CONST.WALL_SENSE_TYPES';
     }
@@ -38,7 +38,7 @@ interface WallDataSchema extends DocumentSchema {
   dir: FieldReturnType<
     fields.RequiredNumber,
     {
-      default: typeof CONST.WALL_DIRECTIONS.BOTH;
+      default: typeof foundry.CONST.WALL_DIRECTIONS.BOTH;
       validate: (v: unknown) => v is foundry.CONST.WALL_DIRECTIONS;
       validationError: 'Invalid {name} {field} which must be a value in CONST.WALL_DIRECTIONS';
     }
@@ -46,7 +46,7 @@ interface WallDataSchema extends DocumentSchema {
   door: FieldReturnType<
     fields.RequiredNumber,
     {
-      default: typeof CONST.WALL_DOOR_TYPES.NONE;
+      default: typeof foundry.CONST.WALL_DOOR_TYPES.NONE;
       validate: (v: unknown) => v is foundry.CONST.WALL_DOOR_TYPES;
       validationError: 'Invalid {name} {field} which must be a value in CONST.WALL_DOOR_TYPES';
     }
@@ -54,7 +54,7 @@ interface WallDataSchema extends DocumentSchema {
   ds: FieldReturnType<
     fields.RequiredNumber,
     {
-      default: typeof CONST.WALL_DOOR_STATES.CLOSED;
+      default: typeof foundry.CONST.WALL_DOOR_STATES.CLOSED;
       validate: (v: unknown) => v is foundry.CONST.WALL_DOOR_STATES;
       validationError: 'Invalid {name} {field} which must be a value in CONST.WALL_DOOR_STATES';
     }

--- a/src/foundry/common/data/data.mjs/wallData.d.ts
+++ b/src/foundry/common/data/data.mjs/wallData.d.ts
@@ -4,7 +4,7 @@ import * as documents from '../../documents.mjs';
 import * as fields from '../fields.mjs';
 
 interface WallDataSchema extends DocumentSchema {
-  _id: typeof fields.DOCUMENT_ID;
+  _id: fields.DocumentId;
   c: DocumentField<[x0: number, y0: number, x1: number, y1: number]> & {
     type: [typeof Number];
     required: true;
@@ -12,7 +12,7 @@ interface WallDataSchema extends DocumentSchema {
     validationError: 'Invalid {name} coordinates provided which must be a length-4 array of finite numbers';
   };
   move: FieldReturnType<
-    typeof fields.REQUIRED_NUMBER,
+    fields.RequiredNumber,
     {
       default: typeof CONST.WALL_MOVEMENT_TYPES.NORMAL;
       validate: (v: unknown) => v is foundry.CONST.WALL_MOVEMENT_TYPES;
@@ -20,7 +20,7 @@ interface WallDataSchema extends DocumentSchema {
     }
   >;
   sense: FieldReturnType<
-    typeof fields.REQUIRED_NUMBER,
+    fields.RequiredNumber,
     {
       default: typeof CONST.WALL_SENSE_TYPES.NORMAL;
       validate: (v: unknown) => v is foundry.CONST.WALL_SENSE_TYPES;
@@ -28,7 +28,7 @@ interface WallDataSchema extends DocumentSchema {
     }
   >;
   sound: FieldReturnType<
-    typeof fields.REQUIRED_NUMBER,
+    fields.RequiredNumber,
     {
       default: typeof CONST.WALL_SENSE_TYPES.NORMAL;
       validate: (v: unknown) => v is foundry.CONST.WALL_SENSE_TYPES;
@@ -36,7 +36,7 @@ interface WallDataSchema extends DocumentSchema {
     }
   >;
   dir: FieldReturnType<
-    typeof fields.REQUIRED_NUMBER,
+    fields.RequiredNumber,
     {
       default: typeof CONST.WALL_DIRECTIONS.BOTH;
       validate: (v: unknown) => v is foundry.CONST.WALL_DIRECTIONS;
@@ -44,7 +44,7 @@ interface WallDataSchema extends DocumentSchema {
     }
   >;
   door: FieldReturnType<
-    typeof fields.REQUIRED_NUMBER,
+    fields.RequiredNumber,
     {
       default: typeof CONST.WALL_DOOR_TYPES.NONE;
       validate: (v: unknown) => v is foundry.CONST.WALL_DOOR_TYPES;
@@ -52,19 +52,20 @@ interface WallDataSchema extends DocumentSchema {
     }
   >;
   ds: FieldReturnType<
-    typeof fields.REQUIRED_NUMBER,
+    fields.RequiredNumber,
     {
       default: typeof CONST.WALL_DOOR_STATES.CLOSED;
       validate: (v: unknown) => v is foundry.CONST.WALL_DOOR_STATES;
       validationError: 'Invalid {name} {field} which must be a value in CONST.WALL_DOOR_STATES';
     }
   >;
-  flags: typeof fields.OBJECT_FIELD;
+  flags: fields.ObjectField;
 }
 
 interface WallDataProperties {
   /**
    * The _id which uniquely identifies the embedded Wall document
+   * @defaultValue `null`
    */
   _id: string | null;
 
@@ -118,6 +119,7 @@ interface WallDataProperties {
 interface WallDataConstructorData {
   /**
    * The _id which uniquely identifies the embedded Wall document
+   * @defaultValue `null`
    */
   _id?: string | null | undefined;
 
@@ -172,7 +174,7 @@ interface WallDataConstructorData {
  * The data schema for a Wall document.
  * @see BaseWall
  */
-export declare class WallData extends DocumentData<
+export class WallData extends DocumentData<
   WallDataSchema,
   WallDataProperties,
   PropertiesToSource<WallDataProperties>,
@@ -181,6 +183,7 @@ export declare class WallData extends DocumentData<
 > {
   /**
    * The data schema for a WallData object
+   * @override
    */
   static defineSchema(): WallDataSchema;
 
@@ -191,4 +194,4 @@ export declare class WallData extends DocumentData<
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export declare interface WallData extends WallDataProperties {}
+export interface WallData extends WallDataProperties {}

--- a/src/foundry/common/data/fields.mjs.d.ts
+++ b/src/foundry/common/data/fields.mjs.d.ts
@@ -475,9 +475,9 @@ export function embeddedCollectionField<
  * }
  * ```
  * With default config:
- * Property type: `[Document]`
- * Constructor type: `[DocumentConstructorData] | null | undefined`
- * Default: `[]`
+ * Property type: `EmbeddedCollection<DocumentConstructor, DocumentData>`
+ * Constructor type: `DocumentConstructorData[] | null | undefined`
+ * Default: `new EmbeddedCollection(DocumentData, [], DocumentConstructor)`
  */
 // TODO: Improve
 interface EmbeddedCollectionField<

--- a/src/foundry/common/data/fields.mjs.d.ts
+++ b/src/foundry/common/data/fields.mjs.d.ts
@@ -475,7 +475,7 @@ export function embeddedCollectionField<
  * }
  * ```
  * With default config:
- * Property type: `EmbeddedCollection<DocumentConstructor, DocumentData>`
+ * Property type: `EmbeddedCollection<DocumentConstructor, ParentDocumentData>`
  * Constructor type: `DocumentConstructorData[] | null | undefined`
  * Default: `new EmbeddedCollection(DocumentData, [], DocumentConstructor)`
  */

--- a/src/foundry/common/data/fields.mjs.d.ts
+++ b/src/foundry/common/data/fields.mjs.d.ts
@@ -5,12 +5,13 @@ import { FieldReturnType } from '../../../types/helperTypes';
 
 /**
  * A required boolean field which may be used in a Document.
- * @remarks
+ */
+export const BOOLEAN_FIELD: BooleanField;
+/**
  * Property type: `boolean`
- * Constructor type: `boolean | undefined | null`
+ * Constructor type: `boolean | null | undefined`
  * Default: `false`
  */
-export declare const BOOLEAN_FIELD: BooleanField;
 interface BooleanField extends DocumentField<boolean> {
   type: typeof Boolean;
   required: true;
@@ -19,11 +20,12 @@ interface BooleanField extends DocumentField<boolean> {
 
 /**
  * A standard string color field which may be used in a Document.
- * @remarks
- * Property type: `string | undefined | null`
- * Constructor type: `string | undefined | null`
  */
-export declare const COLOR_FIELD: ColorField;
+export const COLOR_FIELD: ColorField;
+/**
+ * Property type: `string | null | undefined`
+ * Constructor type: `string | null | undefined`
+ */
 interface ColorField extends DocumentField<string> {
   type: typeof String;
   required: false;
@@ -34,11 +36,12 @@ interface ColorField extends DocumentField<string> {
 
 /**
  * A standard string field for an image file path which may be used in a Document.
- * @remarks
- * Property type: `string | undefined | null`
- * Constructor type: `string | undefined | null`
  */
-export declare const IMAGE_FIELD: ImageField;
+export const IMAGE_FIELD: ImageField;
+/**
+ * Property type: `string | null | undefined`
+ * Constructor type: `string | null | undefined`
+ */
 interface ImageField extends DocumentField<string> {
   type: typeof String;
   required: false;
@@ -49,11 +52,12 @@ interface ImageField extends DocumentField<string> {
 
 /**
  * A standard string field for a video or image file path may be used in a Document.
- * @remarks
- * Property type: `string | undefined | null`
- * Constructor type: `string | undefined | null`
  */
-export declare const VIDEO_FIELD: VideoField;
+export const VIDEO_FIELD: VideoField;
+/**
+ * Property type: `string | null | undefined`
+ * Constructor type: `string | null | undefined`
+ */
 interface VideoField extends DocumentField<string> {
   type: typeof String;
   required: false;
@@ -64,11 +68,12 @@ interface VideoField extends DocumentField<string> {
 
 /**
  * A standard string field for an audio file path which may be used in a Document.
- * @remarks
- * Property type: `string | undefined | null`
- * Constructor type: `string | undefined | null`
  */
-export declare const AUDIO_FIELD: AudioField;
+export const AUDIO_FIELD: AudioField;
+/**
+ * Property type: `string | null | undefined`
+ * Constructor type: `string | null | undefined`
+ */
 interface AudioField extends DocumentField<string> {
   type: typeof String;
   required: false;
@@ -79,11 +84,12 @@ interface AudioField extends DocumentField<string> {
 
 /**
  * A standard integer field which may be used in a Document.
- * @remarks
- * Property type: `number | undefined`
- * Constructor type: `number | undefined | null`
  */
-export declare const INTEGER_FIELD: IntegerField;
+export const INTEGER_FIELD: IntegerField;
+/**
+ * Property type: `number | undefined`
+ * Constructor type: `number | null | undefined`
+ */
 interface IntegerField extends DocumentField<number> {
   type: typeof Number;
   required: false;
@@ -93,12 +99,13 @@ interface IntegerField extends DocumentField<number> {
 
 /**
  * A string field which contains serialized JSON data that may be used in a Document.
- * @remarks
- * Property type: `string | undefined`
- * Constructor type: `string | object | undefined | null`
  */
-export declare const JSON_FIELD: JSONField;
-interface JSONField extends DocumentField<string> {
+export const JSON_FIELD: JsonField;
+/**
+ * Property type: `string | undefined`
+ * Constructor type: `string | object | null | undefined`
+ */
+interface JsonField extends DocumentField<string> {
   type: typeof String;
   required: false;
   clean: (s: unknown) => string;
@@ -108,11 +115,12 @@ interface JSONField extends DocumentField<string> {
 
 /**
  * A non-negative integer field which may be used in a Document.
- * @remarks
- * Property type: `number | undefined`
- * Constructor type: `number | undefined | null`
  */
-export declare const NONNEGATIVE_INTEGER_FIELD: NonnegativeIntegerField;
+export const NONNEGATIVE_INTEGER_FIELD: NonnegativeIntegerField;
+/**
+ * Property type: `number | undefined`
+ * Constructor type: `number | null | undefined`
+ */
 interface NonnegativeIntegerField extends DocumentField<number> {
   type: typeof Number;
   required: false;
@@ -124,11 +132,12 @@ interface NonnegativeIntegerField extends DocumentField<number> {
  * A non-negative integer field which may be used in a Document.
  *
  * @remarks The validation actually checks for `> 0`, the JSDoc is incorrect in foundry.
- * @remarks
- * Property type: `number | undefined`
- * Constructor type: `number | undefined | null`
  */
-export declare const POSITIVE_INTEGER_FIELD: PositiveIntegerField;
+export const POSITIVE_INTEGER_FIELD: PositiveIntegerField;
+/**
+ * Property type: `number | undefined`
+ * Constructor type: `number | null | undefined`
+ */
 interface PositiveIntegerField extends DocumentField<number> {
   type: typeof Number;
   required: false;
@@ -138,25 +147,27 @@ interface PositiveIntegerField extends DocumentField<number> {
 
 /**
  * A template for a required inner-object field which may be used in a Document.
- * @remarks
+ */
+export const OBJECT_FIELD: ObjectField;
+/**
  * Property type: `object`
- * Constructor type: `object | undefined | null`
+ * Constructor type: `object | null | undefined`
  * Default `{}`
  */
-export declare const OBJECT_FIELD: ObjectField;
 interface ObjectField extends DocumentField<object> {
   type: typeof Object;
-  default: {};
+  default: Record<string, never>;
   required: true;
 }
 
 /**
  * An optional string field which may be included by a Document.
- * @remarks
- * Property type: `string | undefined`
- * Constructor type: `string | undefined | null`
  */
-export declare const STRING_FIELD: StringField;
+export const STRING_FIELD: StringField;
+/**
+ * Property type: `string | undefined`
+ * Constructor type: `string | null | undefined`
+ */
 interface StringField extends DocumentField<string> {
   type: typeof String;
   required: false;
@@ -165,11 +176,12 @@ interface StringField extends DocumentField<string> {
 
 /**
  * An optional numeric field which may be included in a Document.
- * @remarks
- * Property type: `number | undefined | null`
- * Constructor type: `number | undefined | null`
  */
-export declare const NUMERIC_FIELD: NumericField;
+export const NUMERIC_FIELD: NumericField;
+/**
+ * Property type: `number | null | undefined`
+ * Constructor type: `number | null | undefined`
+ */
 interface NumericField extends DocumentField<number> {
   type: typeof Number;
   required: false;
@@ -178,12 +190,13 @@ interface NumericField extends DocumentField<number> {
 
 /**
  * A required numeric field which may be included in a Document and may not be null.
- * @remarks
+ */
+export const REQUIRED_NUMBER: RequiredNumber;
+/**
  * Property type: `number`
- * Constructor type: `number | undefined | null`
+ * Constructor type: `number | null | undefined`
  * Default: `0`
  */
-export declare const REQUIRED_NUMBER: RequiredNumber;
 interface RequiredNumber extends DocumentField<number> {
   type: typeof Number;
   required: true;
@@ -193,13 +206,14 @@ interface RequiredNumber extends DocumentField<number> {
 
 /**
  * A field used to designate a non-negative number
- * @remarks
+ */
+export const NONNEGATIVE_NUMBER_FIELD: NonnegativeNumberField;
+/**
  * Property type: `number`
- * Constructor type: `number | undefined | null`
+ * Constructor type: `number | null | undefined`
  * Default: `0`
  */
-export declare const NONNEGATIVE_NUMBER_FIELD: NonNegativeNumberField;
-interface NonNegativeNumberField extends DocumentField<number> {
+interface NonnegativeNumberField extends DocumentField<number> {
   type: typeof Number;
   required: true;
   nullable: false;
@@ -210,11 +224,12 @@ interface NonNegativeNumberField extends DocumentField<number> {
 
 /**
  * A required numeric field which must be a positive finite value that may be included in a Document.
- * @remarks
+ */
+export const REQUIRED_POSITIVE_NUMBER: RequiredPositiveNumber;
+/**
  * Property type: `number`
  * Constructor type: `number`
  */
-export declare const REQUIRED_POSITIVE_NUMBER: RequiredPositiveNumber;
 interface RequiredPositiveNumber extends DocumentField<number> {
   type: typeof Number;
   required: true;
@@ -225,12 +240,13 @@ interface RequiredPositiveNumber extends DocumentField<number> {
 
 /**
  * A required numeric field which represents an angle of rotation in degrees between 0 and 360.
- * @remarks
+ */
+export const ANGLE_FIELD: AngleField;
+/**
  * Property type: `number`
- * Constructor type: `number | undefined | null`
+ * Constructor type: `number | null | undefined`
  * Default: `360`
  */
-export declare const ANGLE_FIELD: AngleField;
 interface AngleField extends DocumentField<number> {
   type: typeof Number;
   required: true;
@@ -243,12 +259,13 @@ interface AngleField extends DocumentField<number> {
 
 /**
  * A required numeric field which represents a uniform number between 0 and 1.
- * @remarks
+ */
+export const ALPHA_FIELD: AlphaField;
+/**
  * Property type: `number`
- * Constructor type: `number | undefined | null`
+ * Constructor type: `number | null | undefined`
  * Default: `1`
  */
-export declare const ALPHA_FIELD: AlphaField;
 interface AlphaField extends DocumentField<number> {
   type: typeof Number;
   required: true;
@@ -260,11 +277,12 @@ interface AlphaField extends DocumentField<number> {
 
 /**
  * A string field which requires a non-blank value and may not be null.
- * @remarks
+ */
+export const REQUIRED_STRING: RequiredString;
+/**
  * Property type: `string`
  * Constructor type: `string`
  */
-export declare const REQUIRED_STRING: RequiredString;
 interface RequiredString extends DocumentField<string> {
   type: typeof String;
   required: true;
@@ -274,12 +292,13 @@ interface RequiredString extends DocumentField<string> {
 
 /**
  * A string field which is required, but may be left blank as an empty string.
- * @remarks
- * Property type: `string`
- * Constructor type: `string | undefined | null`
- * Default: `''`
  */
-export declare const BLANK_STRING: BlankString;
+export const BLANK_STRING: BlankString;
+/**
+ * Property type: `string`
+ * Constructor type: `string | null | undefined`
+ * Default: `""`
+ */
 interface BlankString extends DocumentField<string> {
   type: typeof String;
   required: true;
@@ -290,12 +309,13 @@ interface BlankString extends DocumentField<string> {
 
 /**
  * A field used for integer sorting of a Document relative to its siblings
- * @remarks
+ */
+export const INTEGER_SORT_FIELD: IntegerSortField;
+/**
  * Property type: `number`
- * Constructor type: `number | undefined | null`
+ * Constructor type: `number | null | undefined`
  * Default: `0`
  */
-export declare const INTEGER_SORT_FIELD: IntegerSortField;
 interface IntegerSortField extends DocumentField<number> {
   type: typeof Number;
   required: true;
@@ -306,12 +326,13 @@ interface IntegerSortField extends DocumentField<number> {
 
 /**
  * A numeric timestamp field which may be used in a Document.
- * @remarks
- * Property type: `number | undefined`
- * Constructor type: `number | undefined | null`
- * Default: `Date.now`
  */
-export declare const TIMESTAMP_FIELD: TimestampField;
+export const TIMESTAMP_FIELD: TimestampField;
+/**
+ * Property type: `number | undefined`
+ * Constructor type: `number | null | undefined`
+ * Default: `Date.now()`
+ */
 interface TimestampField extends DocumentField<number> {
   type: typeof Number;
   required: false;
@@ -328,12 +349,13 @@ declare function _validateId(id: string | null): boolean;
 
 /**
  * The standard identifier for a Document.
- * @remarks
+ */
+export const DOCUMENT_ID: DocumentId;
+/**
  * Property type: `string | null`
- * Constructor type: `string | undefined | null`
+ * Constructor type: `string | null | undefined`
  * Default: `null`
  */
-export declare const DOCUMENT_ID: DocumentId;
 interface DocumentId extends DocumentField<string | null> {
   type: typeof String;
   required: true;
@@ -345,12 +367,13 @@ interface DocumentId extends DocumentField<string | null> {
 
 /**
  * The standard permissions object which may be included by a Document.
- * @remarks
+ */
+export const DOCUMENT_PERMISSIONS: DocumentPermissions;
+/**
  * Property type: `Partial<Record<string, DOCUMENT_PERMISSION_LEVELS>>`
- * Constructor type: `Partial<Record<string, DOCUMENT_PERMISSION_LEVELS>> | undefined | null`
+ * Constructor type: `Partial<Record<string, DOCUMENT_PERMISSION_LEVELS>> | null | undefined`
  * Default: `{ default: DOCUMENT_PERMISSION_LEVELS.NONE }`
  */
-export declare const DOCUMENT_PERMISSIONS: DocumentPermissions;
 interface DocumentPermissions extends DocumentField<Partial<Record<string, DOCUMENT_PERMISSION_LEVELS>>> {
   type: typeof Object;
   required: true;
@@ -379,9 +402,22 @@ interface ForeignDocumentFieldOptions {
 /**
  * Create a foreign key field which references a primary Document id
  */
-export declare function foreignDocumentField<T extends ForeignDocumentFieldOptions>(
-  options: T
-): ForeignDocumentField<T>;
+export function foreignDocumentField<T extends ForeignDocumentFieldOptions>(options: T): ForeignDocumentField<T>;
+/**
+ * Default config:
+ * ```
+ * {
+ *   type: String,
+ *   required: false,
+ *   nullable: true,
+ *   default: null
+ * }
+ * ```
+ * With default config:
+ * Property type: `string | null`
+ * Constructor type: `ForeignDocument | string | null | undefined`
+ * Default: `null`
+ */
 interface ForeignDocumentField<T extends ForeignDocumentFieldOptions> extends DocumentField<string | null> {
   type: typeof String;
   required: T extends {
@@ -419,13 +455,30 @@ interface EmbeddedCollectionFieldOptions {
  * @param options  - Additional field options
  *                   (default: `{}`)
  */
-export declare function embeddedCollectionField<
+export function embeddedCollectionField<
   ConcreteDocumentConstructor extends { readonly documentName: string } & ConstructorOf<Document<any, any>>,
   Options extends EmbeddedCollectionFieldOptions
 >(
   document: ConcreteDocumentConstructor,
   options?: Options
 ): EmbeddedCollectionField<ConcreteDocumentConstructor, Options>;
+/**
+ * Default config:
+ * ```
+ * {
+ *   type: {
+ *     [documentName]: DocumentConstructor
+ *   },
+ *   required: true,
+ *   default: [],
+ *   isCollection: true
+ * }
+ * ```
+ * With default config:
+ * Property type: `[Document]`
+ * Constructor type: `[DocumentConstructorData] | null | undefined`
+ * Default: `[]`
+ */
 // TODO: Improve
 interface EmbeddedCollectionField<
   ConcreteDocumentConstructor extends ConstructorOf<Document<any, any>>,
@@ -441,9 +494,22 @@ interface EmbeddedCollectionField<
  * A special field which contains a data object defined from the game System model.
  * @param document - The Document class definition
  */
-export declare function systemDataField<
+export function systemDataField<
   DocumentSpecifier extends { readonly documentName: keyof Game.SystemData<any>['model'] }
 >(document: DocumentSpecifier): SystemDataField;
+/**
+ * Default config:
+ * ```
+ * {
+ *   type: Object,
+ *   required: true,
+ *   default: object // template object of object type from template.json
+ * }
+ * ```
+ * Property type: `object`
+ * Constructor type: `object | null | undefined`
+ * Default: `{}`
+ */
 // TODO: Improve
 interface SystemDataField extends DocumentField<any> {
   type: typeof Object;
@@ -454,7 +520,7 @@ interface SystemDataField extends DocumentField<any> {
 /**
  * Return a document field which is a modification of a static field type
  */
-export declare function field<T extends DocumentField<any>, U extends Partial<DocumentField<any>>>(
+export function field<T extends DocumentField<any>, U extends Partial<DocumentField<any>>>(
   field: T,
   options?: U
 ): FieldReturnType<T, U>;

--- a/src/foundry/common/documents.mjs/baseActiveEffect.d.ts
+++ b/src/foundry/common/documents.mjs/baseActiveEffect.d.ts
@@ -1,7 +1,8 @@
+import { ConfiguredDocumentClass } from '../../../types/helperTypes';
 import { DocumentMetadata, DocumentModificationOptions } from '../abstract/document.mjs';
-import { ConfiguredDocumentClass, ConstructorDataType } from '../../../types/helperTypes';
 import { Document } from '../abstract/module.mjs';
 import * as data from '../data/data.mjs';
+import type { ActiveEffectDataConstructorData } from '../data/data.mjs/activeEffectData.js';
 import { BaseActor } from './baseActor';
 import { BaseItem } from './baseItem';
 import { BaseUser } from './baseUser';
@@ -30,7 +31,7 @@ export declare class BaseActiveEffect extends Document<
 
   /** @override */
   protected _preCreate(
-    data: ConstructorDataType<data.ActiveEffectData>,
+    data: ActiveEffectDataConstructorData,
     options: DocumentModificationOptions,
     user: BaseUser
   ): Promise<void>;

--- a/src/foundry/common/documents.mjs/baseActor.d.ts
+++ b/src/foundry/common/documents.mjs/baseActor.d.ts
@@ -1,11 +1,12 @@
+import { ConfiguredDocumentClass } from '../../../types/helperTypes';
 import { DocumentMetadata, DocumentModificationOptions } from '../abstract/document.mjs';
 import { Document } from '../abstract/module.mjs';
+import * as data from '../data/data.mjs';
+import type { ActorDataConstructorData } from '../data/data.mjs/actorData.js';
 import { BaseActiveEffect } from './baseActiveEffect';
 import { BaseItem } from './baseItem';
-import * as data from '../data/data.mjs';
-import { BaseUser } from './baseUser';
-import { ConfiguredDocumentClass, ConstructorDataType } from '../../../types/helperTypes';
 import { BaseToken } from './baseToken';
+import { BaseUser } from './baseUser';
 
 /**
  * The base Actor model definition which defines common behavior of an Actor document between both client and server.
@@ -54,14 +55,14 @@ export declare class BaseActor extends Document<
 
   /** @override */
   protected _preCreate(
-    data: ConstructorDataType<data.ActorData>,
+    data: ActorDataConstructorData,
     options: DocumentModificationOptions,
     user: BaseUser
   ): Promise<void>;
 
   /** @override */
   protected _preUpdate(
-    changed: DeepPartial<ConstructorDataType<data.ActorData>>,
+    changed: DeepPartial<ActorDataConstructorData>,
     options: DocumentModificationOptions,
     user: BaseUser
   ): Promise<void>;

--- a/src/foundry/common/documents.mjs/baseCard.d.ts
+++ b/src/foundry/common/documents.mjs/baseCard.d.ts
@@ -1,9 +1,10 @@
+import { ConfiguredDocumentClass } from '../../../types/helperTypes';
 import { DocumentMetadata, DocumentModificationOptions } from '../abstract/document.mjs';
 import { Document } from '../abstract/module.mjs';
 import * as data from '../data/data.mjs';
-import { BaseUser } from './baseUser';
-import { ConfiguredDocumentClass, ConstructorDataType } from '../../../types/helperTypes';
+import type { CardDataConstructorData } from '../data/data.mjs/cardData.js';
 import { BaseCards } from './baseCards';
+import { BaseUser } from './baseUser';
 
 /**
  * The base Card definition which defines common behavior of an embedded Card document shared by both client and server.
@@ -37,7 +38,7 @@ export declare class BaseCard extends Document<data.CardData, InstanceType<Confi
 
   /** @override */
   protected _preCreate(
-    data: ConstructorDataType<data.CardData>,
+    data: CardDataConstructorData,
     options: DocumentModificationOptions,
     user: BaseUser
   ): Promise<void>;

--- a/src/foundry/common/documents.mjs/baseCombat.d.ts
+++ b/src/foundry/common/documents.mjs/baseCombat.d.ts
@@ -1,6 +1,6 @@
-import { ConstructorDataType } from '../../../types/helperTypes';
 import { DocumentMetadata } from '../abstract/document.mjs';
 import { Document } from '../abstract/module.mjs';
+import type { CombatDataConstructorData } from '../data/data.mjs/combatData.js';
 import { data } from '../module.mjs';
 import { BaseCombatant } from './baseCombatant';
 import { BaseUser } from './baseUser';
@@ -37,5 +37,5 @@ export declare class BaseCombat extends Document<data.CombatData> {
    * Is a user able to update an existing Combat?
    * @param doc - (unused)
    */
-  protected static _canUpdate(user: BaseUser, doc: BaseCombat, data?: ConstructorDataType<data.CombatData>): boolean;
+  protected static _canUpdate(user: BaseUser, doc: BaseCombat, data?: CombatDataConstructorData): boolean;
 }

--- a/src/foundry/common/documents.mjs/baseCombatant.d.ts
+++ b/src/foundry/common/documents.mjs/baseCombatant.d.ts
@@ -1,6 +1,7 @@
-import { ConfiguredDocumentClass, ConstructorDataType } from '../../../types/helperTypes';
+import { ConfiguredDocumentClass } from '../../../types/helperTypes';
 import { DocumentMetadata } from '../abstract/document.mjs';
 import { Document } from '../abstract/module.mjs';
+import type { CombatantDataConstructorData } from '../data/data.mjs/combatantData.js';
 import { data } from '../module.mjs';
 import { BaseCombat } from './baseCombat';
 import { BaseUser } from './baseUser';
@@ -35,18 +36,10 @@ export declare class BaseCombatant extends Document<
    * Is a user able to update an existing Combatant?
    * @remarks doc seems unused
    */
-  protected static _canUpdate(
-    user: BaseUser,
-    doc: BaseCombatant,
-    data?: ConstructorDataType<data.CombatantData>
-  ): boolean;
+  protected static _canUpdate(user: BaseUser, doc: BaseCombatant, data?: CombatantDataConstructorData): boolean;
 
   /**
    * Is a user able to create this Combatant?
    */
-  protected static _canCreate(
-    user: BaseUser,
-    doc: BaseCombatant,
-    data?: ConstructorDataType<data.CombatantData>
-  ): boolean;
+  protected static _canCreate(user: BaseUser, doc: BaseCombatant, data?: CombatantDataConstructorData): boolean;
 }

--- a/src/foundry/common/documents.mjs/baseFogExploration.d.ts
+++ b/src/foundry/common/documents.mjs/baseFogExploration.d.ts
@@ -1,8 +1,8 @@
-import { ConstructorDataType } from '../../../types/helperTypes';
 import { DocumentMetadata, DocumentModificationOptions } from '../abstract/document.mjs';
 import { Document } from '../abstract/module.mjs';
-import { BaseUser } from './baseUser';
 import * as data from '../data/data.mjs';
+import type { FogExplorationDataConstructorData } from '../data/data.mjs/fogExplorationData.js';
+import { BaseUser } from './baseUser';
 
 /**
  * The base FogExploration model definition which defines common behavior of an FogExploration document between both client and server.
@@ -30,7 +30,7 @@ export declare class BaseFogExploration extends Document<data.FogExplorationData
 
   /** @override */
   protected _preUpdate(
-    changed: DeepPartial<ConstructorDataType<data.FogExplorationData>>,
+    changed: DeepPartial<FogExplorationDataConstructorData>,
     options: DocumentModificationOptions,
     user: BaseUser
   ): Promise<void>;

--- a/src/foundry/common/documents.mjs/baseMacro.d.ts
+++ b/src/foundry/common/documents.mjs/baseMacro.d.ts
@@ -1,9 +1,9 @@
-import * as data from '../data/data.mjs';
-import { Document } from '../abstract/module.mjs';
 import { DocumentMetadata, DocumentModificationOptions } from '../abstract/document.mjs';
-import { BaseUser } from './baseUser';
-import { ConstructorDataType } from '../../../types/helperTypes';
+import { Document } from '../abstract/module.mjs';
 import * as CONST from '../constants.mjs';
+import * as data from '../data/data.mjs';
+import type { MacroDataConstructorData } from '../data/data.mjs/macroData.js';
+import { BaseUser } from './baseUser';
 
 /**
  * The base Macro model definition which defines common behavior of an Macro document between both client and server.
@@ -32,7 +32,7 @@ export declare class BaseMacro extends Document<data.MacroData> {
 
   /** @override */
   protected _preCreate(
-    data: ConstructorDataType<data.MacroData>,
+    data: MacroDataConstructorData,
     options: DocumentModificationOptions,
     user: BaseUser
   ): Promise<void>;

--- a/src/foundry/common/documents.mjs/baseWall.d.ts
+++ b/src/foundry/common/documents.mjs/baseWall.d.ts
@@ -1,10 +1,10 @@
-import { Context } from '../abstract/document.mjs';
-import { ConfiguredDocumentClass, ConstructorDataType } from '../../../types/helperTypes';
-import { DocumentMetadata } from '../abstract/document.mjs';
+import { ConfiguredDocumentClass } from '../../../types/helperTypes';
+import { Context, DocumentMetadata } from '../abstract/document.mjs';
 import { Document } from '../abstract/module.mjs';
+import * as data from '../data/data.mjs';
+import type { WallDataConstructorData } from '../data/data.mjs/wallData.js';
 import { BaseScene } from './baseScene';
 import { BaseUser } from './baseUser';
-import * as data from '../data/data.mjs';
 
 /**
  * The base Wall model definition which defines common behavior of an Wall document between both client and server.
@@ -14,7 +14,7 @@ export declare class BaseWall extends Document<data.WallData, InstanceType<Confi
    * @remarks This is not overridden in foundry but reflects the real behavior.
    */
   constructor(
-    data: ConstructorDataType<data.WallData>,
+    data: WallDataConstructorData,
     context?: Context<InstanceType<ConfiguredDocumentClass<typeof BaseScene>>>
   );
 
@@ -39,9 +39,5 @@ export declare class BaseWall extends Document<data.WallData, InstanceType<Confi
   /**
    * Is a user able to update an existing Wall?
    */
-  protected static _canUpdate(
-    user: BaseUser,
-    doc: BaseWall,
-    data?: Partial<ConstructorDataType<data.WallData>>
-  ): boolean;
+  protected static _canUpdate(user: BaseUser, doc: BaseWall, data?: Partial<WallDataConstructorData>): boolean;
 }

--- a/src/foundry/common/packages.mjs/moduleData.d.ts
+++ b/src/foundry/common/packages.mjs/moduleData.d.ts
@@ -2,19 +2,20 @@ import * as fields from '../data/fields.mjs';
 import { PackageData, PackageDataConstructorData, PackageDataProperties, PackageDataSchema } from './packageData';
 
 interface ModuleDataSchema extends PackageDataSchema {
-  coreTranslation: typeof fields.BOOLEAN_FIELD;
-  minimumSystemVersion: typeof fields.STRING_FIELD;
-  library: typeof fields.BOOLEAN_FIELD;
+  coreTranslation: fields.BooleanField;
+  minimumSystemVersion: fields.StringField;
+  library: fields.BooleanField;
 }
 
 interface ModuleDataProperties extends PackageDataProperties {
   /**
    * Does this module provide a translation for the core software?
+   * @defaultValue `false`
    */
   coreTranslation: boolean;
 
   /** A minimum version number of the game system that this module requires */
-  minimumSystemVersion?: string;
+  minimumSystemVersion: string | undefined;
 
   /**
    * A library module provides no user-facing functionality and is solely for
@@ -27,6 +28,7 @@ interface ModuleDataProperties extends PackageDataProperties {
 interface ModuleDataConstructorData extends PackageDataConstructorData {
   /**
    * Does this module provide a translation for the core software?
+   * @defaultValue `false`
    */
   coreTranslation?: boolean | null | undefined;
 
@@ -45,9 +47,10 @@ interface ModuleDataConstructorData extends PackageDataConstructorData {
  * The data schema used to define Module manifest files.
  * Extends the basic PackageData schema with some additional module-specific fields.
  */
-export declare class ModuleData extends PackageData<ModuleDataSchema, ModuleDataProperties, ModuleDataConstructorData> {
+export class ModuleData extends PackageData<ModuleDataSchema, ModuleDataProperties, ModuleDataConstructorData> {
+  /** @override */
   static defineSchema(): ModuleDataSchema;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export declare interface ModuleData extends ModuleDataProperties {}
+export interface ModuleData extends ModuleDataProperties {}

--- a/src/foundry/common/packages.mjs/packageAuthorData.d.ts
+++ b/src/foundry/common/packages.mjs/packageAuthorData.d.ts
@@ -3,53 +3,53 @@ import { DocumentData } from '../abstract/module.mjs';
 import * as fields from '../data/fields.mjs';
 
 interface PackageAuthorDataSchema extends DocumentSchema {
-  name: typeof fields.REQUIRED_STRING;
-  email: typeof fields.STRING_FIELD;
-  url: typeof fields.STRING_FIELD;
-  discord: typeof fields.STRING_FIELD;
+  name: fields.RequiredString;
+  email: fields.StringField;
+  url: fields.StringField;
+  discord: fields.StringField;
 }
 
 interface PackageAuthorDataProperties {
-  /**
-   * The author name
-   */
+  /** The author name */
   name: string;
 
-  /**
-   * The author email address
-   */
+  /** The author email address */
   email: string | undefined;
 
-  /**
-   *  A website url for the author
-   */
+  /** A website url for the author */
   url: string | undefined;
 
-  /**
-   *  A Discord username for the author
-   */
+  /** A Discord username for the author */
   discord: string | undefined;
 }
 
 interface PackageAuthorDataConstructorData {
+  /** The author name */
   name: string;
+
+  /** The author email address */
   email?: string | null | undefined;
+
+  /** A website url for the author */
   url?: string | null | undefined;
+
+  /** A Discord username for the author */
   discord?: string | null | undefined;
 }
 
 /**
  * An inner data object which represents a single package author in the authors array.
  */
-export declare class PackageAuthorData extends DocumentData<
+export class PackageAuthorData extends DocumentData<
   PackageAuthorDataSchema,
   PackageAuthorDataProperties,
   PropertiesToSource<PackageAuthorDataProperties>,
   PackageAuthorDataConstructorData,
   null
 > {
-  constructor(data?: DeepPartial<PropertiesToSource<PackageAuthorDataProperties>>, document?: null);
+  constructor(data?: PackageAuthorDataConstructorData, document?: null);
 
+  /** @override */
   static defineSchema(): PackageAuthorDataSchema;
 }
 

--- a/src/foundry/common/packages.mjs/packageCompendiumData.d.ts
+++ b/src/foundry/common/packages.mjs/packageCompendiumData.d.ts
@@ -3,23 +3,18 @@ import { DocumentData } from '../abstract/module.mjs';
 import * as fields from '../data/fields.mjs';
 
 interface PackageCompendiumDataSchema extends DocumentSchema {
-  name: typeof fields.REQUIRED_STRING;
-  label: typeof fields.REQUIRED_STRING;
-  path: typeof fields.REQUIRED_STRING;
-  private: FieldReturnType<
-    typeof fields.BOOLEAN_FIELD,
-    {
-      default: false;
-    }
-  >;
+  name: fields.RequiredString;
+  label: fields.RequiredString;
+  path: fields.RequiredString;
+  private: FieldReturnType<fields.BooleanField, { default: false }>;
   entity: FieldReturnType<
-    typeof fields.REQUIRED_STRING,
+    fields.RequiredString,
     {
       validate: (v: string) => v is foundry.CONST.COMPENDIUM_DOCUMENT_TYPES;
       validationError: 'Invalid package compendium entity type provided which must be a value in CONST.COMPENDIUM_ENTITY_TYPES';
     }
   >;
-  system: typeof fields.STRING_FIELD;
+  system: fields.StringField;
 }
 
 interface PackageCompendiumDataProperties {
@@ -32,6 +27,7 @@ interface PackageCompendiumDataProperties {
   /** The local relative path to the compendium source .db file. The filename should match the name attribute. */
   path: string;
 
+  /** @defaultValue `false` */
   private: boolean;
 
   /** The specific document type that is contained within this compendium pack */
@@ -51,6 +47,7 @@ interface PackageCompendiumDataConstructorData {
   /** The local relative path to the compendium source .db file. The filename should match the name attribute. */
   path: string;
 
+  /** @defaultValue `false` */
   private?: boolean | null | undefined;
 
   /** The specific document type that is contained within this compendium pack */
@@ -63,14 +60,15 @@ interface PackageCompendiumDataConstructorData {
 /**
  * An inner data object which represents a single compendium pack definition provided by a package in the packs array.
  */
-export declare class PackageCompendiumData extends DocumentData<
+export class PackageCompendiumData extends DocumentData<
   PackageCompendiumDataSchema,
   PackageCompendiumDataProperties,
   PropertiesToSource<PackageCompendiumDataProperties>,
   PackageCompendiumDataConstructorData
 > {
+  /** @override */
   static defineSchema(): PackageCompendiumDataSchema;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export declare interface PackageCompendiumData extends PackageCompendiumDataProperties {}
+export interface PackageCompendiumData extends PackageCompendiumDataProperties {}

--- a/src/foundry/common/packages.mjs/packageData.d.ts
+++ b/src/foundry/common/packages.mjs/packageData.d.ts
@@ -9,13 +9,30 @@ import { PackageLanguageData, PackageLanguageDataConstructorData } from './packa
 /**
  * A helper field used for string arrays
  */
-declare const STRING_ARRAY_FIELD: DocumentField<string[]> & {
-  type: [String];
+declare const STRING_ARRAY_FIELD: StringArrayField;
+/**
+ * Property type: `string[]`
+ * Constructor type: `string[] | null | undefined`
+ * Default `[]`
+ */
+type StringArrayField = DocumentField<string[]> & {
+  type: [typeof String];
   required: true;
   default: [];
   clean: (v: unknown) => string[];
 };
 
+/**
+ * A helper field used for arrays of package include objects
+ */
+declare const INCLUDE_ARRAY_FIELD: <T extends ConstructorOf<DocumentData<any, any>>>(
+  type: T
+) => IncludeArrayFieldReturnType<T>;
+/**
+ * Property type: `T[]`
+ * Constructor type: `T[] | null | undefined`
+ * Default `[]`
+ */
 type IncludeArrayFieldReturnType<T extends ConstructorOf<DocumentData<any, any>>> = DocumentField<
   Array<InstanceType<T>>
 > & {
@@ -25,49 +42,45 @@ type IncludeArrayFieldReturnType<T extends ConstructorOf<DocumentData<any, any>>
   clean: (v: unknown) => InstanceType<T>['_source'][];
 };
 
-/**
- * A helper field used for arrays of package include objects
- */
-declare const INCLUDE_ARRAY_FIELD: <T extends ConstructorOf<DocumentData<any, any>>>(
-  type: T
-) => IncludeArrayFieldReturnType<T>;
-
-export interface PackageDataSchema extends DocumentSchema {
-  name: typeof fields.STRING_FIELD;
-  title: typeof fields.STRING_FIELD;
-  description: typeof fields.BLANK_STRING;
-  author: typeof fields.STRING_FIELD;
+interface PackageDataSchema extends DocumentSchema {
+  name: fields.RequiredString;
+  title: fields.RequiredString;
+  description: fields.BlankString;
+  author: fields.StringField;
   authors: IncludeArrayFieldReturnType<typeof PackageAuthorData>;
-  url: typeof fields.STRING_FIELD;
-  license: typeof fields.STRING_FIELD;
-  readme: typeof fields.STRING_FIELD;
-  bugs: typeof fields.STRING_FIELD;
-  changelog: typeof fields.STRING_FIELD;
-  flags: typeof fields.OBJECT_FIELD;
-  version: FieldReturnType<typeof fields.REQUIRED_STRING, { default: '1.0.0' }>;
-  minimumCoreVersion: typeof fields.STRING_FIELD;
-  compatibleCoreVersion: typeof fields.STRING_FIELD;
-  scripts: typeof STRING_ARRAY_FIELD;
-  esmodules: typeof STRING_ARRAY_FIELD;
-  styles: typeof STRING_ARRAY_FIELD;
+  url: fields.StringField;
+  license: fields.StringField;
+  readme: fields.StringField;
+  bugs: fields.StringField;
+  changelog: fields.StringField;
+  flags: fields.ObjectField;
+  version: FieldReturnType<fields.RequiredString, { default: '1.0.0' }>;
+  minimumCoreVersion: fields.StringField;
+  compatibleCoreVersion: fields.StringField;
+  scripts: StringArrayField;
+  esmodules: StringArrayField;
+  styles: StringArrayField;
   languages: IncludeArrayFieldReturnType<typeof PackageLanguageData>;
   packs: IncludeArrayFieldReturnType<typeof PackageCompendiumData>;
-  system: typeof STRING_ARRAY_FIELD;
+  system: StringArrayField;
   dependencies: IncludeArrayFieldReturnType<typeof PackageDependencyData>;
-  socket: FieldReturnType<typeof fields.BOOLEAN_FIELD, { default: false }>;
-  manifest: typeof fields.STRING_FIELD;
-  download: typeof fields.STRING_FIELD;
-  protected: FieldReturnType<typeof fields.BOOLEAN_FIELD, { default: false }>;
+  socket: FieldReturnType<fields.BooleanField, { default: false }>;
+  manifest: fields.StringField;
+  download: fields.StringField;
+  protected: FieldReturnType<fields.BooleanField, { default: false }>;
 }
 
-export interface PackageDataProperties {
+interface PackageDataProperties {
   /** The canonical package name, should be lower-case with no spaces or special characters */
-  name: string | undefined;
+  name: string;
 
   /** The human-readable package title, containing spaces and special characters */
-  title: string | undefined;
+  title: string;
 
-  /** An optional package description, may contain HTML */
+  /**
+   * An optional package description, may contain HTML
+   * @defaultValue `""`
+   */
   description: string;
 
   /** A singular package author; this is an old field staged for later deprecation, please use authors */
@@ -99,7 +112,7 @@ export interface PackageDataProperties {
 
   /**
    * The current package version
-   * @defaultValue `'1.0.0'`
+   * @defaultValue `"1.0.0"`
    */
   version: string;
 
@@ -163,21 +176,24 @@ export interface PackageDataProperties {
   /** A publicly accessible web URL where the source files for this package may be downloaded. Required in order to support module installation. */
   download: string | undefined;
 
-  /***
+  /**
    * Whether this package uses the protected content access system.
    * @defaultValue `false`
    */
   protected: boolean;
 }
 
-export interface PackageDataConstructorData {
+interface PackageDataConstructorData {
   /** The canonical package name, should be lower-case with no spaces or special characters */
-  name?: string | null | undefined;
+  name: string;
 
   /** The human-readable package title, containing spaces and special characters */
-  title?: string | null | undefined;
+  title: string;
 
-  /** An optional package description, may contain HTML */
+  /**
+   * An optional package description, may contain HTML
+   * @defaultValue `""`
+   */
   description?: string | null | undefined;
 
   /** A singular package author; this is an old field staged for later deprecation, please use authors */
@@ -209,7 +225,7 @@ export interface PackageDataConstructorData {
 
   /**
    * The current package version
-   * @defaultValue `'1.0.0'`
+   * @defaultValue `"1.0.0"`
    */
   version?: string | null | undefined;
 
@@ -273,7 +289,7 @@ export interface PackageDataConstructorData {
   /** A publicly accessible web URL where the source files for this package may be downloaded. Required in order to support module installation. */
   download?: string | null | undefined;
 
-  /***
+  /**
    * Whether this package uses the protected content access system.
    * @defaultValue `false`
    */
@@ -284,11 +300,12 @@ export interface PackageDataConstructorData {
  * The data schema used to define a Package manifest.
  * Specific types of packages extend this schema with additional fields.
  */
-export declare class PackageData<
+export class PackageData<
   Schema extends Omit<PackageDataSchema, 'system'>,
   Properties extends Omit<PackageDataProperties, 'system'>,
   ConstructorData extends Omit<PackageDataConstructorData, 'system'>
 > extends DocumentData<Schema, Properties, PropertiesToSource<PackageDataProperties>, ConstructorData> {
+  /** @override */
   static defineSchema(): Omit<PackageDataSchema, 'system'>;
 
   /** @override */

--- a/src/foundry/common/packages.mjs/packageData.d.ts
+++ b/src/foundry/common/packages.mjs/packageData.d.ts
@@ -1,10 +1,10 @@
-import { ConstructorDataType, FieldReturnType, PropertiesToSource } from '../../../types/helperTypes';
+import { FieldReturnType, PropertiesToSource } from '../../../types/helperTypes';
 import { DocumentData } from '../abstract/module.mjs';
 import * as fields from '../data/fields.mjs';
-import { PackageAuthorData } from './packageAuthorData';
-import { PackageCompendiumData } from './packageCompendiumData';
-import { PackageDependencyData } from './packageDependencyData';
-import { PackageLanguageData } from './packageLanguageData';
+import { PackageAuthorData, PackageAuthorDataConstructorData } from './packageAuthorData';
+import { PackageCompendiumData, PackageCompendiumDataConstructorData } from './packageCompendiumData';
+import { PackageDependencyData, PackageDependencyDataConstructorData } from './packageDependencyData';
+import { PackageLanguageData, PackageLanguageDataConstructorData } from './packageLanguageData';
 
 /**
  * A helper field used for string arrays
@@ -187,7 +187,7 @@ export interface PackageDataConstructorData {
    * An array of author objects who are co-authors of this package. Preferred to the singular author field.
    * @defaultValue `[]`
    */
-  authors?: ConstructorDataType<PackageAuthorData>[] | null | undefined;
+  authors?: PackageAuthorDataConstructorData[] | null | undefined;
 
   /** A web url where more details about the package may be found */
   url?: string | null | undefined;
@@ -241,13 +241,13 @@ export interface PackageDataConstructorData {
    * An array of language data objects which are included by this package
    * @defaultValue `[]`
    */
-  languages?: ConstructorDataType<PackageLanguageData>[] | null | undefined;
+  languages?: PackageLanguageDataConstructorData[] | null | undefined;
 
   /**
    * An array of compendium packs which are included by this package
    * @defaultValue `[]`
    */
-  packs?: ConstructorDataType<PackageCompendiumData>[] | null | undefined;
+  packs?: PackageCompendiumDataConstructorData[] | null | undefined;
 
   /**
    * An array of game system names which this module supports
@@ -259,7 +259,7 @@ export interface PackageDataConstructorData {
    * An array of dependency objects which define required dependencies for using this package
    * @defaultValue `[]`
    */
-  dependencies?: ConstructorDataType<PackageDependencyData>[] | null | undefined;
+  dependencies?: PackageDependencyDataConstructorData[] | null | undefined;
 
   /**
    * Whether to require a package-specific socket namespace for this package

--- a/src/foundry/common/packages.mjs/packageDependencyData.d.ts
+++ b/src/foundry/common/packages.mjs/packageDependencyData.d.ts
@@ -3,23 +3,26 @@ import { DocumentData } from '../abstract/module.mjs';
 import * as fields from '../data/fields.mjs';
 
 interface PackageDependencyDataSchema extends DocumentSchema {
-  name: typeof fields.REQUIRED_STRING;
+  name: fields.RequiredString;
   type: FieldReturnType<
-    typeof fields.REQUIRED_STRING,
+    fields.RequiredString,
     {
       default: 'module';
       validate: (v: unknown) => boolean;
       validationError: 'Invalid package type "{value}" which must be a value from CONST.PACKAGE_TYPES';
     }
   >;
-  manifest: typeof fields.STRING_FIELD;
+  manifest: fields.StringField;
 }
 
 interface PackageDependencyDataProperties {
   /** The dependency package name */
   name: string;
 
-  /** The dependency package type, from CONST.PACKAGE_TYPES */
+  /**
+   * The dependency package type, from CONST.PACKAGE_TYPES
+   * @defaultValue `"module"`
+   */
   type: foundry.CONST.PACKAGE_TYPES;
 
   /** An explicit manifest URL, otherwise learned from the Foundry web server */
@@ -30,7 +33,10 @@ interface PackageDependencyDataConstructorData {
   /** The dependency package name */
   name: string;
 
-  /** The dependency package type, from CONST.PACKAGE_TYPES */
+  /**
+   * The dependency package type, from CONST.PACKAGE_TYPES
+   * @defaultValue `"module"`
+   */
   type?: foundry.CONST.PACKAGE_TYPES | null | undefined;
 
   /** An explicit manifest URL, otherwise learned from the Foundry web server */
@@ -40,12 +46,13 @@ interface PackageDependencyDataConstructorData {
 /**
  * An inner data object which represents a single package dependency in the dependencies array.
  */
-export declare class PackageDependencyData extends DocumentData<
+export class PackageDependencyData extends DocumentData<
   PackageDependencyDataSchema,
   PackageDependencyDataProperties,
   PropertiesToSource<PackageDependencyDataProperties>,
   PackageDependencyDataConstructorData
 > {
+  /** @override */
   static defineSchema(): PackageDependencyDataSchema;
 
   /** @override */
@@ -56,4 +63,4 @@ export declare class PackageDependencyData extends DocumentData<
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export declare interface PackageDependencyData extends PackageDependencyDataProperties {}
+export interface PackageDependencyData extends PackageDependencyDataProperties {}

--- a/src/foundry/common/packages.mjs/packageLanguageData.d.ts
+++ b/src/foundry/common/packages.mjs/packageLanguageData.d.ts
@@ -4,16 +4,16 @@ import * as fields from '../data/fields.mjs';
 
 interface PackageLanguageDataSchema extends DocumentSchema {
   lang: FieldReturnType<
-    typeof fields.REQUIRED_STRING,
+    fields.RequiredString,
     {
       validate: (lang: string) => boolean;
       validationError: 'Invalid language code provided which is not supported by Intl.getCanonicalLocales';
     }
   >;
-  name: typeof fields.STRING_FIELD;
-  path: typeof fields.STRING_FIELD;
-  system: typeof fields.STRING_FIELD;
-  module: typeof fields.STRING_FIELD;
+  name: fields.StringField;
+  path: fields.RequiredString;
+  system: fields.StringField;
+  module: fields.StringField;
 }
 
 interface PackageLanguageDataProperties {
@@ -24,7 +24,7 @@ interface PackageLanguageDataProperties {
   name: string | undefined;
 
   /** The relative path to included JSON translation strings */
-  path: string | undefined;
+  path: string;
 
   /** Only apply this set of translations when a specific system is being used */
   system: string | undefined;
@@ -40,7 +40,7 @@ interface PackageLanguageDataConstructorData {
   name?: string | null | undefined;
 
   /** The relative path to included JSON translation strings */
-  path?: string | null | undefined;
+  path: string;
 
   /** Only apply this set of translations when a specific system is being used */
   system?: string | null | undefined;
@@ -51,12 +51,13 @@ interface PackageLanguageDataConstructorData {
 /**
  * An inner data object which represents a single language specification provided by a package in the languages array.
  */
-export declare class PackageLanguageData extends DocumentData<
+export class PackageLanguageData extends DocumentData<
   PackageLanguageDataSchema,
   PackageLanguageDataProperties,
   PropertiesToSource<PackageLanguageDataProperties>,
   PackageLanguageDataConstructorData
 > {
+  /** @override */
   static defineSchema(): PackageLanguageDataSchema;
 
   /** @override */
@@ -71,4 +72,4 @@ export declare class PackageLanguageData extends DocumentData<
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export declare interface PackageLanguageData extends PackageLanguageDataProperties {}
+export interface PackageLanguageData extends PackageLanguageDataProperties {}

--- a/src/foundry/common/packages.mjs/systemData.d.ts
+++ b/src/foundry/common/packages.mjs/systemData.d.ts
@@ -2,12 +2,12 @@ import * as fields from '../data/fields.mjs';
 import { PackageData, PackageDataConstructorData, PackageDataProperties, PackageDataSchema } from './packageData';
 
 interface SystemDataSchema extends PackageDataSchema {
-  background: typeof fields.STRING_FIELD;
-  initiative: typeof fields.STRING_FIELD;
-  gridDistance: typeof fields.NUMERIC_FIELD;
-  gridUnits: typeof fields.STRING_FIELD;
-  primaryTokenAttribute: typeof fields.STRING_FIELD;
-  secondaryTokenAttribute: typeof fields.STRING_FIELD;
+  background: fields.StringField;
+  initiative: fields.StringField;
+  gridDistance: fields.NumericField;
+  gridUnits: fields.StringField;
+  primaryTokenAttribute: fields.StringField;
+  secondaryTokenAttribute: fields.StringField;
 }
 
 interface SystemDataProperties extends PackageDataProperties {
@@ -50,9 +50,10 @@ interface SystemDataConstructorData extends PackageDataConstructorData {
  * The data schema used to define System manifest files.
  * Extends the basic PackageData schema with some additional system-specific fields.
  */
-export declare class SystemData extends PackageData<SystemDataSchema, SystemDataProperties, SystemDataConstructorData> {
+export class SystemData extends PackageData<SystemDataSchema, SystemDataProperties, SystemDataConstructorData> {
+  /** @override */
   static defineSchema(): SystemDataSchema;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export declare interface SystemData extends SystemDataProperties {}
+export interface SystemData extends SystemDataProperties {}

--- a/src/foundry/common/packages.mjs/tagPackageAvailability.d.ts
+++ b/src/foundry/common/packages.mjs/tagPackageAvailability.d.ts
@@ -1,7 +1,7 @@
 /**
  * Checks a package against its availability code to see if it requires a compability warning, and if so, updates the pkg
  * @param pkg - The package
- * @remarks This doesn't actually update the package, it just sets the `unavailable` and `incompatible` flags if needed.
+ * @remarks This doesn't actually update the package, it just sets the `unavailable` and `incompatible` properties if needed.
  */
 export declare function tagPackageAvailability(pkg: {
   availability: foundry.CONST.PACKAGE_AVAILABILITY_CODES;

--- a/src/foundry/common/packages.mjs/worldData.d.ts
+++ b/src/foundry/common/packages.mjs/worldData.d.ts
@@ -3,13 +3,13 @@ import * as fields from '../data/fields.mjs';
 import { PackageData, PackageDataConstructorData, PackageDataProperties, PackageDataSchema } from './packageData';
 
 interface WorldDataSchema extends Omit<PackageDataSchema, 'system'> {
-  system: typeof fields.REQUIRED_STRING;
-  background: typeof fields.STRING_FIELD;
-  coreVersion: typeof fields.REQUIRED_STRING;
-  nextSession: typeof fields.STRING_FIELD;
-  resetKeys: typeof fields.BOOLEAN_FIELD;
-  safeMode: typeof fields.BOOLEAN_FIELD;
-  systemVersion: FieldReturnType<typeof fields.REQUIRED_STRING, { default: () => string }>;
+  system: fields.RequiredString;
+  background: fields.StringField;
+  coreVersion: fields.RequiredString;
+  nextSession: fields.StringField;
+  resetKeys: fields.BooleanField;
+  safeMode: fields.BooleanField;
+  systemVersion: FieldReturnType<fields.RequiredString, { default: () => string }>;
 }
 
 interface WorldDataProperties extends Omit<PackageDataProperties, 'system'> {
@@ -25,11 +25,16 @@ interface WorldDataProperties extends Omit<PackageDataProperties, 'system'> {
   /** An ISO datetime string when the next game session is scheduled to occur */
   nextSession: string | undefined;
 
+  /** @defaultValue `false` */
   resetKeys: boolean;
 
+  /** @defaultValue `false` */
   safeMode: boolean;
 
-  /** The version of the game system for which this world has been migrated */
+  /**
+   * The version of the game system for which this world has been migrated
+   * @defaultValue `game.system?.data.version ?? ""`
+   */
   systemVersion: string;
 }
 
@@ -46,11 +51,16 @@ interface WorldDataConstructorData extends Omit<PackageDataConstructorData, 'sys
   /** An ISO datetime string when the next game session is scheduled to occur */
   nextSession?: string | null | undefined;
 
+  /** @defaultValue `false` */
   resetKeys?: boolean | null | undefined;
 
+  /** @defaultValue `false` */
   safeMode?: boolean | null | undefined;
 
-  /** The version of the game system for which this world has been migrated */
+  /**
+   * The version of the game system for which this world has been migrated
+   * @defaultValue `game.system?.data.version ?? ""`
+   */
   systemVersion?: string | null | undefined;
 }
 
@@ -58,9 +68,10 @@ interface WorldDataConstructorData extends Omit<PackageDataConstructorData, 'sys
  * The data schema used to define World manifest files.
  * Extends the basic PackageData schema with some additional world-specific fields.
  */
-export declare class WorldData extends PackageData<WorldDataSchema, WorldDataProperties, WorldDataConstructorData> {
+export class WorldData extends PackageData<WorldDataSchema, WorldDataProperties, WorldDataConstructorData> {
+  /** @override */
   static defineSchema(): WorldDataSchema;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export declare interface WorldData extends WorldDataProperties {}
+export interface WorldData extends WorldDataProperties {}

--- a/src/foundry/foundry.js/application.d.ts
+++ b/src/foundry/foundry.js/application.d.ts
@@ -440,7 +440,7 @@ declare namespace Application {
 
     /**
      * The default CSS id to assign to the rendered HTML
-     * @defaultValue `''`
+     * @defaultValue `""`
      */
     id: string;
 
@@ -452,7 +452,7 @@ declare namespace Application {
 
     /**
      * A default window title string (popOut only)
-     * @defaultValue `''`
+     * @defaultValue `""`
      */
     title: string;
 

--- a/src/foundry/foundry.js/applications/filePicker.d.ts
+++ b/src/foundry/foundry.js/applications/filePicker.d.ts
@@ -70,7 +70,7 @@ declare class FilePicker<
 
   /**
    * Record the last-browsed directory path so that re-opening a different FilePicker instance uses the same target
-   * @defaultValue `''`
+   * @defaultValue `""`
    */
   static LAST_BROWSED_DIRECTORY: string;
 

--- a/src/foundry/foundry.js/applications/formApplication.d.ts
+++ b/src/foundry/foundry.js/applications/formApplication.d.ts
@@ -171,7 +171,7 @@ declare abstract class FormApplication<
    * @param options        - TinyMCE initialization options passed to TextEditor.create
    *                         (default: `{}`)
    * @param initialContent - Initial text content for the editor area.
-   *                         (default: `''`)
+   *                         (default: `""`)
    */
   activateEditor(name: string, options?: TextEditor.Options, initialContent?: string): void;
 

--- a/src/foundry/foundry.js/applications/formApplications/documentSheets/rollTableConfig.d.ts
+++ b/src/foundry/foundry.js/applications/formApplications/documentSheets/rollTableConfig.d.ts
@@ -1,8 +1,5 @@
-import type {
-  ConfiguredDocumentClassForName,
-  ConstructorDataType,
-  ToObjectFalseType
-} from '../../../../../types/helperTypes';
+import type { ConfiguredDocumentClassForName, ToObjectFalseType } from '../../../../../types/helperTypes';
+import type { TableResultDataConstructorData } from '../../../../common/data/data.mjs/tableResultData.js';
 
 declare global {
   /**
@@ -55,7 +52,7 @@ declare global {
      */
     protected _onCreateResult(
       event: JQuery.ClickEvent | DragEvent,
-      resultData?: ConstructorDataType<foundry.data.TableResultData>
+      resultData?: TableResultDataConstructorData
     ): Promise<ConfiguredDocumentClassForName<'TableResult'>[]>;
 
     /**

--- a/src/foundry/foundry.js/applications/formApplications/tokenConfig.d.ts
+++ b/src/foundry/foundry.js/applications/formApplications/tokenConfig.d.ts
@@ -1,4 +1,5 @@
-import type { ConfiguredDocumentClassForName, ConstructorDataType } from '../../../../types/helperTypes';
+import type { ConfiguredDocumentClassForName } from '../../../../types/helperTypes';
+import type { TokenDataConstructorData } from '../../../common/data/data.mjs/tokenData.js';
 
 declare global {
   /**
@@ -70,9 +71,7 @@ declare global {
     activateListeners(html: JQuery): void;
 
     /** @override */
-    protected _getSubmitData(
-      updateData?: ConstructorDataType<foundry.data.TokenData>
-    ): Record<string, unknown> & { lightAlpha: number };
+    protected _getSubmitData(updateData?: TokenDataConstructorData): Record<string, unknown> & { lightAlpha: number };
 
     /** @override */
     protected _updateObject(

--- a/src/foundry/foundry.js/applications/sidebarTab.d.ts
+++ b/src/foundry/foundry.js/applications/sidebarTab.d.ts
@@ -8,7 +8,7 @@ declare abstract class SidebarTab<
   constructor(...args: ConstructorParameters<typeof Application>);
   /**
    * The base name of this sidebar tab
-   * @defaultValue `''`
+   * @defaultValue `""`
    */
   tabName: string;
 

--- a/src/foundry/foundry.js/applications/sidebarTabs/chatLog.d.ts
+++ b/src/foundry/foundry.js/applications/sidebarTabs/chatLog.d.ts
@@ -1,4 +1,5 @@
-import { ConfiguredDocumentClass, ConstructorDataType } from '../../../../types/helperTypes';
+import { ConfiguredDocumentClass } from '../../../../types/helperTypes';
+import type { ChatMessageDataConstructorData } from '../../../common/data/data.mjs/chatMessageData.js';
 
 declare global {
   /**
@@ -162,7 +163,7 @@ declare global {
     protected _processDiceCommand(
       command: string,
       match: RegExpMatchArray,
-      chatData: ConstructorDataType<foundry.data.ChatMessageData>,
+      chatData: ChatMessageDataConstructorData,
       createOptions: DocumentModificationContext
     ): void;
 
@@ -178,7 +179,7 @@ declare global {
     protected _processWhisperCommand(
       command: string,
       match: RegExpMatchArray,
-      chatData: ConstructorDataType<foundry.data.ChatMessageData>,
+      chatData: ChatMessageDataConstructorData,
       createOptions: DocumentModificationContext
     ): void;
 
@@ -193,7 +194,7 @@ declare global {
     protected _processChatCommand(
       command: string,
       match: RegExpMatchArray,
-      chatData: ConstructorDataType<foundry.data.ChatMessageData>,
+      chatData: ChatMessageDataConstructorData,
       createOptions: DocumentModificationContext
     ): void;
 

--- a/src/foundry/foundry.js/avSettings.d.ts
+++ b/src/foundry/foundry.js/avSettings.d.ts
@@ -116,22 +116,22 @@ declare class AVSettings {
       type: string;
 
       /**
-       * @defaultValue `''`
+       * @defaultValue `""`
        */
       url: string;
 
       /**
-       * @defaultValue `''`
+       * @defaultValue `""`
        */
       room: string;
 
       /**
-       * @defaultValue `''`
+       * @defaultValue `""`
        */
       username: string;
 
       /**
-       * @defaultValue `''`
+       * @defaultValue `""`
        */
       password: string;
     };
@@ -143,17 +143,17 @@ declare class AVSettings {
       type: string;
 
       /**
-       * @defaultValue `''`
+       * @defaultValue `""`
        */
       url: string;
 
       /**
-       * @defaultValue `''`
+       * @defaultValue `""`
        */
       username: string;
 
       /**
-       * @defaultValue `''`
+       * @defaultValue `""`
        */
       password: string;
     };

--- a/src/foundry/foundry.js/clientDocuments/activeEffect.d.ts
+++ b/src/foundry/foundry.js/clientDocuments/activeEffect.d.ts
@@ -1,5 +1,6 @@
+import { ConfiguredDocumentClass } from '../../../types/helperTypes';
 import { DocumentModificationOptions } from '../../common/abstract/document.mjs';
-import { ConfiguredDocumentClass, ConstructorDataType } from '../../../types/helperTypes';
+import type { ActiveEffectDataConstructorData } from '../../common/data/data.mjs/activeEffectData.js';
 import { EffectChangeData } from '../../common/data/data.mjs/effectChangeData';
 
 declare global {
@@ -133,7 +134,7 @@ declare global {
     protected _getSourceName(): Promise<string>;
 
     protected _preCreate(
-      data: ConstructorDataType<foundry.data.ActiveEffectData>,
+      data: ActiveEffectDataConstructorData,
       options: DocumentModificationOptions,
       user: foundry.documents.BaseUser
     ): Promise<void>;

--- a/src/foundry/foundry.js/clientDocuments/actor.d.ts
+++ b/src/foundry/foundry.js/clientDocuments/actor.d.ts
@@ -1,11 +1,7 @@
-import {
-  ConfiguredDocumentClass,
-  ConfiguredObjectClassForName,
-  ConstructorDataType,
-  DocumentConstructor
-} from '../../../types/helperTypes';
+import { ConfiguredDocumentClass, ConfiguredObjectClassForName, DocumentConstructor } from '../../../types/helperTypes';
 import { DocumentModificationOptions } from '../../common/abstract/document.mjs';
 import EmbeddedCollection from '../../common/abstract/embedded-collection.mjs';
+import type { ActorDataConstructorData } from '../../common/data/data.mjs/actorData.js';
 
 declare global {
   /**
@@ -170,7 +166,7 @@ declare global {
 
     /** @override */
     protected _preCreate(
-      data: ConstructorDataType<foundry.data.ActorData>,
+      data: ActorDataConstructorData,
       options: DocumentModificationOptions,
       user: foundry.documents.BaseUser
     ): Promise<void>;

--- a/src/foundry/foundry.js/clientDocuments/chatMessage.d.ts
+++ b/src/foundry/foundry.js/clientDocuments/chatMessage.d.ts
@@ -1,5 +1,6 @@
-import { ConfiguredDocumentClass, ConstructorDataType } from '../../../types/helperTypes';
+import { ConfiguredDocumentClass } from '../../../types/helperTypes';
 import { DocumentModificationOptions } from '../../common/abstract/document.mjs';
+import type { ChatMessageDataConstructorData } from '../../common/data/data.mjs/chatMessageData.js';
 
 declare global {
   /**
@@ -72,9 +73,9 @@ declare global {
      * @returns The modified ChatMessage data with rollMode preferences applied
      */
     static applyRollMode(
-      chatData: ConstructorDataType<foundry.data.ChatMessageData>,
+      chatData: ChatMessageDataConstructorData,
       rollMode: foundry.CONST.DICE_ROLL_MODES
-    ): ConstructorDataType<foundry.data.ChatMessageData>;
+    ): ChatMessageDataConstructorData;
 
     /**
      * Update the data of a ChatMessage instance to apply a requested rollMode
@@ -197,7 +198,7 @@ declare global {
 
     /** @override */
     _preCreate(
-      data: ConstructorDataType<foundry.data.ChatMessageData>,
+      data: ChatMessageDataConstructorData,
       options: DocumentModificationOptions,
       user: foundry.documents.BaseUser
     ): Promise<void>;

--- a/src/foundry/foundry.js/clientDocuments/combat.d.ts
+++ b/src/foundry/foundry.js/clientDocuments/combat.d.ts
@@ -1,6 +1,7 @@
-import { ConfiguredDocumentClass, ConstructorDataType, PropertiesToSource } from '../../../types/helperTypes';
+import { ConfiguredDocumentClass, PropertiesToSource } from '../../../types/helperTypes';
 import { DocumentModificationOptions } from '../../common/abstract/document.mjs';
 import { CombatantDataProperties } from '../../common/data/data.mjs/combatantData';
+import type { CombatDataConstructorData } from '../../common/data/data.mjs/combatData.js';
 
 declare global {
   /**
@@ -183,18 +184,13 @@ declare global {
 
     /** @deprecated since 0.8.0 */
     createCombatant(
-      data:
-        | ConstructorDataType<foundry.data.CombatData>
-        | (ConstructorDataType<foundry.data.CombatData> & Record<string, unknown>),
+      data: CombatDataConstructorData | (CombatDataConstructorData & Record<string, unknown>),
       options?: DocumentModificationContext
     ): this['createEmbeddedDocuments'];
 
     /** @deprecated since 0.8.0 */
     updateCombatant(
-      data: DeepPartial<
-        | ConstructorDataType<foundry.data.CombatData>
-        | (ConstructorDataType<foundry.data.CombatData> & Record<string, unknown>)
-      >,
+      data: DeepPartial<CombatDataConstructorData | (CombatDataConstructorData & Record<string, unknown>)>,
       options?: DocumentModificationContext
     ): NonNullable<ReturnType<this['combatants']['get']>>['update'];
 

--- a/src/foundry/foundry.js/clientDocuments/folder.d.ts
+++ b/src/foundry/foundry.js/clientDocuments/folder.d.ts
@@ -1,5 +1,6 @@
+import { ConfiguredDocumentClass } from '../../../types/helperTypes';
 import { DocumentModificationOptions } from '../../common/abstract/document.mjs';
-import { ConfiguredDocumentClass, ConstructorDataType } from '../../../types/helperTypes';
+import type { FolderDataConstructorData } from '../../common/data/data.mjs/folderData.js';
 
 declare global {
   /**
@@ -69,10 +70,7 @@ declare global {
      * Document is returned.
      */
     static createDialog(
-      data?: DeepPartial<
-        | ConstructorDataType<foundry.data.FolderData>
-        | (ConstructorDataType<foundry.data.FolderData> & Record<string, unknown>)
-      >,
+      data?: DeepPartial<FolderDataConstructorData | (FolderDataConstructorData & Record<string, unknown>)>,
       options?: Dialog.Options
     ): any;
 

--- a/src/foundry/foundry.js/clientDocuments/item.d.ts
+++ b/src/foundry/foundry.js/clientDocuments/item.d.ts
@@ -1,4 +1,5 @@
-import { ConfiguredDocumentClass, ConstructorDataType } from '../../../types/helperTypes';
+import { ConfiguredDocumentClass } from '../../../types/helperTypes';
+import type { ItemDataConstructorData } from '../../common/data/data.mjs/itemData.js';
 
 declare global {
   /**
@@ -69,9 +70,7 @@ declare global {
      * @deprecated since 0.8.1
      */
     static createOwned(
-      itemData:
-        | ConstructorDataType<foundry.data.ItemData>
-        | (ConstructorDataType<foundry.data.ItemData> & Record<string, unknown>),
+      itemData: ItemDataConstructorData | (ItemDataConstructorData & Record<string, unknown>),
       actor: InstanceType<ConfiguredDocumentClass<typeof foundry.documents.BaseActor>>
     ): InstanceType<ConfiguredDocumentClass<typeof foundry.documents.BaseItem>>;
   }

--- a/src/foundry/foundry.js/clientDocuments/playlist.d.ts
+++ b/src/foundry/foundry.js/clientDocuments/playlist.d.ts
@@ -1,5 +1,6 @@
-import type { ConfiguredDocumentClass, ConstructorDataType } from '../../../types/helperTypes';
+import type { ConfiguredDocumentClass } from '../../../types/helperTypes';
 import type { DocumentModificationOptions } from '../../common/abstract/document.mjs';
+import type { PlaylistDataConstructorData } from '../../common/data/data.mjs/playlistData.js';
 
 declare global {
   /**
@@ -128,7 +129,7 @@ declare global {
 
     /** @override */
     protected _preUpdate(
-      changed: DeepPartial<ConstructorDataType<foundry.data.PlaylistData>>,
+      changed: DeepPartial<PlaylistDataConstructorData>,
       options: DocumentModificationOptions,
       user: foundry.documents.BaseUser
     ): Promise<void>;

--- a/src/foundry/foundry.js/clientDocuments/scene.d.ts
+++ b/src/foundry/foundry.js/clientDocuments/scene.d.ts
@@ -1,13 +1,23 @@
-import { ConfiguredDocumentClass, ConstructorDataType, PropertiesToSource } from '../../../types/helperTypes';
+import { ConfiguredDocumentClass, PropertiesToSource } from '../../../types/helperTypes';
 import { DocumentModificationOptions } from '../../common/abstract/document.mjs';
-import { AmbientLightDataProperties } from '../../common/data/data.mjs/ambientLightData';
-import { AmbientSoundDataProperties } from '../../common/data/data.mjs/ambientSoundData';
-import { DrawingDataProperties } from '../../common/data/data.mjs/drawingData';
-import { MeasuredTemplateDataProperties } from '../../common/data/data.mjs/measuredTemplateData';
-import { NoteDataProperties } from '../../common/data/data.mjs/noteData';
-import { TileDataProperties } from '../../common/data/data.mjs/tileData';
-import { TokenDataProperties } from '../../common/data/data.mjs/tokenData';
-import { WallDataProperties } from '../../common/data/data.mjs/wallData';
+import {
+  AmbientLightDataConstructorData,
+  AmbientLightDataProperties
+} from '../../common/data/data.mjs/ambientLightData';
+import {
+  AmbientSoundDataConstructorData,
+  AmbientSoundDataProperties
+} from '../../common/data/data.mjs/ambientSoundData';
+import { DrawingDataConstructorData, DrawingDataProperties } from '../../common/data/data.mjs/drawingData';
+import {
+  MeasuredTemplateDataConstructorData,
+  MeasuredTemplateDataProperties
+} from '../../common/data/data.mjs/measuredTemplateData';
+import { NoteDataConstructorData, NoteDataProperties } from '../../common/data/data.mjs/noteData';
+import type { SceneDataConstructorData } from '../../common/data/data.mjs/sceneData.js';
+import { TileDataConstructorData, TileDataProperties } from '../../common/data/data.mjs/tileData';
+import { TokenDataConstructorData, TokenDataProperties } from '../../common/data/data.mjs/tokenData';
+import { WallDataConstructorData, WallDataProperties } from '../../common/data/data.mjs/wallData';
 
 declare global {
   /**
@@ -94,10 +104,7 @@ declare global {
      * @param options    - (default: `{}`)
      */
     clone(
-      createData?: DeepPartial<
-        | ConstructorDataType<foundry.data.SceneData>
-        | (ConstructorDataType<foundry.data.SceneData> & Record<string, unknown>)
-      >,
+      createData?: DeepPartial<SceneDataConstructorData | (SceneDataConstructorData & Record<string, unknown>)>,
       options?: { save?: boolean; keepId?: boolean }
     ): TemporaryDocument<this> | Promise<TemporaryDocument<this | undefined>>;
 
@@ -106,7 +113,7 @@ declare global {
 
     /** @override */
     protected _preCreate(
-      data: ConstructorDataType<foundry.data.SceneData>,
+      data: SceneDataConstructorData,
       options: DocumentModificationOptions,
       user: foundry.documents.BaseUser
     ): Promise<void>;
@@ -120,7 +127,7 @@ declare global {
 
     /** @override */
     protected _preUpdate(
-      changed: DeepPartial<ConstructorDataType<foundry.data.SceneData>>,
+      changed: DeepPartial<SceneDataConstructorData>,
       options: DocumentModificationOptions,
       user: foundry.documents.BaseUser
     ): Promise<void>;
@@ -147,49 +154,49 @@ declare global {
     /** @override */
     _preCreateEmbeddedDocuments(
       embeddedName: string,
-      result: ConstructorDataType<foundry.data.DrawingData>[],
+      result: DrawingDataConstructorData[],
       options: DocumentModificationOptions,
       userId: string
     ): void;
     _preCreateEmbeddedDocuments(
       embeddedName: string,
-      result: ConstructorDataType<foundry.data.TokenData>[],
+      result: TokenDataConstructorData[],
       options: DocumentModificationOptions,
       userId: string
     ): void;
     _preCreateEmbeddedDocuments(
       embeddedName: string,
-      result: ConstructorDataType<foundry.data.AmbientLightData>[],
+      result: AmbientLightDataConstructorData[],
       options: DocumentModificationOptions,
       userId: string
     ): void;
     _preCreateEmbeddedDocuments(
       embeddedName: string,
-      result: ConstructorDataType<foundry.data.NoteData>[],
+      result: NoteDataConstructorData[],
       options: DocumentModificationOptions,
       userId: string
     ): void;
     _preCreateEmbeddedDocuments(
       embeddedName: string,
-      result: ConstructorDataType<foundry.data.AmbientSoundData>[],
+      result: AmbientSoundDataConstructorData[],
       options: DocumentModificationOptions,
       userId: string
     ): void;
     _preCreateEmbeddedDocuments(
       embeddedName: string,
-      result: ConstructorDataType<foundry.data.MeasuredTemplateData>[],
+      result: MeasuredTemplateDataConstructorData[],
       options: DocumentModificationOptions,
       userId: string
     ): void;
     _preCreateEmbeddedDocuments(
       embeddedName: string,
-      result: ConstructorDataType<foundry.data.TileData>[],
+      result: TileDataConstructorData[],
       options: DocumentModificationOptions,
       userId: string
     ): void;
     _preCreateEmbeddedDocuments(
       embeddedName: string,
-      result: ConstructorDataType<foundry.data.WallData>[],
+      result: WallDataConstructorData[],
       options: DocumentModificationOptions,
       userId: string
     ): void;

--- a/src/foundry/foundry.js/collections/documentCollections/compendiumCollection.d.ts
+++ b/src/foundry/foundry.js/collections/documentCollections/compendiumCollection.d.ts
@@ -286,7 +286,7 @@ interface ImportAllOptions {
   folderId?: string | null;
   /**
    * A new Folder name to create.
-   * @defaultValue `''`
+   * @defaultValue `""`
    * */
   folderName?: string;
   /**

--- a/src/foundry/foundry.js/collections/documentCollections/worldCollections/playlists.d.ts
+++ b/src/foundry/foundry.js/collections/documentCollections/worldCollections/playlists.d.ts
@@ -1,4 +1,5 @@
-import { ConfiguredDocumentClass, ConstructorDataType } from '../../../../../types/helperTypes';
+import { ConfiguredDocumentClass } from '../../../../../types/helperTypes';
+import type { SceneDataConstructorData } from '../../../../common/data/data.mjs/sceneData.js';
 
 declare global {
   /**
@@ -35,7 +36,7 @@ declare global {
      */
     protected _onChangeScene(
       scene: StoredDocument<InstanceType<ConfiguredDocumentClass<typeof foundry.documents.BaseScene>>>,
-      data: DeepPartial<ConstructorDataType<foundry.documents.BaseScene['data']>>
+      data: DeepPartial<SceneDataConstructorData>
     ): Promise<void>;
   }
 }

--- a/src/foundry/foundry.js/handlebarsHelpers.d.ts
+++ b/src/foundry/foundry.js/handlebarsHelpers.d.ts
@@ -218,7 +218,7 @@ declare namespace HandlebarsHelpers {
 
       /**
        * The original HTML content as a string
-       * @defaultValue `''`
+       * @defaultValue `""`
        */
       content?: string;
     };
@@ -259,7 +259,7 @@ declare namespace HandlebarsHelpers {
   interface NumberInputOptions extends Handlebars.HelperOptions {
     hash: {
       /**
-       * @defaultValue `''`
+       * @defaultValue `""`
        */
       name?: string;
 
@@ -271,12 +271,12 @@ declare namespace HandlebarsHelpers {
       disabled?: boolean;
 
       /**
-       * @defaultValue `''`
+       * @defaultValue `""`
        */
       placeholder?: string;
 
       /**
-       * @defaultValue `''`
+       * @defaultValue `""`
        */
       class?: string;
 

--- a/src/foundry/foundry.js/searchFilter.d.ts
+++ b/src/foundry/foundry.js/searchFilter.d.ts
@@ -84,7 +84,7 @@ declare namespace SearchFilter {
 
     /**
      * The initial value of the search query.
-     * @defaultValue `''`
+     * @defaultValue `""`
      */
     initial?: SearchFilter['query'];
 

--- a/src/foundry/foundry.js/textEditor.d.ts
+++ b/src/foundry/foundry.js/textEditor.d.ts
@@ -6,7 +6,7 @@ declare class TextEditor {
    * Create a Rich Text Editor. The current implementation uses TinyMCE
    * @param options - Configuration options provided to the Editor init
    * @param content - Initial HTML or text content to populate the editor with
-   *                  (default: `''`)
+   *                  (default: `""`)
    * @returns The editor instance.
    */
   static create(options: TextEditor.Options, content: string): Promise<tinyMCE.Editor>;

--- a/test-d/foundry/common/data/data.mjs/settingData.test-d.ts
+++ b/test-d/foundry/common/data/data.mjs/settingData.test-d.ts
@@ -2,4 +2,9 @@ import { expectError, expectType } from 'tsd';
 
 expectError(new foundry.data.SettingData());
 expectError(new foundry.data.SettingData({}));
-expectType<foundry.data.SettingData>(new foundry.data.SettingData({ key: 'foo', value: 'bar' }));
+expectError(new foundry.data.SettingData({ key: 'foo', value: 'bar' }));
+expectType<foundry.data.SettingData>(new foundry.data.SettingData({ key: 'foo.bar', value: 'bar' }));
+const namespace = 'foo';
+const key = 'bar';
+expectType<foundry.data.SettingData>(new foundry.data.SettingData({ key: `${namespace}.${key}`, value: 'bar' }));
+expectError(new foundry.data.SettingData({ key: namespace + '.' + key, value: 'bar' }));

--- a/test-d/foundry/common/data/data.mjs/userData.test-d.ts
+++ b/test-d/foundry/common/data/data.mjs/userData.test-d.ts
@@ -3,3 +3,7 @@ import { expectError, expectType } from 'tsd';
 expectError(new foundry.data.UserData());
 expectError(new foundry.data.UserData({}));
 expectType<foundry.data.UserData>(new foundry.data.UserData({ name: 'foo' }));
+expectType<foundry.data.UserData>(new foundry.data.UserData({ name: 'foo', hotbar: { 1: 'foo' } }));
+expectType<foundry.data.UserData>(new foundry.data.UserData({ name: 'foo', hotbar: { '1': 'foo' } }));
+expectType<foundry.data.UserData>(new foundry.data.UserData({ name: 'foo', hotbar: { ['1']: 'foo' } }));
+expectError(new foundry.data.UserData({ name: 'foo', hotbar: { foo: 'foo' } }));

--- a/test-d/foundry/common/documents.mjs/baseSetting.test-d.ts
+++ b/test-d/foundry/common/documents.mjs/baseSetting.test-d.ts
@@ -1,13 +1,16 @@
 import { expectType } from 'tsd';
 
 expectType<Promise<StoredDocument<Setting> | undefined>>(
-  foundry.documents.BaseSetting.create({ key: 'foo', value: 'bar' })
+  foundry.documents.BaseSetting.create({ key: 'foo.bar', value: 'bar' })
 );
 expectType<Promise<StoredDocument<Setting>[]>>(foundry.documents.BaseSetting.createDocuments([]));
 expectType<Promise<Setting[]>>(foundry.documents.BaseSetting.updateDocuments([]));
 expectType<Promise<Setting[]>>(foundry.documents.BaseSetting.deleteDocuments([]));
 
-const settingData = await foundry.documents.BaseSetting.create({ key: 'fizz', value: 'buzz' }, { temporary: true });
+const settingData = await foundry.documents.BaseSetting.create(
+  { key: 'fizz.buzz', value: 'buzz' },
+  { temporary: true }
+);
 if (settingData) {
   expectType<foundry.data.SettingData>(settingData.data);
 }

--- a/test-d/foundry/foundry.js/clientDocuments/setting.test-d.ts
+++ b/test-d/foundry/foundry.js/clientDocuments/setting.test-d.ts
@@ -1,11 +1,11 @@
 import { expectType } from 'tsd';
 
-const setting = new Setting({ key: 'foo', value: 'bar' });
+const setting = new Setting({ key: 'foo.bar', value: 'bar' });
 
 expectType<typeof foundry.data.SettingData>(Setting.schema);
 expectType<string>(setting.key);
 expectType<unknown>(setting.value);
-expectType<Promise<StoredDocument<Setting> | undefined>>(Setting.create({ key: 'foo', value: 'bar' }));
+expectType<Promise<StoredDocument<Setting> | undefined>>(Setting.create({ key: 'foo.bar', value: 'bar' }));
 expectType<Promise<StoredDocument<Setting>[]>>(Setting.createDocuments([]));
 expectType<Promise<Setting[]>>(Setting.updateDocuments([]));
 expectType<Promise<Setting[]>>(Setting.deleteDocuments([]));


### PR DESCRIPTION
This refactors all data classes and brings them all to a common
standard. Mainly this does the following:
- adds missing defaultValue documentations
- adds missing union type members for constructor data (especially
  foreign document fields)
- removes superfluous export and declare statements
- makes the order of null and undefined union members consistent
- moves the types internal documentation of property and constructor
  types to the types instead of the field constants
- uses the field types instead of the field constants everywhere
- replaces the use of ConstructorDataType with direct constructor data
  interface use where possible

This already includes PR #1482, so should be merged afterwards.