### PR TITLE
Add the possibility to pass the Actor / Item type as generic paramete…

### DIFF
--- a/src/foundry/foundry.js/applications/formApplications/documentSheets/actorSheet.d.ts
+++ b/src/foundry/foundry.js/applications/formApplications/documentSheets/actorSheet.d.ts
@@ -8,13 +8,17 @@ declare global {
    * @param actor   - The Actor instance being displayed within the sheet.
    * @param options - Additional application configuration options.
    *
-   * @typeParam Options - the type of the options object
-   * @typeParam Data    - The data structure used to render the handlebars template.
+   * @typeParam Options       - The type of the options object
+   * @typeParam ConcreteActor - The concrete Actor document class that this sheet manages
+   * @typeParam Data          - The data structure used to render the handlebars template
    */
   class ActorSheet<
     Options extends ActorSheet.Options = ActorSheet.Options,
-    Data extends object = ActorSheet.Data<Options>
-  > extends DocumentSheet<Options, Data, InstanceType<ConfiguredDocumentClass<typeof Actor>>> {
+    ConcreteActor extends InstanceType<ConfiguredDocumentClass<typeof Actor>> = InstanceType<
+      ConfiguredDocumentClass<typeof Actor>
+    >,
+    Data extends object = ActorSheet.Data<Options, ConcreteActor>
+  > extends DocumentSheet<Options, Data, ConcreteActor> {
     /**
      * @defaultValue
      * ```typescript
@@ -162,8 +166,12 @@ declare global {
     /**
      * @typeParam Options - the type of the options object
      */
-    interface Data<Options extends ActorSheet.Options = ActorSheet.Options>
-      extends DocumentSheet.Data<InstanceType<ConfiguredDocumentClass<typeof Actor>>, Options> {
+    interface Data<
+      Options extends ActorSheet.Options = ActorSheet.Options,
+      ConcreteActor extends InstanceType<ConfiguredDocumentClass<typeof Actor>> = InstanceType<
+        ConfiguredDocumentClass<typeof Actor>
+      >
+    > extends DocumentSheet.Data<ConcreteActor, Options> {
       actor: this['document'];
       items: ToObjectFalseType<foundry.data.ActorData>['items'];
       effects: ToObjectFalseType<foundry.data.ActorData>['effects'];

--- a/src/foundry/foundry.js/applications/formApplications/documentSheets/itemSheet.d.ts
+++ b/src/foundry/foundry.js/applications/formApplications/documentSheets/itemSheet.d.ts
@@ -7,13 +7,17 @@ declare global {
    * @param item    - The Item instance being displayed within the sheet.
    * @param options - Additional application configuration options.
    *
-   * @typeParam Options - the type of the options object
-   * @typeParam Data    - The data structure used to render the handlebars template.
+   * @typeParam Options      - the type of the options object
+   * @typeParam ConcreteItem - The concrete Item document class that this sheet manages
+   * @typeParam Data         - The data structure used to render the handlebars template.
    */
   class ItemSheet<
     Options extends ItemSheet.Options = ItemSheet.Options,
-    Data extends object = ItemSheet.Data<Options>
-  > extends DocumentSheet<Options, Data, InstanceType<ConfiguredDocumentClass<typeof Item>>> {
+    ConcreteItem extends InstanceType<ConfiguredDocumentClass<typeof Item>> = InstanceType<
+      ConfiguredDocumentClass<typeof Item>
+    >,
+    Data extends object = ItemSheet.Data<Options, ConcreteItem>
+  > extends DocumentSheet<Options, Data, ConcreteItem> {
     /**
      * @defaultValue
      * ```typescript
@@ -78,8 +82,12 @@ declare global {
     /**
      * @typeParam Options - the type of the options object
      */
-    interface Data<Options extends ItemSheet.Options = ItemSheet.Options>
-      extends DocumentSheet.Data<InstanceType<ConfiguredDocumentClass<typeof Item>>, Options> {
+    interface Data<
+      Options extends ItemSheet.Options = ItemSheet.Options,
+      ConcreteItem extends InstanceType<ConfiguredDocumentClass<typeof Item>> = InstanceType<
+        ConfiguredDocumentClass<typeof Item>
+      >
+    > extends DocumentSheet.Data<ConcreteItem, Options> {
       item: this['document'];
     }
 

--- a/test-d/foundry/foundry.js/applications/formApplications/documentSheets/actorSheet.test-d.ts
+++ b/test-d/foundry/foundry.js/applications/formApplications/documentSheets/actorSheet.test-d.ts
@@ -1,4 +1,5 @@
 import type { ToObjectFalseType } from '../../../../../../src/types/helperTypes';
+import type { ActorDataSource } from '../../../../../../src/foundry/common/data/data.mjs/actorData';
 
 import { expectType } from 'tsd';
 
@@ -10,3 +11,12 @@ expectType<ToObjectFalseType<foundry.data.ItemData>[]>((await actorSheet.getData
 expectType<ToObjectFalseType<foundry.data.ActiveEffectData>[]>((await actorSheet.getData()).effects);
 expectType<ActorSheet.Options>((await actorSheet.getData()).options);
 expectType<TokenDocument | null>(actorSheet.token);
+
+type NPC = Actor & {
+  data: foundry.data.ActorData & { type: 'npc'; _source: ActorDataSource & { type: 'npc' } };
+};
+const npc = new Actor({ name: 'Some dude', type: 'npc' }) as NPC;
+const npcSheet = new ActorSheet<ActorSheet.Options, NPC>(npc);
+expectType<'npc'>(npcSheet.actor.data.type);
+expectType<number>(npcSheet.actor.data.data.damage);
+expectType<string>(npcSheet.actor.data._source.data.faction);


### PR DESCRIPTION
…r to ItemSheet / ActorSheet

I am not 100% sure if we want this because of the breaking change it introduces. See https://github.com/League-of-Foundry-Developers/foundry-vtt-types/issues/1553#issuecomment-1019221383 for more info on that.

Closes #1553