### PR TITLE
fix return type of Application._renderOuter

### DIFF
--- a/src/foundry/foundry.js/application.d.ts
+++ b/src/foundry/foundry.js/application.d.ts
@@ -323,7 +323,7 @@ declare abstract class Application<Options extends ApplicationOptions = Applicat
    * @returns A promise resolving to the constructed jQuery object
    * @internal
    */
-  protected _renderOuter(): Promise<HTMLElement> | Promise<JQuery<JQuery.Node>>;
+  protected _renderOuter(): Promise<JQuery>;
 
   /**
    * Render the inner application content


### PR DESCRIPTION
I believe the intended use of `Application._renderOuter` is exemplified by something like the following.

```ts
protected async _renderOuter() {
    const element = await super._renderOuter();
    $(element).addClass("FOO");
    return element;
}
```

However, the return type -- a union of two different `Promise<T>` types -- causes the code above to fail at compile time.

```
TS2416: Property '_renderOuter' in type 'MyDialog' is not assignable to the same property in base type 'Dialog<Options>'.
  Type '() => Promise<HTMLElement | JQuery<Node>>' is not assignable to type '() => Promise<HTMLElement> | Promise<JQuery<Node>>'.
    Type 'Promise<HTMLElement | JQuery<Node>>' is not assignable to type 'Promise<HTMLElement> | Promise<JQuery<Node>>'.
      Type 'Promise<HTMLElement | JQuery<Node>>' is not assignable to type 'Promise<HTMLElement>'.
        Type 'HTMLElement | JQuery<Node>' is not assignable to type 'HTMLElement'.
          Type 'JQuery<Node>' is missing the following properties from type 'HTMLElement': accessKey, accessKeyLabel, autocapitalize, dir, and 258 more.
```

The same problem happens when not using `async`. In short, the type resolved by the promises returned by the current definition of `super._renderOptions` cannot actually be used to resolve a promise that is compatible with that definition.

```ts
protected _renderOuter() { // SAME ERROR AS ABOVE
    return super._renderOuter()
        .then(element => {
            $(element).addClass("FOOOOOOOOO");
            return element;
        });
}
```