### PR TITLE
Add in configuration for getRollData()

### DIFF
--- a/src/foundry/foundry.js/clientDocuments/actor.d.ts
+++ b/src/foundry/foundry.js/clientDocuments/actor.d.ts
@@ -120,7 +120,7 @@ declare global {
     /**
      * Prepare a data object which defines the data schema used by dice roll commands against this Actor
      */
-    getRollData(): this['data']['data'];
+    getRollData(): object;
 
     /** @override */
     protected _getSheetClass(): ConstructorOf<FormApplication> | null;

--- a/src/foundry/foundry.js/clientDocuments/item.d.ts
+++ b/src/foundry/foundry.js/clientDocuments/item.d.ts
@@ -43,7 +43,7 @@ declare global {
     /**
      * Prepare a data object which defines the data schema used by dice roll commands against this Item
      */
-    getRollData(): this['data']['data'];
+    getRollData(): object;
 
     /** @override */
     protected _getSheetClass(): typeof ItemSheet | null;

--- a/test-d/foundry/foundry.js/clientDocuments/item.test-d.ts
+++ b/test-d/foundry/foundry.js/clientDocuments/item.test-d.ts
@@ -57,5 +57,5 @@ if (item) {
   expectType<boolean>(item.isOwned);
   expectType<ActiveEffect[]>(item.transferredEffects);
   expectType<'weapon' | 'armor'>(item.type);
-  expectType<(object & ArmorDataPropertiesData) | (object & WeaponDataPropertiesData)>(item.getRollData());
+  expectType<object>(item.getRollData());
 }


### PR DESCRIPTION
Motivation: Systems that extend `Item` and `Actor` frequently break polymorphism. The very frequent case of `data.data` and `data._source` has already been accounted for with `DataConfig` and `SourceConfig` respectively. However `getRollData()` also is not always polymorphic to `this.data.data` like it's currently typed as. Most notably Atropos's own D&D 5e implementation has [Actor5e#getRollData()](https://gitlab.com/foundrynet/dnd5e/-/blob/1db8dfe5b8126ba2efb98f5daff3932a0bd94f1a/module/actor/entity.js#L197-206) and [Item5e#getRollData()](https://gitlab.com/foundrynet/dnd5e/-/blob/1db8dfe5b8126ba2efb98f5daff3932a0bd94f1a/module/item/entity.js#L1324-1345) which aren't even bivariant.

Implementation:
Similar to the aforementioned `DataConfig` and `SourceConfig`, this PR adds `GetRollDataConfig` which allows you to type a `Actor` and `Item`'s `getRollData` method. If not provided it defaults to `this.data.data` per before so this change should be completely backwards compatible unless someone just happens to have a `GetRollDataConfig` interface defined in the global namespace in the expected format.