### PR TITLE
Update DefaultTokenConfig for v9

### DIFF
--- a/src/foundry/common/data/data.mjs/index.d.ts
+++ b/src/foundry/common/data/data.mjs/index.d.ts
@@ -26,7 +26,6 @@ export { SceneData } from './sceneData';
 export { SettingData } from './settingData';
 export { TableResultData } from './tableResultData';
 export { TileData } from './tileData';
-export { TokenBarData } from './tokenBarData';
 export { TokenData } from './tokenData';
 export { UserData } from './userData';
 export { WallData } from './wallData';

--- a/src/foundry/foundry.js/applications/formApplications/avConfig.d.ts
+++ b/src/foundry/foundry.js/applications/formApplications/avConfig.d.ts
@@ -50,7 +50,7 @@ declare class AVConfig<
   protected _onTurnTypeChanged(event: JQuery.ChangeEvent): void;
 
   /** @override */
-  protected _updateObject(event: Event, formData?: object): Promise<void>;
+  protected _updateObject(event: Event, formData?: object): Promise<unknown>;
 }
 
 declare namespace AVConfig {

--- a/src/foundry/foundry.js/applications/formApplications/combatTrackerConfig.d.ts
+++ b/src/foundry/foundry.js/applications/formApplications/combatTrackerConfig.d.ts
@@ -25,10 +25,7 @@ declare class CombatTrackerConfig<
   getData(options?: Partial<Options>): Data | Promise<Data>;
 
   /** @override */
-  protected _updateObject(
-    event: Event,
-    formData: ClientSettings.Values['core.combatTrackerConfig']
-  ): Promise<ClientSettings.Values['core.combatTrackerConfig']>;
+  protected _updateObject(event: Event, formData: ClientSettings.Values['core.combatTrackerConfig']): Promise<unknown>;
 }
 
 declare namespace CombatTrackerConfig {

--- a/src/foundry/foundry.js/applications/formApplications/documentSheets/ambientLightConfig.d.ts
+++ b/src/foundry/foundry.js/applications/formApplications/documentSheets/ambientLightConfig.d.ts
@@ -58,10 +58,7 @@ declare global {
      * @param event - (unused)
      * @override
      */
-    protected _updateObject(
-      event: Event,
-      formData: AmbientLightConfig.FormData
-    ): Promise<InstanceType<ConfiguredDocumentClassForName<'AmbientLight'>> | undefined>;
+    protected _updateObject(event: Event, formData: AmbientLightConfig.FormData): Promise<unknown>;
 
     /**
      * Refresh the display of the AmbientLight object

--- a/src/foundry/foundry.js/applications/formApplications/documentSheets/ambientSoundConfig.d.ts
+++ b/src/foundry/foundry.js/applications/formApplications/documentSheets/ambientSoundConfig.d.ts
@@ -34,10 +34,7 @@ declare global {
      * @param event - (unused)
      * @override
      */
-    protected _updateObject(
-      event: Event,
-      formData: AmbientSoundConfig.FormData
-    ): Promise<InstanceType<ConfiguredDocumentClassForName<'AmbientSound'>>>;
+    protected _updateObject(event: Event, formData: AmbientSoundConfig.FormData): Promise<unknown>;
 
     /** @override */
     close(options?: Application.CloseOptions): Promise<void>;

--- a/src/foundry/foundry.js/applications/formApplications/documentSheets/combatantConfig.d.ts
+++ b/src/foundry/foundry.js/applications/formApplications/documentSheets/combatantConfig.d.ts
@@ -32,10 +32,7 @@ declare global {
      * @param event - (unused)
      * @override
      */
-    protected _updateObject(
-      event: Event,
-      formData: CombatantConfig.FormData
-    ): Promise<InstanceType<ConfiguredDocumentClass<typeof Combatant>> | undefined>;
+    protected _updateObject(event: Event, formData: CombatantConfig.FormData): Promise<unknown>;
   }
 
   namespace CombatantConfig {

--- a/src/foundry/foundry.js/applications/formApplications/documentSheets/folderConfig.d.ts
+++ b/src/foundry/foundry.js/applications/formApplications/documentSheets/folderConfig.d.ts
@@ -40,10 +40,7 @@ declare global {
      * @override
      * @internal
      */
-    protected _updateObject(
-      event: Event,
-      formData: FolderConfig.FormData
-    ): Promise<InstanceType<ConfiguredDocumentClass<typeof Folder>> | undefined>;
+    protected _updateObject(event: Event, formData: FolderConfig.FormData): Promise<unknown>;
   }
 
   namespace FolderConfig {

--- a/src/foundry/foundry.js/applications/formApplications/documentSheets/journalSheet.d.ts
+++ b/src/foundry/foundry.js/applications/formApplications/documentSheets/journalSheet.d.ts
@@ -72,10 +72,7 @@ declare global {
     getData(options?: Partial<Options>): Promise<Data> | Data;
 
     /** @override */
-    protected _updateObject(
-      event: Event,
-      formData: JournalSheet.FormData
-    ): ReturnType<DocumentSheet<Options, Data>['_updateObject']>;
+    protected _updateObject(event: Event, formData: JournalSheet.FormData): Promise<unknown>;
 
     /**
      * Handle requests to switch the rendered mode of the Journal Entry sheet

--- a/src/foundry/foundry.js/applications/formApplications/documentSheets/macroConfig.d.ts
+++ b/src/foundry/foundry.js/applications/formApplications/documentSheets/macroConfig.d.ts
@@ -50,10 +50,7 @@ declare global {
     protected _onExecute(event: JQuery.ClickEvent): Promise<void>;
 
     /** @override */
-    protected _updateObject(
-      event: Event,
-      formData: MacroConfig.FormData
-    ): Promise<InstanceType<ConfiguredDocumentClass<typeof Macro>> | undefined>;
+    protected _updateObject(event: Event, formData: MacroConfig.FormData): Promise<unknown>;
   }
 
   namespace MacroConfig {

--- a/src/foundry/foundry.js/applications/formApplications/documentSheets/measuredTemplateConfig.d.ts
+++ b/src/foundry/foundry.js/applications/formApplications/documentSheets/measuredTemplateConfig.d.ts
@@ -30,10 +30,7 @@ declare global {
     getData(): Data | Promise<Data>;
 
     /** @override */
-    protected _updateObject(
-      event: Event,
-      formData: MeasuredTemplateConfig.FormData
-    ): Promise<InstanceType<ConfiguredDocumentClassForName<'MeasuredTemplate'>> | undefined>;
+    protected _updateObject(event: Event, formData: MeasuredTemplateConfig.FormData): Promise<unknown>;
   }
 
   namespace MeasuredTemplateConfig {

--- a/src/foundry/foundry.js/applications/formApplications/documentSheets/noteConfig.d.ts
+++ b/src/foundry/foundry.js/applications/formApplications/documentSheets/noteConfig.d.ts
@@ -33,10 +33,7 @@ declare global {
      * @param event - (unused)
      * @override
      */
-    protected _updateObject(
-      event: Event,
-      formData: NoteConfig.FormData
-    ): Promise<ConfiguredDocumentClassForName<'Note'> | undefined>;
+    protected _updateObject(event: Event, formData: NoteConfig.FormData): Promise<unknown>;
 
     /**
      * @override

--- a/src/foundry/foundry.js/applications/formApplications/documentSheets/playlistSoundConfig.d.ts
+++ b/src/foundry/foundry.js/applications/formApplications/documentSheets/playlistSoundConfig.d.ts
@@ -48,10 +48,7 @@ declare global {
      * @override
      * @param event - (unused)
      */
-    protected _updateObject(
-      event: Event,
-      formData: PlaylistSoundConfig.FormData
-    ): Promise<InstanceType<ConfiguredDocumentClass<typeof PlaylistSound>> | undefined>;
+    protected _updateObject(event: Event, formData: PlaylistSoundConfig.FormData): Promise<unknown>;
   }
 
   namespace PlaylistSoundConfig {

--- a/src/foundry/foundry.js/applications/formApplications/documentSheets/rollTableConfig.d.ts
+++ b/src/foundry/foundry.js/applications/formApplications/documentSheets/rollTableConfig.d.ts
@@ -114,10 +114,7 @@ declare global {
      * @param formData - The validated FormData translated into an Object for submission
      * @internal
      */
-    protected _updateObject(
-      event: Event,
-      formData: RollTableConfig.FormData
-    ): Promise<InstanceType<ConfiguredDocumentClassForName<'RollTable'>> | undefined>;
+    protected _updateObject(event: Event, formData: RollTableConfig.FormData): Promise<unknown>;
 
     /**
      * Display a roulette style animation when a Roll Table result is drawn from the sheet

--- a/src/foundry/foundry.js/applications/formApplications/documentSheets/sceneConfig.d.ts
+++ b/src/foundry/foundry.js/applications/formApplications/documentSheets/sceneConfig.d.ts
@@ -93,10 +93,7 @@ declare global {
     /**
      * @override
      */
-    protected _updateObject(
-      event: Event,
-      formData: SceneConfig.FormData
-    ): Promise<InstanceType<ConfiguredDocumentClassForName<'Scene'>> | undefined>;
+    protected _updateObject(event: Event, formData: SceneConfig.FormData): Promise<unknown>;
   }
 
   namespace SceneConfig {

--- a/src/foundry/foundry.js/applications/formApplications/documentSheets/tileConfig.d.ts
+++ b/src/foundry/foundry.js/applications/formApplications/documentSheets/tileConfig.d.ts
@@ -41,10 +41,7 @@ declare global {
      * @param event - (unused)
      * @override
      */
-    protected _updateObject(
-      event: Event,
-      formData: TileConfig.FormData
-    ): Promise<InstanceType<ConfiguredDocumentClassForName<'Tile'>> | undefined>;
+    protected _updateObject(event: Event, formData: TileConfig.FormData): Promise<unknown>;
   }
 
   namespace TileConfig {

--- a/src/foundry/foundry.js/applications/formApplications/documentSheets/userConfig.d.ts
+++ b/src/foundry/foundry.js/applications/formApplications/documentSheets/userConfig.d.ts
@@ -41,10 +41,7 @@ declare global {
     /**
      * @remarks This method not overridden in foundry but added to provide types when overriding the UserConfig.
      */
-    protected _updateObject(
-      event: Event,
-      formData: FormData
-    ): Promise<InstanceType<ConfiguredDocumentClass<typeof User>> | undefined>;
+    protected _updateObject(event: Event, formData: FormData): Promise<unknown>;
   }
 
   namespace UserConfig {

--- a/src/foundry/foundry.js/applications/formApplications/drawingConfig.d.ts
+++ b/src/foundry/foundry.js/applications/formApplications/drawingConfig.d.ts
@@ -39,10 +39,7 @@ declare global {
     protected static _getFillTypes(): DrawingConfig.FillTypes;
 
     /** @override */
-    protected _updateObject(
-      event: Event,
-      formData: DrawingConfig.FormData
-    ): Promise<foundry.data.DrawingData['_source'] | ConfiguredDocumentClassForName<'Drawing'> | undefined>;
+    protected _updateObject(event: Event, formData: DrawingConfig.FormData): Promise<unknown>;
 
     /** @override */
     close(options?: FormApplication.CloseOptions): Promise<void>;

--- a/src/foundry/foundry.js/applications/formApplications/entitySheetConfig.d.ts
+++ b/src/foundry/foundry.js/applications/formApplications/entitySheetConfig.d.ts
@@ -39,7 +39,7 @@ declare global {
     getData(options?: Partial<Options>): Data | Promise<Data>;
 
     /** @override */
-    protected _updateObject(event: Event, formData: EntitySheetConfig.FormData): Promise<void>;
+    protected _updateObject(event: Event, formData: EntitySheetConfig.FormData): Promise<unknown>;
 
     /**
      * Initialize the configured Sheet preferences for Entities which support dynamic Sheet assignment

--- a/src/foundry/foundry.js/applications/formApplications/gridConfig.d.ts
+++ b/src/foundry/foundry.js/applications/formApplications/gridConfig.d.ts
@@ -145,7 +145,7 @@ declare global {
      * @param event - (unused)
      * @override
      */
-    protected _updateObject(event: Event, formData: GridConfig.FormData): ReturnType<Scene['update']>;
+    protected _updateObject(event: Event, formData: GridConfig.FormData): Promise<unknown>;
   }
 
   namespace GridConfig {

--- a/src/foundry/foundry.js/applications/formApplications/index.d.ts
+++ b/src/foundry/foundry.js/applications/formApplications/index.d.ts
@@ -1,6 +1,5 @@
 import './avConfig';
 import './combatTrackerConfig';
-import './defaultTokenConfig';
 import './documentSheet';
 import './documentSheets';
 import './drawingConfig';
@@ -12,5 +11,6 @@ import './moduleManagement';
 import './permissionConfig';
 import './settingsConfig';
 import './tokenConfig';
+import './tokenConfigs';
 import './wallConfig';
 import './worldConfig';

--- a/src/foundry/foundry.js/applications/formApplications/moduleManagement.d.ts
+++ b/src/foundry/foundry.js/applications/formApplications/moduleManagement.d.ts
@@ -65,7 +65,7 @@ declare class ModuleManagement<
    * @override
    * @param event - (unused)
    */
-  protected _updateObject(event: Event, formData: ModuleManagement.FormData): Promise<Record<string, boolean>>;
+  protected _updateObject(event: Event, formData: ModuleManagement.FormData): Promise<unknown>;
 
   /**
    * Restores the Form UI to the internal checked state

--- a/src/foundry/foundry.js/applications/formApplications/permissionConfig.d.ts
+++ b/src/foundry/foundry.js/applications/formApplications/permissionConfig.d.ts
@@ -49,7 +49,7 @@ declare class PermissionConfig extends FormApplication<FormApplicationOptions, P
    * @param event - (unused)
    * @override
    */
-  protected _updateObject(event: Event, formData: PermissionConfig.FormData): Promise<void>;
+  protected _updateObject(event: Event, formData: PermissionConfig.FormData): Promise<unknown>;
 }
 
 declare namespace PermissionConfig {

--- a/src/foundry/foundry.js/applications/formApplications/settingsConfig.d.ts
+++ b/src/foundry/foundry.js/applications/formApplications/settingsConfig.d.ts
@@ -51,7 +51,7 @@ declare global {
     protected _onResetDefaults(event: JQuery.ClickEvent): void;
 
     /** @override */
-    protected _updateObject(event: Event, formData: SettingsConfig.FormData): Promise<void>;
+    protected _updateObject(event: Event, formData: SettingsConfig.FormData): Promise<unknown>;
   }
 
   namespace SettingsConfig {

--- a/src/foundry/foundry.js/applications/formApplications/tokenConfig.d.ts
+++ b/src/foundry/foundry.js/applications/formApplications/tokenConfig.d.ts
@@ -74,14 +74,7 @@ declare global {
     protected _getSubmitData(updateData?: TokenDataConstructorData): Record<string, unknown> & { lightAlpha: number };
 
     /** @override */
-    protected _updateObject(
-      event: Event,
-      formData: TokenConfig.FormData
-    ): Promise<
-      | InstanceType<ConfiguredDocumentClassForName<'Token'>>
-      | InstanceType<ConfiguredDocumentClassForName<'Actor'>>
-      | undefined
-    >;
+    protected _updateObject(event: Event, formData: TokenConfig.FormData): Promise<unknown>;
 
     /**
      * Handle Token assignment requests to update the default prototype Token

--- a/src/foundry/foundry.js/applications/formApplications/tokenConfigs/defaultTokenConfig.d.ts
+++ b/src/foundry/foundry.js/applications/formApplications/tokenConfigs/defaultTokenConfig.d.ts
@@ -1,3 +1,6 @@
+import type { ConfiguredDocumentClassForName } from '../../../../../types/helperTypes';
+import type { TokenBarData } from '../../../../common/data/data.mjs/tokenBarData';
+
 declare global {
   /**
    * A sheet that alters the values of the default Token configuration used when new Token documents are created.
@@ -5,13 +8,18 @@ declare global {
   class DefaultTokenConfig<
     Options extends FormApplicationOptions = FormApplicationOptions,
     Data extends DefaultTokenConfig.Data = DefaultTokenConfig.Data
-  > extends FormApplication<Options, Data, foundry.data.TokenData['_source']> {
-    constructor(object: unknown, options: Options);
+  > extends TokenConfig<Options, Data> {
+    constructor(object: unknown, options?: Partial<Options> | undefined);
 
     data: foundry.data.TokenData;
 
+    object: InstanceType<ConfiguredDocumentClassForName<'Token'>>;
+
+    token: InstanceType<ConfiguredDocumentClassForName<'Token'>>;
+
     /**
      * The named world setting that stores the default Token configuration
+     * @defaultValue `"defaultToken"`
      */
     static SETTING: string;
 
@@ -20,24 +28,26 @@ declare global {
      * @defaultValue
      * ```typescript
      * foundry.utils.mergeObject(super.defaultOptions, {
-     *   id: "default-token-config",
-     *   classes: ["sheet"],
      *   template: "templates/scene/default-token-config.html",
-     *   title: "Default Token Configuration",
-     *   width: 480,
-     *   height: "auto"
+     *   sheetConfig: false
      * })
      * ```
      */
-    static get defaultOptions(): typeof FormApplication['defaultOptions'];
+    static get defaultOptions(): FormApplicationOptions;
+
+    /** @override */
+    get id(): string;
+
+    /** @override */
+    get title(): string;
 
     /** @override */
     getData(options: unknown): Data | Promise<Data>;
 
     /** @override */
     _getSubmitData(
-      updateData?: Parameters<FormApplication['_getSubmitData']>[0]
-    ): ReturnType<FormApplication['_getSubmitData']>;
+      updateData?: Parameters<TokenConfig['_getSubmitData']>[0]
+    ): ReturnType<TokenConfig['_getSubmitData']>;
 
     /** @override */
     _updateObject(event: Event, formData?: object): Promise<unknown>;
@@ -49,16 +59,19 @@ declare global {
      * Reset the form to default values
      */
     reset(): void;
+
+    /** @override */
+    protected _onBarChange(): Promise<void>;
   }
 
   namespace DefaultTokenConfig {
-    interface Data {
-      object: DefaultTokenConfig['object'];
+    interface Data<Options extends FormApplicationOptions = FormApplicationOptions>
+      extends Omit<TokenConfig.Data<Options>, 'object' | 'bar1' | 'bar2'> {
+      object: foundry.data.TokenData['_source'];
+      isDefault: true;
       barAttributes: ReturnType<typeof TokenDocument['getTrackedAttributeChoices']>;
-      dispositions: Record<ValueOf<typeof CONST.TOKEN_DISPOSITIONS>, string>;
-      lightAnimations: Record<string, string>;
-      displayModes: Record<ValueOf<typeof CONST.TOKEN_DISPLAY_MODES>, string>;
-      lightAlpha: number;
+      bar1: TokenBarData;
+      bar2: TokenBarData;
     }
   }
 }

--- a/src/foundry/foundry.js/applications/formApplications/tokenConfigs/index.d.ts
+++ b/src/foundry/foundry.js/applications/formApplications/tokenConfigs/index.d.ts
@@ -1,0 +1,1 @@
+import './defaultTokenConfig';

--- a/src/foundry/foundry.js/applications/formApplications/wallConfig.d.ts
+++ b/src/foundry/foundry.js/applications/formApplications/wallConfig.d.ts
@@ -32,10 +32,7 @@ declare global {
     getData(): Data | Promise<Data>;
 
     /** @override */
-    protected _updateObject(
-      event: Event,
-      formData: WallConfig.FormData
-    ): Promise<InstanceType<ConfiguredDocumentClassForName<'Wall'>> | undefined>;
+    protected _updateObject(event: Event, formData: WallConfig.FormData): Promise<unknown>;
   }
 
   namespace WallConfig {


### PR DESCRIPTION
Closes #1392

Additionally, this also changes the return type of _updateObject to Promise<unknown> for
every FormApplication, as the concrete return type is not supposed to be used.