### PR TITLE
Make 'default' property in dialog data optional

### DIFF
--- a/src/foundry/client/ui/dialog.d.ts
+++ b/src/foundry/client/ui/dialog.d.ts
@@ -187,7 +187,7 @@ declare namespace Dialog {
     /**
      * The name of the default button which should be triggered on Enter
      */
-    default?: string;
+    default?: string | undefined;
   }
 }
 

--- a/src/foundry/client/ui/dialog.d.ts
+++ b/src/foundry/client/ui/dialog.d.ts
@@ -187,7 +187,7 @@ declare namespace Dialog {
     /**
      * The name of the default button which should be triggered on Enter
      */
-    default: string;
+    default?: string;
   }
 }
 


### PR DESCRIPTION
Often times I leave off `default` if I want to ensure the user makes a conscious decision. I figure it should be optional to allow for this. 