### PR TITLE
Relax "modes" type in Effect Config Data

### DIFF
--- a/src/foundry/client/apps/forms/effect-config.d.ts
+++ b/src/foundry/client/apps/forms/effect-config.d.ts
@@ -57,7 +57,7 @@ declare global {
       isActorEffect: boolean;
       isItemEffect: boolean;
       submitText: string;
-      modes: Record<foundry.CONST.ACTIVE_EFFECT_MODES, string>;
+      modes: Record<number, string>;
     }
 
     type Options = DocumentSheetOptions;

--- a/test-d/foundry/client/apps/forms/effect-config.test-d.ts
+++ b/test-d/foundry/client/apps/forms/effect-config.test-d.ts
@@ -13,7 +13,7 @@ expectType<foundry.data.ActiveEffectData>((await config.getData()).data);
 expectType<boolean>((await config.getData()).isActorEffect);
 expectType<boolean>((await config.getData()).isItemEffect);
 expectType<string>((await config.getData()).submitText);
-expectType<Record<foundry.CONST.ACTIVE_EFFECT_MODES, string>>((await config.getData()).modes);
+expectType<Record<number, string>>((await config.getData()).modes);
 expectType<DocumentSheetOptions>(config.options);
 
 const withCustomOptions = new ActiveEffectConfig<DocumentSheetOptions & { custom: true }>(new ActiveEffect());


### PR DESCRIPTION
While #1795 fixed the mode type, I should've probably also reflected that in the Active Effect Config 💁‍♂️ 