### PR TITLE
Minor Utils TLC

### DIFF
--- a/src/types/utils.d.ts
+++ b/src/types/utils.d.ts
@@ -120,12 +120,6 @@ type Merge<T, U> = T extends object
   : U;
 
 /**
- * If `T` is `Promise<TResult>` then `TResult`; otherwise `T`.
- * @typeParam T - the type which, if a Promise, will be unwrapped.
- */
-type PromisedType<T> = T extends Promise<infer TResult> ? TResult : T;
-
-/**
  * Instance of `T`, which may or may not be in a promise.
  * @typeParam T - the type which might be wrapped in a promise.
  */

--- a/src/types/utils.d.ts
+++ b/src/types/utils.d.ts
@@ -125,6 +125,12 @@ type Merge<T, U> = T extends object
  */
 type PromisedType<T> = T extends Promise<infer TResult> ? TResult : T;
 
+/**
+ * Instance of `T`, which may or may not be in a promise.
+ * @typeParam T - the type which might be wrapped in a promise.
+ */
+type MaybePromise<T> = T | Promise<T>;
+
 type StoredDocument<D extends { data: { _source: unknown } }> = D & {
   id: string;
   data: D['data'] & {

--- a/test-d/types/utils.test-d.ts
+++ b/test-d/types/utils.test-d.ts
@@ -50,6 +50,9 @@ expectType<number>(promisedTypeOfNumProm);
 const promisedTypeOfNumber: PromisedType<number> = 0;
 expectType<number>(promisedTypeOfNumber);
 
+const numberMaybePromise: MaybePromise<number> = 0;
+expectType<number>(await numberMaybePromise);
+
 declare const user: User;
 expectType<string | null>(user.id);
 expectType<string | null>(user.data._id);

--- a/test-d/types/utils.test-d.ts
+++ b/test-d/types/utils.test-d.ts
@@ -43,13 +43,6 @@ expectType<'Foo  Bar'>(titlecaseWithSpaces);
 declare const titlecaseWithThreeWords: Titlecase<'foo bar baz'>;
 expectType<'Foo Bar Baz'>(titlecaseWithThreeWords);
 
-type NumberPromise = Promise<number>;
-const promisedTypeOfNumProm: PromisedType<NumberPromise> = 0;
-expectType<number>(promisedTypeOfNumProm);
-
-const promisedTypeOfNumber: PromisedType<number> = 0;
-expectType<number>(promisedTypeOfNumber);
-
 const numberMaybePromise: MaybePromise<number> = 0;
 expectType<number>(await numberMaybePromise);
 


### PR DESCRIPTION
Added `MaybePromise` type to clean up places that may potentially return either a value or a promise to said value. No changes were done, since @ghost91- was working on the one place it would be used.

Removed unused `PromisedType`, which got replaced with TS 4.5's `Awaited`.