### PR TITLE
Add Dot Notation key support to utility functions

### DIFF
--- a/src/foundry/common/utils/helpers.mjs.d.ts
+++ b/src/foundry/common/utils/helpers.mjs.d.ts
@@ -1,4 +1,11 @@
 import type { TypeOfTag } from "typescript/lib/typescript";
+import type {
+  DotNotationKeys,
+  DotNotationObject,
+  FlatObject,
+  GetValueFromDotKey,
+  InputValue
+} from "../../../types/helperTypes";
 
 /**
  * Benchmark the performance of a function, calling it a requested number of iterations.
@@ -172,6 +179,7 @@ export declare function encodeURL(path: string): string;
  *              (default: `0`)
  * @returns An expanded object
  */
+export declare function expandObject<T extends Record<string, unknown>>(obj: FlatObject<T>, _d?: number): T;
 export declare function expandObject(obj: object, _d?: number): any;
 
 /**
@@ -213,6 +221,7 @@ interface FilterObjectOptions {
  * @param d   - Track the recursion depth to prevent overflow
  * @returns A flattened object
  */
+export declare function flattenObject<T extends Record<string, unknown>>(obj: T, _d?: number): FlatObject<T>;
 export declare function flattenObject(obj: object, _d?: number): any;
 
 /**
@@ -256,7 +265,7 @@ export function getType(
  * @param key    - An object property with notation a.b.c
  * @returns An indicator for whether the property exists
  */
-export declare function hasProperty(object: object, key: string): boolean;
+export declare function hasProperty<T extends InputValue, key extends DotNotationKeys<T>>(object: T, key: key): boolean;
 
 /**
  * A helper function which searches through an object to retrieve a value by a string key.
@@ -265,7 +274,10 @@ export declare function hasProperty(object: object, key: string): boolean;
  * @param key    - An object property with notation a.b.c
  * @returns The value of the found property
  */
-export declare function getProperty(object: object, key: string): any;
+export declare function getProperty<T extends InputValue, K extends DotNotationKeys<T>>(
+  object: T,
+  key: K
+): GetValueFromDotKey<T, K>;
 
 /**
  * A helper function which searches through an object to assign a value using a string key
@@ -275,7 +287,11 @@ export declare function getProperty(object: object, key: string): any;
  * @param value  - The value to be assigned
  * @returns Whether the value was changed from its previous value
  */
-export declare function setProperty(object: object, key: string, value: any): boolean;
+export declare function setProperty<T extends InputValue, K extends DotNotationKeys<T>>(
+  object: T,
+  key: K,
+  value: GetValueFromDotKey<T, K>
+): boolean;
 
 /**
  * Invert an object by assigning its values as keys and its keys as values.

--- a/src/types/utils.d.ts
+++ b/src/types/utils.d.ts
@@ -141,3 +141,5 @@ type PropertyTypeOrFallback<T, Key extends string, Fallback> = Key extends keyof
  * Makes the given keys `K` of the type `T` required
  */
 type RequiredProps<T, K extends keyof T> = Required<Pick<T, K>> & Omit<T, K>;
+
+type StringNumber<S extends string> = S extends `${number}` ? S : never;

--- a/test-d/foundry/common/utils/helpers.mjs.test-d.ts
+++ b/test-d/foundry/common/utils/helpers.mjs.test-d.ts
@@ -202,6 +202,44 @@ declare class ClassWithConstructorParameters {
 expectType<boolean>(foundry.utils.isSubclass(ClassWithNoConstructorParameters, ClassWithConstructorParameters));
 expectType<boolean>(foundry.utils.isSubclass(ClassWithConstructorParameters, ClassWithNoConstructorParameters));
 
+// expandObject
+// hard to infer back
+expectType<{}>(foundry.utils.expandObject({}));
+expectType<{ test: number }>(foundry.utils.expandObject({ test: 1 }));
+expectType<{ test: number; deep: { value: number } }>(
+  foundry.utils.expandObject<{ test: number; deep: { value: number } }>({
+    test: 1,
+    "deep.value": 1
+  })
+);
+expectType<{ "0": number }>(foundry.utils.expandObject<{ "0": number }>({ "0": 1 }));
+
+// hasProperty
+expectType<boolean>(foundry.utils.hasProperty({ k1: 1 }, "k1"));
+expectError(foundry.utils.hasProperty({ k1: 1 }, "k2"));
+expectType<boolean>(foundry.utils.hasProperty({ deep: { value: 1 } }, "deep"));
+expectType<boolean>(foundry.utils.hasProperty({ deep: { value: 1 } }, "deep.value"));
+expectError(foundry.utils.hasProperty({ deep: { key: 1 } }, "deep.value"));
+
+// getProperty
+expectType<number>(foundry.utils.getProperty({ k1: 1, k2: "a" }, "k1"));
+expectType<string>(foundry.utils.getProperty({ k1: 1, k2: "a" }, "k2"));
+expectError(foundry.utils.getProperty({ k1: 1, k2: "a" }, "k3"));
+expectType<{ value: number }>(foundry.utils.getProperty({ deep: { value: 1 } }, "deep"));
+expectType<number>(foundry.utils.getProperty({ deep: { value: 1 } }, "deep.value"));
+expectType<1>(foundry.utils.getProperty({ deep: { value: 1 as const } }, "deep.value"));
+
+// setProperty
+expectType<boolean>(foundry.utils.setProperty({ k1: 1, k2: "a" }, "k1", 2));
+expectType<boolean>(foundry.utils.setProperty({ k1: 1, k2: "a" }, "k2", "b"));
+expectError(foundry.utils.setProperty({ k1: 1, k2: "a" }, "k3", null));
+expectType<boolean>(foundry.utils.setProperty({ deep: { value: 0 } }, "deep", { value: 1 }));
+expectType<boolean>(foundry.utils.setProperty({ deep: { value: 0 } }, "deep.value", 1));
+expectType<boolean>(foundry.utils.setProperty({ deep: { value: 1 as 0 | 1 | -1 } }, "deep.value", -1));
+expectError(foundry.utils.setProperty({ deep: { value: 1 as 0 | 1 | -1 } }, "deep.value", 2));
+expectType<boolean>(foundry.utils.setProperty({ other: 1 } as Record<string, number>, "test", 3));
+expectType<boolean>(foundry.utils.setProperty({ other: 1 } as Record<"test" | "other", number>, "test", 3));
+
 // invertObject
 expectType<{ readonly 1: "a"; readonly foo: "b" }>(foundry.utils.invertObject({ a: 1, b: "foo" } as const));
 

--- a/test-d/types/helperTypes.test-d.ts
+++ b/test-d/types/helperTypes.test-d.ts
@@ -1,0 +1,63 @@
+import { expectType } from "tsd";
+import type { ArrayOrTupleKey, DotNotationKeys, GetValueFromDotKey } from "../../src/types/helperTypes";
+
+declare function type<T>(): T;
+
+// basic objects
+expectType<"k1">(type<DotNotationKeys<{ k1: 1 }>>());
+expectType<"k2">(type<DotNotationKeys<{ k2: 1 }>>());
+expectType<"k1" | "k2">(type<DotNotationKeys<{ k1: 1; k2: 1 }>>());
+
+// objects with depth
+expectType<"k1" | "k2" | "deep" | "deep.value">(type<DotNotationKeys<{ k1: 1; k2: 1; deep: { value: 1 } }>>());
+expectType<
+  | "a"
+  | "a.really"
+  | "a.really.deep"
+  | "a.really.deep.object"
+  | "a.really.deep.object.holding"
+  | "a.really.deep.object.holding.a"
+  | "a.really.deep.object.holding.a.value"
+>(type<DotNotationKeys<{ a: { really: { deep: { object: { holding: { a: { value: 1 } } } } } } }>>());
+
+// arrays
+expectType<`${number}`>(type<DotNotationKeys<number[]>>());
+expectType<`${number}` | `${number}.${number}`>(type<DotNotationKeys<number[][]>>());
+expectType<`${number}` | `${number}.${number}` | `${number}.${number}.${number}`>(
+  type<DotNotationKeys<number[][][]>>()
+);
+
+// tuples!
+expectType<"0">(type<ArrayOrTupleKey<[9]>>());
+expectType<"0" | "1">(type<ArrayOrTupleKey<[9, 9]>>());
+expectType<number>(type<ArrayOrTupleKey<9[]>>());
+expectType<"0">(type<DotNotationKeys<[9]>>());
+expectType<"0" | "1">(type<DotNotationKeys<[9, 9]>>());
+expectType<"0" | "0.int" | "0.str">(type<DotNotationKeys<[{ int: 1; str: "" }]>>());
+expectType<"0" | "0.int" | "0.str" | "1">(type<DotNotationKeys<[{ int: 1; str: "" }, 2]>>());
+
+// arrays with objects
+expectType<`${number}` | `${number}.k1`>(type<DotNotationKeys<{ k1: 1 }[]>>());
+expectType<`${number}` | `${number}.k2`>(type<DotNotationKeys<{ k2: 2 }[]>>());
+expectType<`${number}` | `${number}.k1` | `${number}.k2`>(type<DotNotationKeys<{ k1: 1; k2: 2 }[]>>());
+
+// objects with arrays
+expectType<`array` | `array.${number}`>(type<DotNotationKeys<{ array: number[] }>>());
+expectType<`array` | `array.${number}` | `deep` | `deep.array` | `deep.array.${number}`>(
+  type<DotNotationKeys<{ array: number[]; deep: { array: number[] } }>>()
+);
+
+// objects with tuples
+expectType<"tuple" | "tuple.0" | "tuple.1" | "tuple.0.name" | "tuple.1.name">(
+  type<DotNotationKeys<{ tuple: [{ name: string }, { name: string }] }>>()
+);
+
+// mixed
+expectType<"tuple" | "tuple.0" | "tuple.1" | "tuple.2" | "array" | `array.${number}` | "deep" | "deep.value">(
+  type<DotNotationKeys<{ tuple: [1, 2, 3]; array: number[]; deep: { value: number } }>>()
+);
+expectType<"0" | "1" | `1.${number}` | "2" | "2.value">(type<DotNotationKeys<[1, number[], { value: number }]>>());
+expectType<`${number}` | `${number}.0` | `${number}.1`>(type<DotNotationKeys<[number, number][]>>());
+
+expectType<number>(type<GetValueFromDotKey<{ value: number }, "value">>());
+expectType<number>(type<GetValueFromDotKey<[number, 1], "0">>());


### PR DESCRIPTION
Types are complete, but needs to be tied into Document stuff later. Hits complexity limits with the data model as is, and the v10 version is still being worked on.