### PR TITLE
v10 typings: BaseActor, Actor, and Actors

### DIFF
--- a/src/foundry/common/documents.mjs/baseActor.d.ts
+++ b/src/foundry/common/documents.mjs/baseActor.d.ts
@@ -1,8 +1,9 @@
-import { ConfiguredDocumentClass } from "../../../types/helperTypes";
+import { ConfiguredDocumentClass, DocumentSubTypes } from "../../../types/helperTypes";
 import { DocumentMetadata, DocumentModificationOptions } from "../abstract/document.mjs";
 import { Document } from "../abstract/module.mjs";
+import type { DEFAULT_TOKEN } from "../constants.mjs.js";
 import * as data from "../data/data.mjs";
-import type { ActorDataConstructorData } from "../data/data.mjs/actorData";
+import type { ActorDataConstructorData, ActorDataSource } from "../data/data.mjs/actorData";
 import { BaseActiveEffect } from "./baseActiveEffect";
 import { BaseItem } from "./baseItem";
 import { BaseToken } from "./baseToken";
@@ -13,18 +14,20 @@ type ActorMetadata = Merge<
   {
     name: "Actor";
     collection: "actors";
-    label: "DOCUMENT.Actor";
-    labelPlural: "DOCUMENT.Actors";
+    indexed: true;
+    compendiumIndexFields: ["_id", "name", "img", "type", "sort"];
     embedded: {
       ActiveEffect: typeof BaseActiveEffect;
       Item: typeof BaseItem;
     };
+    label: "DOCUMENT.Actor";
+    labelPlural: "DOCUMENT.Actors";
     isPrimary: true;
     hasSystemData: true;
     permissions: {
       create: "ACTOR_CREATE";
+      update: "ACTOR_UPDATE";
     };
-    types: string[];
   }
 >;
 
@@ -36,30 +39,53 @@ export declare class BaseActor extends Document<
   InstanceType<ConfiguredDocumentClass<typeof BaseToken>>,
   ActorMetadata
 > {
-  static override get schema(): typeof data.ActorData;
+  /**
+   * @param data    - Initial data provided to construct the Actor document (default: `{}`)
+   * @param context - The document context, see {@link foundry.abstract.Document} (default: `{}`)
+   */
+  constructor(data?: DeepPartial<data.ActorData>, context?: DocumentConstructionContext);
+
+  static get schema(): ConstructorOf<data.ActorData>;
 
   static override get metadata(): ActorMetadata;
-  /*
-   * A reference to the Collection of embedded ActiveEffect instances in the Actor document, indexed by _id.
-   */
-  get effects(): this["data"]["effects"];
 
-  /**
-   * A reference to the Collection of embedded Item instances in the Actor document, indexed by _id.
-   */
-  get items(): this["data"]["items"];
+  get effects(): data.ActorData["effects"];
 
-  /**
-   * The sub-type of Actor.
-   */
+  get items(): data.ActorData["items"];
+
   get type(): data.ActorData["type"];
 
+  // FIXME: this should be an override once the Document class is updated for v10.
+  static defineSchema(): typeof data.ActorData;
+
+  /**
+   * The default icon used for newly created Actor documents.
+   */
+  static DEFAULT_ICON: typeof DEFAULT_TOKEN;
+
+  /**
+   * The allowed set of Actor types which may exist.
+   */
+  static get TYPES(): DocumentSubTypes<"Actor">[];
+
+  // FIXME: inherit _initializeSource from Document once it's updated for v10
+  protected _initializeSource(data: ActorDataConstructorData): ActorDataSource;
+
+  // FIXME: inherit canUserCreate from Document once it's updated for v10
+  static canUserCreate(user: BaseUser): boolean;
+
+  // FIXME: inherit migrateData from Document once it's updated for v10
+
+  // FIXME: inherit shimData from Document once it's updated for v10
+
+  // FIXME: inherit _preCreate from Document once it's updated for v10
   protected override _preCreate(
     data: ActorDataConstructorData,
     options: DocumentModificationOptions,
     user: BaseUser
   ): Promise<void>;
 
+  // FIXME: inherit _preUpdate from Document once it's updated for v10
   protected override _preUpdate(
     changed: DeepPartial<ActorDataConstructorData>,
     options: DocumentModificationOptions,

--- a/src/foundry/common/documents.mjs/baseActor.d.ts
+++ b/src/foundry/common/documents.mjs/baseActor.d.ts
@@ -3,7 +3,7 @@ import { DocumentMetadata, DocumentModificationOptions } from "../abstract/docum
 import { Document } from "../abstract/module.mjs";
 import type { DEFAULT_TOKEN } from "../constants.mjs.js";
 import * as data from "../data/data.mjs";
-import type { ActorDataConstructorData, ActorDataSource } from "../data/data.mjs/actorData";
+import type { ActorDataConstructorData, ActorDataSchema, ActorDataSource } from "../data/data.mjs/actorData";
 import { BaseActiveEffect } from "./baseActiveEffect";
 import { BaseItem } from "./baseItem";
 import { BaseToken } from "./baseToken";
@@ -45,50 +45,44 @@ export declare class BaseActor extends Document<
    */
   constructor(data?: DeepPartial<data.ActorData>, context?: DocumentConstructionContext);
 
-  static get schema(): ConstructorOf<data.ActorData>;
+  static readonly metadata: Readonly<ActorMetadata>;
 
-  static override get metadata(): ActorMetadata;
-
-  get effects(): data.ActorData["effects"];
-
-  get items(): data.ActorData["items"];
-
-  get type(): data.ActorData["type"];
-
-  // FIXME: this should be an override once the Document class is updated for v10.
-  static defineSchema(): typeof data.ActorData;
+  // FIXME: removed once ancestor classes are updated for v10
+  // @ts-expect-error an override, once ancestor classes are updated for v10
+  static override defineSchema(): ActorDataSchema;
 
   /**
    * The default icon used for newly created Actor documents.
+   * @defaultValue {@link CONST.DEFAULT_TOKEN}
    */
-  static DEFAULT_ICON: typeof DEFAULT_TOKEN;
+  static DEFAULT_ICON: string;
 
   /**
    * The allowed set of Actor types which may exist.
    */
   static get TYPES(): DocumentSubTypes<"Actor">[];
 
-  // FIXME: inherit _initializeSource from Document once it's updated for v10
   protected _initializeSource(data: ActorDataConstructorData): ActorDataSource;
 
-  // FIXME: inherit canUserCreate from Document once it's updated for v10
-  static canUserCreate(user: BaseUser): boolean;
+  static canUserCreate(user: BaseUser): ReturnType<BaseUser["hasPermission"]>;
 
-  // FIXME: inherit migrateData from Document once it's updated for v10
+  static #canCreate(user: User, doc: Actor): ReturnType<User["hasPermission"]>;
 
-  // FIXME: inherit shimData from Document once it's updated for v10
+  static #canUpdate(user: User, doc: Actor, data: DeepPartial<Actor["toObject"]>);
 
-  // FIXME: inherit _preCreate from Document once it's updated for v10
   protected override _preCreate(
     data: ActorDataConstructorData,
     options: DocumentModificationOptions,
     user: BaseUser
   ): Promise<void>;
 
-  // FIXME: inherit _preUpdate from Document once it's updated for v10
   protected override _preUpdate(
     changed: DeepPartial<ActorDataConstructorData>,
     options: DocumentModificationOptions,
     user: BaseUser
   ): Promise<void>;
+
+  static migrateData(data: object): ActorDataSource;
+
+  static shimData(data: ActorDataSource): object;
 }

--- a/src/foundry/common/documents.mjs/baseActor.d.ts
+++ b/src/foundry/common/documents.mjs/baseActor.d.ts
@@ -43,7 +43,7 @@ export declare class BaseActor extends Document<
    * @param data    - Initial data provided to construct the Actor document (default: `{}`)
    * @param context - The document context, see {@link foundry.abstract.Document} (default: `{}`)
    */
-  constructor(data?: DeepPartial<data.ActorData>, context?: DocumentConstructionContext);
+  constructor(data?: ActorDataConstructorData, context?: DocumentConstructionContext);
 
   static readonly metadata: Readonly<ActorMetadata>;
 


### PR DESCRIPTION
* resolves #1939 (technically, it didn't need an update itself, only its collection contents)
* resolves #1950
* resolves #2138

Exception: several class members that are bottlenecked until `DocumentModel` and friends are updated.

This PR intentionally omits `ActorData` and `ActorSheet`, which I'm told are already underway.