### PR TITLE
V10 Typings: update Dialog

### DIFF
--- a/src/foundry/client/ui/dialog.d.ts
+++ b/src/foundry/client/ui/dialog.d.ts
@@ -60,7 +60,7 @@ declare class Dialog<Options extends DialogOptions = DialogOptions> extends Appl
 
   override get title(): string;
 
-  override getData(options?: Partial<Options>): MaybePromise<object>;
+  override getData(options?: Partial<Options>): { content: string; buttons: Record<string, Dialog.Button> };
 
   override activateListeners(html: JQuery): void;
 

--- a/src/foundry/client/ui/dialog.d.ts
+++ b/src/foundry/client/ui/dialog.d.ts
@@ -77,7 +77,7 @@ declare class Dialog<Options extends DialogOptions = DialogOptions> extends Appl
   protected _onKeyDown(event: KeyboardEvent & { key: "Escape" }): ReturnType<Dialog["close"]>;
   protected _onKeyDown(event: KeyboardEvent): void;
 
-  _renderOuter(): ReturnType<Application["_renderOuter"]>;
+  override _renderOuter(): ReturnType<Application["_renderOuter"]>;
 
   /**
    * Submit the Dialog by selecting one of its buttons

--- a/src/foundry/client/ui/dialog.d.ts
+++ b/src/foundry/client/ui/dialog.d.ts
@@ -154,6 +154,11 @@ declare namespace Dialog {
     label?: string;
 
     /**
+     * Whether the button is disabled
+     */
+    disabled?: boolean;
+
+    /**
      * A callback function that fires when the button is clicked
      */
     callback?: (html: JQuery | HTMLElement) => T;

--- a/src/foundry/client/ui/dialog.d.ts
+++ b/src/foundry/client/ui/dialog.d.ts
@@ -8,6 +8,60 @@ interface DialogOptions extends ApplicationOptions {
   jQuery: boolean;
 }
 
+interface DialogButton<T = unknown, JQueryOrHtml = JQuery | HTMLElement> {
+  /**
+   * A Font Awesome icon for the button
+   */
+  icon?: string;
+
+  /**
+   * The label for the button
+   */
+  label?: string;
+
+  /**
+   * Whether the button is disabled
+   */
+  disabled?: boolean;
+
+  /**
+   * A callback function that fires when the button is clicked
+   */
+  callback?: (html: JQueryOrHtml, event?: MouseEvent) => T;
+}
+
+interface DialogData<JQueryOrHtml = JQuery | HTMLElement> {
+  /**
+   * The window title displayed in the dialog header
+   */
+  title: string;
+
+  /**
+   * HTML content for the dialog form
+   */
+  content: string;
+
+  /**
+   * The buttons which are displayed as action choices for the dialog
+   */
+  buttons: Record<string, DialogButton<unknown, JQueryOrHtml>>;
+
+  /**
+   * The name of the default button which should be triggered on Enter keypress
+   */
+  default?: string | undefined;
+
+  /**
+   * A callback function invoked when the dialog is rendered
+   */
+  render?: (element: JQueryOrHtml) => void;
+
+  /**
+   * Common callback operations to perform when the dialog is closed
+   */
+  close?: (element: JQueryOrHtml) => void;
+}
+
 /**
  * Create a modal dialog window displaying a title, a message, and a set of buttons which trigger callback functions.
  *
@@ -41,20 +95,21 @@ declare class Dialog<Options extends DialogOptions = DialogOptions> extends Appl
    * @param data    - An object of dialog data which configures how the modal window is rendered
    * @param options - Dialog rendering options, see {@link Application}
    */
-  constructor(data: Dialog.Data, options?: Partial<Options>);
+  constructor(data: DialogData, options?: Partial<Options>);
 
-  data: Dialog.Data;
+  data: DialogData;
 
   /**
    * A bound instance of the _onKeyDown method which is used to listen to keypress events while the Dialog is active.
    */
-  #onKeyDown: (event: KeyboardEvent) => void | Promise<void>;
+  #onKeyDown: ((event: KeyboardEvent) => MaybePromise<void>) | undefined;
 
   /**
    * @defaultValue
    * ```typescript
    * foundry.utils.mergeObject(super.defaultOptions, {
    *   template: "templates/hud/dialog.html",
+   *   focus: true,
    *   classes: ["dialog"],
    *   width: 400,
    *   jQuery: true
@@ -65,7 +120,7 @@ declare class Dialog<Options extends DialogOptions = DialogOptions> extends Appl
 
   override get title(): string;
 
-  override getData(options?: Partial<Options>): { content: string; buttons: Record<string, Dialog.Button> };
+  override getData(options?: Partial<Options>): MaybePromise<object>;
 
   override activateListeners(html: JQuery): void;
 
@@ -89,7 +144,7 @@ declare class Dialog<Options extends DialogOptions = DialogOptions> extends Appl
    * @param button - The configuration of the chosen button
    * @param event - The originating click event
    */
-  protected submit(button: Dialog.Button, event?: MouseEvent): void;
+  protected submit(button: DialogButton, event?: MouseEvent): void;
 
   override close(options?: Application.CloseOptions): Promise<void>;
 
@@ -151,79 +206,23 @@ declare class Dialog<Options extends DialogOptions = DialogOptions> extends Appl
    * @param data - Data passed to the Dialog constructor
    * @param options - Options passed to the Dialog constructor
    * @param renderOptions - Options passed to the Dialog render call
-   * @return A promise which resolves to the dialogs result.
+   * @returns A promise which resolves to the dialogs result.
    */
   static wait<Options extends DialogOptions = DialogOptions>(
-    data: Dialog.Data<JQuery>,
+    data: DialogData<JQuery>,
     options?: Partial<DialogOptions> & { jQuery?: true },
     renderOptions?: Application.RenderOptions<Options>
   ): Promise<unknown>;
   static wait<Options extends DialogOptions = DialogOptions>(
-    data: Dialog.Data<HTMLElement>,
+    data: DialogData<HTMLElement>,
     options?: Partial<DialogOptions> & { jQuery?: false },
     renderOptions?: Application.RenderOptions<Options>
   ): Promise<unknown>;
   static wait<Options extends DialogOptions = DialogOptions>(
-    data: Dialog.Data<JQuery | HTMLElement>,
+    data: DialogData<JQuery | HTMLElement>,
     options?: Partial<DialogOptions>,
     renderOptions?: Application.RenderOptions<Options>
   ): Promise<unknown>;
-}
-
-declare namespace Dialog {
-  interface Button<T = unknown, JQueryOrHtml = JQuery | HTMLElement> {
-    /**
-     * A Font Awesome icon for the button
-     */
-    icon?: string;
-
-    /**
-     * The label for the button
-     */
-    label?: string;
-
-    /**
-     * Whether the button is disabled
-     */
-    disabled?: boolean;
-
-    /**
-     * A callback function that fires when the button is clicked
-     */
-    callback?: (html: JQueryOrHtml, event?: MouseEvent) => T;
-  }
-
-  interface Data<JQueryOrHtml = JQuery | HTMLElement> {
-    /**
-     * The window title displayed in the dialog header
-     */
-    title: string;
-
-    /**
-     * HTML content for the dialog form
-     */
-    content: string;
-
-    /**
-     * A callback function invoked when the dialog is rendered
-     */
-    render?: (element: JQueryOrHtml) => void;
-
-    /**
-     * Common callback operations to perform when the dialog is closed
-     */
-    close?: (element: JQueryOrHtml) => void;
-
-    /**
-     * The buttons which are displayed as action choices for the dialog
-     */
-    buttons: Record<string, Button<unknown, JQueryOrHtml>>;
-
-    /**
-     * The name of the default button which should be triggered on Enter keypress
-     */
-    default?: string | undefined;
-  }
 }
 
 /**

--- a/src/foundry/client/ui/dialog.d.ts
+++ b/src/foundry/client/ui/dialog.d.ts
@@ -74,7 +74,7 @@ declare class Dialog<Options extends DialogOptions = DialogOptions> extends Appl
    * Handle a keydown event while the dialog is active
    * @param event - The keydown event
    */
-  protected _onKeyDown(event: KeyboardEvent & { key: "Escape" }): Promise<void>;
+  protected _onKeyDown(event: KeyboardEvent & { key: "Escape" }): ReturnType<Dialog["close"]>;
   protected _onKeyDown(event: KeyboardEvent): void;
 
   _renderOuter(): ReturnType<Application["_renderOuter"]>;

--- a/src/foundry/client/ui/dialog.d.ts
+++ b/src/foundry/client/ui/dialog.d.ts
@@ -170,22 +170,22 @@ declare global {
      * ```
      */
     static confirm<Yes = true, No = false>(
-      config: ConfirmConfig<Yes, No, JQuery> & { options?: { jQuery?: true }; rejectClose: true }
+      config: Dialog.ConfirmConfig<Yes, No, JQuery> & { options?: { jQuery?: true }; rejectClose: true }
     ): Promise<Yes | No>;
     static confirm<Yes = true, No = false>(
-      config: ConfirmConfig<Yes, No, JQuery> & { options?: { jQuery?: true } }
+      config: Dialog.ConfirmConfig<Yes, No, JQuery> & { options?: { jQuery?: true } }
     ): Promise<Yes | No | null>;
     static confirm<Yes = true, No = false>(
-      config: ConfirmConfig<Yes, No, HTMLElement> & { options: { jQuery: false }; rejectClose: true }
+      config: Dialog.ConfirmConfig<Yes, No, HTMLElement> & { options: { jQuery: false }; rejectClose: true }
     ): Promise<Yes | No>;
     static confirm<Yes = true, No = false>(
-      config: ConfirmConfig<Yes, No, HTMLElement> & { options: { jQuery: false } }
+      config: Dialog.ConfirmConfig<Yes, No, HTMLElement> & { options: { jQuery: false } }
     ): Promise<Yes | No | null>;
     static confirm<Yes = true, No = false>(
-      config: ConfirmConfig<Yes, No, JQuery | HTMLElement> & { rejectClose: true }
+      config: Dialog.ConfirmConfig<Yes, No, JQuery | HTMLElement> & { rejectClose: true }
     ): Promise<Yes | No>;
     static confirm<Yes = true, No = false>(
-      config?: ConfirmConfig<Yes, No, JQuery | HTMLElement>
+      config?: Dialog.ConfirmConfig<Yes, No, JQuery | HTMLElement>
     ): Promise<Yes | No | null>;
 
     /**
@@ -194,15 +194,15 @@ declare global {
      * @returns A promise which resolves when clicked, or rejects if closed
      */
     static prompt<T>(
-      config: PromptConfig<T, JQuery> & { options?: { jQuery?: true }; rejectClose: false }
+      config: Dialog.PromptConfig<T, JQuery> & { options?: { jQuery?: true }; rejectClose: false }
     ): Promise<T | null>;
-    static prompt<T>(config: PromptConfig<T, JQuery> & { options?: { jQuery?: true } }): Promise<T>;
+    static prompt<T>(config: Dialog.PromptConfig<T, JQuery> & { options?: { jQuery?: true } }): Promise<T>;
     static prompt<T>(
-      config: PromptConfig<T, HTMLElement> & { options: { jQuery: false }; rejectClose: false }
+      config: Dialog.PromptConfig<T, HTMLElement> & { options: { jQuery: false }; rejectClose: false }
     ): Promise<T | null>;
-    static prompt<T>(config: PromptConfig<T, HTMLElement> & { options: { jQuery: false } }): Promise<T>;
-    static prompt<T>(config: PromptConfig<T, JQuery | HTMLElement> & { rejectClose: false }): Promise<T | null>;
-    static prompt<T>(config: PromptConfig<T, JQuery | HTMLElement>): Promise<T>;
+    static prompt<T>(config: Dialog.PromptConfig<T, HTMLElement> & { options: { jQuery: false } }): Promise<T>;
+    static prompt<T>(config: Dialog.PromptConfig<T, JQuery | HTMLElement> & { rejectClose: false }): Promise<T | null>;
+    static prompt<T>(config: Dialog.PromptConfig<T, JQuery | HTMLElement>): Promise<T>;
 
     /**
      * Wrap the Dialog with an enclosing Promise which resolves or rejects when the client makes a choice.
@@ -228,97 +228,99 @@ declare global {
     ): Promise<unknown>;
   }
 
-  /**
-   * @typeParam Yes          - The value returned by the yes callback
-   * @typeParam No           - The value returned by the no callback
-   * @typeParam JQueryOrHtml - The parameter passed to the callbacks, either JQuery or HTMLElement
-   */
-  interface ConfirmConfig<Yes, No, JQueryOrHtml> {
+  namespace Dialog {
     /**
-     * The confirmation window title
+     * @typeParam Yes          - The value returned by the yes callback
+     * @typeParam No           - The value returned by the no callback
+     * @typeParam JQueryOrHtml - The parameter passed to the callbacks, either JQuery or HTMLElement
      */
-    title?: string;
+    interface ConfirmConfig<Yes, No, JQueryOrHtml> {
+      /**
+       * The confirmation window title
+       */
+      title?: string;
+
+      /**
+       * The confirmation message
+       */
+      content?: string;
+
+      /**
+       * Callback function upon yes
+       */
+      yes?: (html: JQueryOrHtml) => Yes;
+
+      /**
+       * Callback function upon no
+       */
+      no?: (html: JQueryOrHtml) => No;
+
+      /**
+       * A function to call when the dialog is rendered
+       */
+      render?: (html: JQueryOrHtml) => void;
+
+      /**
+       * Make "yes" the default choice?
+       * @defaultValue `true`
+       */
+      defaultYes?: boolean;
+
+      /**
+       * Reject the Promise if the Dialog is closed without making a choice.
+       * @defaultValue `false`
+       */
+      rejectClose?: boolean;
+
+      /**
+       * Additional rendering options passed to the Dialog
+       * @defaultValue `{}`
+       */
+      options?: Partial<DialogOptions>;
+    }
 
     /**
-     * The confirmation message
+     * @typeParam Value        - The value returned by the callback function
+     * @typeParam JQueryOrHtml - The parameter passed to the callbacks, either JQuery or HTMLElement
      */
-    content?: string;
+    interface PromptConfig<Value, JQueryOrHtml> {
+      /**
+       * The confirmation window title
+       */
+      title?: string;
 
-    /**
-     * Callback function upon yes
-     */
-    yes?: (html: JQueryOrHtml) => Yes;
+      /**
+       * The confirmation message
+       */
+      content?: string;
 
-    /**
-     * Callback function upon no
-     */
-    no?: (html: JQueryOrHtml) => No;
+      /**
+       * The confirmation button text
+       */
+      label?: string;
 
-    /**
-     * A function to call when the dialog is rendered
-     */
-    render?: (html: JQueryOrHtml) => void;
+      /**
+       * A callback function to fire when the button is clicked
+       */
+      callback: (html: JQueryOrHtml) => Value;
 
-    /**
-     * Make "yes" the default choice?
-     * @defaultValue `true`
-     */
-    defaultYes?: boolean;
+      /**
+       * A function that fires after the dialog is rendered
+       */
+      render?: (html: JQueryOrHtml) => void;
 
-    /**
-     * Reject the Promise if the Dialog is closed without making a choice.
-     * @defaultValue `false`
-     */
-    rejectClose?: boolean;
+      /**
+       * Reject the promise if the dialog is closed without confirming the
+       * choice, otherwise resolve as null
+       * @defaultValue `true`
+       */
+      rejectClose?: boolean;
 
-    /**
-     * Additional rendering options passed to the Dialog
-     * @defaultValue `{}`
-     */
-    options?: Partial<DialogOptions>;
-  }
-
-  /**
-   * @typeParam Value        - The value returned by the callback function
-   * @typeParam JQueryOrHtml - The parameter passed to the callbacks, either JQuery or HTMLElement
-   */
-  interface PromptConfig<Value, JQueryOrHtml> {
-    /**
-     * The confirmation window title
-     */
-    title?: string;
-
-    /**
-     * The confirmation message
-     */
-    content?: string;
-
-    /**
-     * The confirmation button text
-     */
-    label?: string;
-
-    /**
-     * A callback function to fire when the button is clicked
-     */
-    callback: (html: JQueryOrHtml) => Value;
-
-    /**
-     * A function that fires after the dialog is rendered
-     */
-    render?: (html: JQueryOrHtml) => void;
-
-    /**
-     * Reject the promise if the dialog is closed without confirming the
-     * choice, otherwise resolve as null
-     * @defaultValue `true`
-     */
-    rejectClose?: boolean;
-
-    /**
-     * Additional rendering options
-     * @defaultValue `{}`
-     */
-    options?: Partial<DialogOptions>;
+      /**
+       * Additional rendering options
+       * @defaultValue `{}`
+       */
+      options?: Partial<DialogOptions>;
+    }
   }
 }

--- a/src/foundry/client/ui/dialog.d.ts
+++ b/src/foundry/client/ui/dialog.d.ts
@@ -87,8 +87,9 @@ declare class Dialog<Options extends DialogOptions = DialogOptions> extends Appl
   /**
    * Submit the Dialog by selecting one of its buttons
    * @param button - The configuration of the chosen button
+   * @param event - The originating click event
    */
-  protected submit(button: Dialog.Button): void;
+  protected submit(button: Dialog.Button, event?: MouseEvent): void;
 
   override close(options?: Application.CloseOptions): Promise<void>;
 
@@ -166,7 +167,7 @@ declare namespace Dialog {
     /**
      * A callback function that fires when the button is clicked
      */
-    callback?: (html: JQuery | HTMLElement) => T;
+    callback?: (html: JQuery | HTMLElement, event?: MouseEvent) => T;
   }
 
   interface Data {

--- a/src/foundry/client/ui/dialog.d.ts
+++ b/src/foundry/client/ui/dialog.d.ts
@@ -8,19 +8,19 @@ declare global {
      * future will become false by default.
      * @defaultValue `true`
      */
-    jQuery: boolean;
+    jQuery?: boolean;
   }
 
   interface DialogButton<T = unknown, JQueryOrHtml = JQuery | HTMLElement> {
     /**
      * A Font Awesome icon for the button
      */
-    icon?: string;
+    icon: string;
 
     /**
      * The label for the button
      */
-    label?: string;
+    label: string;
 
     /**
      * Whether the button is disabled

--- a/src/foundry/client/ui/dialog.d.ts
+++ b/src/foundry/client/ui/dialog.d.ts
@@ -58,7 +58,7 @@ declare class Dialog<Options extends DialogOptions = DialogOptions> extends Appl
    */
   static override get defaultOptions(): DialogOptions;
 
-  static get title(): string;
+  override get title(): string;
 
   override getData(options?: Partial<Options>): MaybePromise<object>;
 

--- a/src/foundry/client/ui/dialog.d.ts
+++ b/src/foundry/client/ui/dialog.d.ts
@@ -46,6 +46,11 @@ declare class Dialog<Options extends DialogOptions = DialogOptions> extends Appl
   data: Dialog.Data;
 
   /**
+   * A bound instance of the _onKeyDown method which is used to listen to keypress events while the Dialog is active.
+   */
+  #onKeyDown: (event: KeyboardEvent) => void | Promise<void>;
+
+  /**
    * @defaultValue
    * ```typescript
    * foundry.utils.mergeObject(super.defaultOptions, {

--- a/src/foundry/client/ui/dialog.d.ts
+++ b/src/foundry/client/ui/dialog.d.ts
@@ -145,10 +145,33 @@ declare class Dialog<Options extends DialogOptions = DialogOptions> extends Appl
   static prompt<T>(config: PromptConfig<T, HTMLElement> & { options: { jQuery: false } }): Promise<T>;
   static prompt<T>(config: PromptConfig<T, JQuery | HTMLElement> & { rejectClose: false }): Promise<T | null>;
   static prompt<T>(config: PromptConfig<T, JQuery | HTMLElement>): Promise<T>;
+
+  /**
+   * Wrap the Dialog with an enclosing Promise which resolves or rejects when the client makes a choice.
+   * @param data - Data passed to the Dialog constructor
+   * @param options - Options passed to the Dialog constructor
+   * @param renderOptions - Options passed to the Dialog render call
+   * @return A promise which resolves to the dialogs result.
+   */
+  static wait<Options extends DialogOptions = DialogOptions>(
+    data: Dialog.Data<JQuery>,
+    options?: Partial<DialogOptions> & { jQuery?: true },
+    renderOptions?: Application.RenderOptions<Options>
+  ): Promise<unknown>;
+  static wait<Options extends DialogOptions = DialogOptions>(
+    data: Dialog.Data<HTMLElement>,
+    options?: Partial<DialogOptions> & { jQuery?: false },
+    renderOptions?: Application.RenderOptions<Options>
+  ): Promise<unknown>;
+  static wait<Options extends DialogOptions = DialogOptions>(
+    data: Dialog.Data<JQuery | HTMLElement>,
+    options?: Partial<DialogOptions>,
+    renderOptions?: Application.RenderOptions<Options>
+  ): Promise<unknown>;
 }
 
 declare namespace Dialog {
-  interface Button<T = unknown> {
+  interface Button<T = unknown, JQueryOrHtml = JQuery | HTMLElement> {
     /**
      * A Font Awesome icon for the button
      */
@@ -167,10 +190,10 @@ declare namespace Dialog {
     /**
      * A callback function that fires when the button is clicked
      */
-    callback?: (html: JQuery | HTMLElement, event?: MouseEvent) => T;
+    callback?: (html: JQueryOrHtml, event?: MouseEvent) => T;
   }
 
-  interface Data {
+  interface Data<JQueryOrHtml = JQuery | HTMLElement> {
     /**
      * The window title displayed in the dialog header
      */
@@ -184,17 +207,17 @@ declare namespace Dialog {
     /**
      * A callback function invoked when the dialog is rendered
      */
-    render?: (element: JQuery | HTMLElement) => void;
+    render?: (element: JQueryOrHtml) => void;
 
     /**
      * Common callback operations to perform when the dialog is closed
      */
-    close?: (element: JQuery | HTMLElement) => void;
+    close?: (element: JQueryOrHtml) => void;
 
     /**
      * The buttons which are displayed as action choices for the dialog
      */
-    buttons: Record<string, Button>;
+    buttons: Record<string, Button<unknown, JQueryOrHtml>>;
 
     /**
      * The name of the default button which should be triggered on Enter keypress

--- a/src/foundry/client/ui/dialog.d.ts
+++ b/src/foundry/client/ui/dialog.d.ts
@@ -1,320 +1,324 @@
-interface DialogOptions extends ApplicationOptions {
-  /**
-   * Whether to provide jQuery objects to callback functions (if true) or plain
-   * HTMLElement instances (if false). This is currently true by default but in the
-   * future will become false by default.
-   * @defaultValue `true`
-   */
-  jQuery: boolean;
-}
+export {};
 
-interface DialogButton<T = unknown, JQueryOrHtml = JQuery | HTMLElement> {
-  /**
-   * A Font Awesome icon for the button
-   */
-  icon?: string;
+declare global {
+  interface DialogOptions extends ApplicationOptions {
+    /**
+     * Whether to provide jQuery objects to callback functions (if true) or plain
+     * HTMLElement instances (if false). This is currently true by default but in the
+     * future will become false by default.
+     * @defaultValue `true`
+     */
+    jQuery: boolean;
+  }
 
-  /**
-   * The label for the button
-   */
-  label?: string;
+  interface DialogButton<T = unknown, JQueryOrHtml = JQuery | HTMLElement> {
+    /**
+     * A Font Awesome icon for the button
+     */
+    icon?: string;
 
-  /**
-   * Whether the button is disabled
-   */
-  disabled?: boolean;
+    /**
+     * The label for the button
+     */
+    label?: string;
 
-  /**
-   * A callback function that fires when the button is clicked
-   */
-  callback?: (html: JQueryOrHtml, event?: MouseEvent) => T;
-}
+    /**
+     * Whether the button is disabled
+     */
+    disabled?: boolean;
 
-interface DialogData<JQueryOrHtml = JQuery | HTMLElement> {
-  /**
-   * The window title displayed in the dialog header
-   */
-  title: string;
+    /**
+     * A callback function that fires when the button is clicked
+     */
+    callback?: (html: JQueryOrHtml, event?: MouseEvent) => T;
+  }
 
-  /**
-   * HTML content for the dialog form
-   */
-  content: string;
+  interface DialogData<JQueryOrHtml = JQuery | HTMLElement> {
+    /**
+     * The window title displayed in the dialog header
+     */
+    title: string;
 
-  /**
-   * The buttons which are displayed as action choices for the dialog
-   */
-  buttons: Record<string, DialogButton<unknown, JQueryOrHtml>>;
+    /**
+     * HTML content for the dialog form
+     */
+    content: string;
 
-  /**
-   * The name of the default button which should be triggered on Enter keypress
-   */
-  default?: string | undefined;
+    /**
+     * The buttons which are displayed as action choices for the dialog
+     */
+    buttons: Record<string, DialogButton<unknown, JQueryOrHtml>>;
 
-  /**
-   * A callback function invoked when the dialog is rendered
-   */
-  render?: (element: JQueryOrHtml) => void;
+    /**
+     * The name of the default button which should be triggered on Enter keypress
+     */
+    default?: string | undefined;
 
-  /**
-   * Common callback operations to perform when the dialog is closed
-   */
-  close?: (element: JQueryOrHtml) => void;
-}
+    /**
+     * A callback function invoked when the dialog is rendered
+     */
+    render?: (element: JQueryOrHtml) => void;
 
-/**
- * Create a modal dialog window displaying a title, a message, and a set of buttons which trigger callback functions.
- *
- * @example Constructing a custom dialog instance
- * ```typescript
- * let d = new Dialog({
- *  title: "Test Dialog",
- *  content: "<p>You must choose either Option 1, or Option 2</p>",
- *  buttons: {
- *   one: {
- *    icon: '<i class="fas fa-check"></i>',
- *    label: "Option One",
- *    callback: () => console.log("Chose One")
- *   },
- *   two: {
- *    icon: '<i class="fas fa-times"></i>',
- *    label: "Option Two",
- *    callback: () => console.log("Chose Two")
- *   }
- *  },
- *  default: "two",
- *  render: html => console.log("Register interactivity in the rendered dialog"),
- *  close: html => console.log("This always is logged no matter which option is chosen")
- * });
- * d.render(true);
- * ```
- * @typeParam Options - the type of the options object
- */
-declare class Dialog<Options extends DialogOptions = DialogOptions> extends Application<Options> {
-  /**
-   * @param data    - An object of dialog data which configures how the modal window is rendered
-   * @param options - Dialog rendering options, see {@link Application}
-   */
-  constructor(data: DialogData, options?: Partial<Options>);
-
-  data: DialogData;
+    /**
+     * Common callback operations to perform when the dialog is closed
+     */
+    close?: (element: JQueryOrHtml) => void;
+  }
 
   /**
-   * A bound instance of the _onKeyDown method which is used to listen to keypress events while the Dialog is active.
-   */
-  #onKeyDown: ((event: KeyboardEvent) => MaybePromise<void>) | undefined;
-
-  /**
-   * @defaultValue
-   * ```typescript
-   * foundry.utils.mergeObject(super.defaultOptions, {
-   *   template: "templates/hud/dialog.html",
-   *   focus: true,
-   *   classes: ["dialog"],
-   *   width: 400,
-   *   jQuery: true
-   * })
-   * ```
-   */
-  static override get defaultOptions(): DialogOptions;
-
-  override get title(): string;
-
-  override getData(options?: Partial<Options>): MaybePromise<object>;
-
-  override activateListeners(html: JQuery): void;
-
-  /**
-   * Handle a left-mouse click on one of the dialog choice buttons
-   * @param event - The left-mouse click event
-   */
-  protected _onClickButton(event: MouseEvent): void;
-
-  /**
-   * Handle a keydown event while the dialog is active
-   * @param event - The keydown event
-   */
-  protected _onKeyDown(event: KeyboardEvent & { key: "Escape" }): Promise<void>;
-  protected _onKeyDown(event: KeyboardEvent): void;
-
-  override _renderOuter(): ReturnType<Application["_renderOuter"]>;
-
-  /**
-   * Submit the Dialog by selecting one of its buttons
-   * @param button - The configuration of the chosen button
-   * @param event - The originating click event
-   */
-  protected submit(button: DialogButton, event?: MouseEvent): void;
-
-  override close(options?: Application.CloseOptions): Promise<void>;
-
-  /**
-   * A helper factory method to create simple confirmation dialog windows which consist of simple yes/no prompts.
-   * If you require more flexibility, a custom Dialog instance is preferred.
+   * Create a modal dialog window displaying a title, a message, and a set of buttons which trigger callback functions.
    *
-   * @param config - Confirmation dialog configuration (defaultValue: `{}`)
-   * @returns A promise which resolves once the user makes a choice or closes the window.
-   *
-   * @example Prompt the user with a yes or no question
+   * @example Constructing a custom dialog instance
    * ```typescript
-   * let d = Dialog.confirm({
-   *  title: "A Yes or No Question",
-   *  content: "<p>Choose wisely.</p>",
-   *  yes: () => console.log("You chose ... wisely"),
-   *  no: () => console.log("You chose ... poorly"),
-   *  defaultYes: false
+   * let d = new Dialog({
+   *  title: "Test Dialog",
+   *  content: "<p>You must choose either Option 1, or Option 2</p>",
+   *  buttons: {
+   *   one: {
+   *    icon: '<i class="fas fa-check"></i>',
+   *    label: "Option One",
+   *    callback: () => console.log("Chose One")
+   *   },
+   *   two: {
+   *    icon: '<i class="fas fa-times"></i>',
+   *    label: "Option Two",
+   *    callback: () => console.log("Chose Two")
+   *   }
+   *  },
+   *  default: "two",
+   *  render: html => console.log("Register interactivity in the rendered dialog"),
+   *  close: html => console.log("This always is logged no matter which option is chosen")
    * });
+   * d.render(true);
    * ```
+   * @typeParam Options - the type of the options object
    */
-  static confirm<Yes = true, No = false>(
-    config: ConfirmConfig<Yes, No, JQuery> & { options?: { jQuery?: true }; rejectClose: true }
-  ): Promise<Yes | No>;
-  static confirm<Yes = true, No = false>(
-    config: ConfirmConfig<Yes, No, JQuery> & { options?: { jQuery?: true } }
-  ): Promise<Yes | No | null>;
-  static confirm<Yes = true, No = false>(
-    config: ConfirmConfig<Yes, No, HTMLElement> & { options: { jQuery: false }; rejectClose: true }
-  ): Promise<Yes | No>;
-  static confirm<Yes = true, No = false>(
-    config: ConfirmConfig<Yes, No, HTMLElement> & { options: { jQuery: false } }
-  ): Promise<Yes | No | null>;
-  static confirm<Yes = true, No = false>(
-    config: ConfirmConfig<Yes, No, JQuery | HTMLElement> & { rejectClose: true }
-  ): Promise<Yes | No>;
-  static confirm<Yes = true, No = false>(
-    config?: ConfirmConfig<Yes, No, JQuery | HTMLElement>
-  ): Promise<Yes | No | null>;
+  class Dialog<Options extends DialogOptions = DialogOptions> extends Application<Options> {
+    /**
+     * @param data    - An object of dialog data which configures how the modal window is rendered
+     * @param options - Dialog rendering options, see {@link Application}
+     */
+    constructor(data: DialogData, options?: Partial<Options>);
+
+    data: DialogData;
+
+    /**
+     * A bound instance of the _onKeyDown method which is used to listen to keypress events while the Dialog is active.
+     */
+    #onKeyDown: ((event: KeyboardEvent) => MaybePromise<void>) | undefined;
+
+    /**
+     * @defaultValue
+     * ```typescript
+     * foundry.utils.mergeObject(super.defaultOptions, {
+     *   template: "templates/hud/dialog.html",
+     *   focus: true,
+     *   classes: ["dialog"],
+     *   width: 400,
+     *   jQuery: true
+     * })
+     * ```
+     */
+    static override get defaultOptions(): DialogOptions;
+
+    override get title(): string;
+
+    override getData(options?: Partial<Options>): MaybePromise<object>;
+
+    override activateListeners(html: JQuery): void;
+
+    /**
+     * Handle a left-mouse click on one of the dialog choice buttons
+     * @param event - The left-mouse click event
+     */
+    protected _onClickButton(event: MouseEvent): void;
+
+    /**
+     * Handle a keydown event while the dialog is active
+     * @param event - The keydown event
+     */
+    protected _onKeyDown(event: KeyboardEvent & { key: "Escape" }): Promise<void>;
+    protected _onKeyDown(event: KeyboardEvent): void;
+
+    override _renderOuter(): ReturnType<Application["_renderOuter"]>;
+
+    /**
+     * Submit the Dialog by selecting one of its buttons
+     * @param button - The configuration of the chosen button
+     * @param event - The originating click event
+     */
+    protected submit(button: DialogButton, event?: MouseEvent): void;
+
+    override close(options?: Application.CloseOptions): Promise<void>;
+
+    /**
+     * A helper factory method to create simple confirmation dialog windows which consist of simple yes/no prompts.
+     * If you require more flexibility, a custom Dialog instance is preferred.
+     *
+     * @param config - Confirmation dialog configuration (defaultValue: `{}`)
+     * @returns A promise which resolves once the user makes a choice or closes the window.
+     *
+     * @example Prompt the user with a yes or no question
+     * ```typescript
+     * let d = Dialog.confirm({
+     *  title: "A Yes or No Question",
+     *  content: "<p>Choose wisely.</p>",
+     *  yes: () => console.log("You chose ... wisely"),
+     *  no: () => console.log("You chose ... poorly"),
+     *  defaultYes: false
+     * });
+     * ```
+     */
+    static confirm<Yes = true, No = false>(
+      config: ConfirmConfig<Yes, No, JQuery> & { options?: { jQuery?: true }; rejectClose: true }
+    ): Promise<Yes | No>;
+    static confirm<Yes = true, No = false>(
+      config: ConfirmConfig<Yes, No, JQuery> & { options?: { jQuery?: true } }
+    ): Promise<Yes | No | null>;
+    static confirm<Yes = true, No = false>(
+      config: ConfirmConfig<Yes, No, HTMLElement> & { options: { jQuery: false }; rejectClose: true }
+    ): Promise<Yes | No>;
+    static confirm<Yes = true, No = false>(
+      config: ConfirmConfig<Yes, No, HTMLElement> & { options: { jQuery: false } }
+    ): Promise<Yes | No | null>;
+    static confirm<Yes = true, No = false>(
+      config: ConfirmConfig<Yes, No, JQuery | HTMLElement> & { rejectClose: true }
+    ): Promise<Yes | No>;
+    static confirm<Yes = true, No = false>(
+      config?: ConfirmConfig<Yes, No, JQuery | HTMLElement>
+    ): Promise<Yes | No | null>;
+
+    /**
+     * A helper factory method to display a basic "prompt" style Dialog with a single button
+     * @param config - Dialog configuration options
+     * @returns A promise which resolves when clicked, or rejects if closed
+     */
+    static prompt<T>(
+      config: PromptConfig<T, JQuery> & { options?: { jQuery?: true }; rejectClose: false }
+    ): Promise<T | null>;
+    static prompt<T>(config: PromptConfig<T, JQuery> & { options?: { jQuery?: true } }): Promise<T>;
+    static prompt<T>(
+      config: PromptConfig<T, HTMLElement> & { options: { jQuery: false }; rejectClose: false }
+    ): Promise<T | null>;
+    static prompt<T>(config: PromptConfig<T, HTMLElement> & { options: { jQuery: false } }): Promise<T>;
+    static prompt<T>(config: PromptConfig<T, JQuery | HTMLElement> & { rejectClose: false }): Promise<T | null>;
+    static prompt<T>(config: PromptConfig<T, JQuery | HTMLElement>): Promise<T>;
+
+    /**
+     * Wrap the Dialog with an enclosing Promise which resolves or rejects when the client makes a choice.
+     * @param data - Data passed to the Dialog constructor
+     * @param options - Options passed to the Dialog constructor
+     * @param renderOptions - Options passed to the Dialog render call
+     * @returns A promise which resolves to the dialogs result.
+     */
+    static wait<Options extends DialogOptions = DialogOptions>(
+      data: DialogData<JQuery>,
+      options?: Partial<DialogOptions> & { jQuery?: true },
+      renderOptions?: Application.RenderOptions<Options>
+    ): Promise<unknown>;
+    static wait<Options extends DialogOptions = DialogOptions>(
+      data: DialogData<HTMLElement>,
+      options?: Partial<DialogOptions> & { jQuery?: false },
+      renderOptions?: Application.RenderOptions<Options>
+    ): Promise<unknown>;
+    static wait<Options extends DialogOptions = DialogOptions>(
+      data: DialogData<JQuery | HTMLElement>,
+      options?: Partial<DialogOptions>,
+      renderOptions?: Application.RenderOptions<Options>
+    ): Promise<unknown>;
+  }
 
   /**
-   * A helper factory method to display a basic "prompt" style Dialog with a single button
-   * @param config - Dialog configuration options
-   * @returns A promise which resolves when clicked, or rejects if closed
+   * @typeParam Yes          - The value returned by the yes callback
+   * @typeParam No           - The value returned by the no callback
+   * @typeParam JQueryOrHtml - The parameter passed to the callbacks, either JQuery or HTMLElement
    */
-  static prompt<T>(
-    config: PromptConfig<T, JQuery> & { options?: { jQuery?: true }; rejectClose: false }
-  ): Promise<T | null>;
-  static prompt<T>(config: PromptConfig<T, JQuery> & { options?: { jQuery?: true } }): Promise<T>;
-  static prompt<T>(
-    config: PromptConfig<T, HTMLElement> & { options: { jQuery: false }; rejectClose: false }
-  ): Promise<T | null>;
-  static prompt<T>(config: PromptConfig<T, HTMLElement> & { options: { jQuery: false } }): Promise<T>;
-  static prompt<T>(config: PromptConfig<T, JQuery | HTMLElement> & { rejectClose: false }): Promise<T | null>;
-  static prompt<T>(config: PromptConfig<T, JQuery | HTMLElement>): Promise<T>;
+  interface ConfirmConfig<Yes, No, JQueryOrHtml> {
+    /**
+     * The confirmation window title
+     */
+    title?: string;
+
+    /**
+     * The confirmation message
+     */
+    content?: string;
+
+    /**
+     * Callback function upon yes
+     */
+    yes?: (html: JQueryOrHtml) => Yes;
+
+    /**
+     * Callback function upon no
+     */
+    no?: (html: JQueryOrHtml) => No;
+
+    /**
+     * A function to call when the dialog is rendered
+     */
+    render?: (html: JQueryOrHtml) => void;
+
+    /**
+     * Make "yes" the default choice?
+     * @defaultValue `true`
+     */
+    defaultYes?: boolean;
+
+    /**
+     * Reject the Promise if the Dialog is closed without making a choice.
+     * @defaultValue `false`
+     */
+    rejectClose?: boolean;
+
+    /**
+     * Additional rendering options passed to the Dialog
+     * @defaultValue `{}`
+     */
+    options?: Partial<DialogOptions>;
+  }
 
   /**
-   * Wrap the Dialog with an enclosing Promise which resolves or rejects when the client makes a choice.
-   * @param data - Data passed to the Dialog constructor
-   * @param options - Options passed to the Dialog constructor
-   * @param renderOptions - Options passed to the Dialog render call
-   * @returns A promise which resolves to the dialogs result.
+   * @typeParam Value        - The value returned by the callback function
+   * @typeParam JQueryOrHtml - The parameter passed to the callbacks, either JQuery or HTMLElement
    */
-  static wait<Options extends DialogOptions = DialogOptions>(
-    data: DialogData<JQuery>,
-    options?: Partial<DialogOptions> & { jQuery?: true },
-    renderOptions?: Application.RenderOptions<Options>
-  ): Promise<unknown>;
-  static wait<Options extends DialogOptions = DialogOptions>(
-    data: DialogData<HTMLElement>,
-    options?: Partial<DialogOptions> & { jQuery?: false },
-    renderOptions?: Application.RenderOptions<Options>
-  ): Promise<unknown>;
-  static wait<Options extends DialogOptions = DialogOptions>(
-    data: DialogData<JQuery | HTMLElement>,
-    options?: Partial<DialogOptions>,
-    renderOptions?: Application.RenderOptions<Options>
-  ): Promise<unknown>;
-}
+  interface PromptConfig<Value, JQueryOrHtml> {
+    /**
+     * The confirmation window title
+     */
+    title?: string;
 
-/**
- * @typeParam Yes          - The value returned by the yes callback
- * @typeParam No           - The value returned by the no callback
- * @typeParam JQueryOrHtml - The parameter passed to the callbacks, either JQuery or HTMLElement
- */
-interface ConfirmConfig<Yes, No, JQueryOrHtml> {
-  /**
-   * The confirmation window title
-   */
-  title?: string;
+    /**
+     * The confirmation message
+     */
+    content?: string;
 
-  /**
-   * The confirmation message
-   */
-  content?: string;
+    /**
+     * The confirmation button text
+     */
+    label?: string;
 
-  /**
-   * Callback function upon yes
-   */
-  yes?: (html: JQueryOrHtml) => Yes;
+    /**
+     * A callback function to fire when the button is clicked
+     */
+    callback: (html: JQueryOrHtml) => Value;
 
-  /**
-   * Callback function upon no
-   */
-  no?: (html: JQueryOrHtml) => No;
+    /**
+     * A function that fires after the dialog is rendered
+     */
+    render?: (html: JQueryOrHtml) => void;
 
-  /**
-   * A function to call when the dialog is rendered
-   */
-  render?: (html: JQueryOrHtml) => void;
+    /**
+     * Reject the promise if the dialog is closed without confirming the
+     * choice, otherwise resolve as null
+     * @defaultValue `true`
+     */
+    rejectClose?: boolean;
 
-  /**
-   * Make "yes" the default choice?
-   * @defaultValue `true`
-   */
-  defaultYes?: boolean;
-
-  /**
-   * Reject the Promise if the Dialog is closed without making a choice.
-   * @defaultValue `false`
-   */
-  rejectClose?: boolean;
-
-  /**
-   * Additional rendering options passed to the Dialog
-   * @defaultValue `{}`
-   */
-  options?: Partial<DialogOptions>;
-}
-
-/**
- * @typeParam Value        - The value returned by the callback function
- * @typeParam JQueryOrHtml - The parameter passed to the callbacks, either JQuery or HTMLElement
- */
-interface PromptConfig<Value, JQueryOrHtml> {
-  /**
-   * The confirmation window title
-   */
-  title?: string;
-
-  /**
-   * The confirmation message
-   */
-  content?: string;
-
-  /**
-   * The confirmation button text
-   */
-  label?: string;
-
-  /**
-   * A callback function to fire when the button is clicked
-   */
-  callback: (html: JQueryOrHtml) => Value;
-
-  /**
-   * A function that fires after the dialog is rendered
-   */
-  render?: (html: JQueryOrHtml) => void;
-
-  /**
-   * Reject the promise if the dialog is closed without confirming the
-   * choice, otherwise resolve as null
-   * @defaultValue `true`
-   */
-  rejectClose?: boolean;
-
-  /**
-   * Additional rendering options
-   * @defaultValue `{}`
-   */
-  options?: Partial<DialogOptions>;
+    /**
+     * Additional rendering options
+     * @defaultValue `{}`
+     */
+    options?: Partial<DialogOptions>;
+  }
 }

--- a/src/foundry/client/ui/dialog.d.ts
+++ b/src/foundry/client/ui/dialog.d.ts
@@ -74,7 +74,7 @@ declare class Dialog<Options extends DialogOptions = DialogOptions> extends Appl
    * Handle a keydown event while the dialog is active
    * @param event - The keydown event
    */
-  protected _onKeyDown(event: KeyboardEvent & { key: "Escape" }): ReturnType<Dialog["close"]>;
+  protected _onKeyDown(event: KeyboardEvent & { key: "Escape" }): Promise<void>;
   protected _onKeyDown(event: KeyboardEvent): void;
 
   override _renderOuter(): ReturnType<Application["_renderOuter"]>;

--- a/test-d/foundry/client/ui/dialog.test-d.ts
+++ b/test-d/foundry/client/ui/dialog.test-d.ts
@@ -628,3 +628,55 @@ expectType<Promise<string>>(
     rejectClose: true
   })
 );
+
+expectType<Promise<unknown>>(
+  Dialog.wait({
+    title: title,
+    content: content,
+    buttons: {
+      button: {
+        callback: (jqOrHtml: JQuery | HTMLElement) => {
+          expectType<JQuery | HTMLElement>(jqOrHtml);
+        }
+      }
+    }
+  })
+);
+
+expectType<Promise<unknown>>(
+  Dialog.wait(
+    {
+      title: title,
+      content: content,
+      buttons: {
+        button: {
+          callback: (jq) => {
+            expectType<JQuery>(jq);
+          }
+        }
+      }
+    },
+    {
+      jQuery: true
+    }
+  )
+);
+
+expectType<Promise<unknown>>(
+  Dialog.wait(
+    {
+      title: title,
+      content: content,
+      buttons: {
+        button: {
+          callback: (html) => {
+            expectType<HTMLElement>(html);
+          }
+        }
+      }
+    },
+    {
+      jQuery: false
+    }
+  )
+);

--- a/test-d/foundry/client/ui/dialog.test-d.ts
+++ b/test-d/foundry/client/ui/dialog.test-d.ts
@@ -4,6 +4,7 @@ import "../../../index";
 const title = "title";
 const content = "content";
 const label = "label";
+const icon = "<i class='fas fa-bug-slash'>";
 
 expectType<Promise<true | false | null>>(
   Dialog.confirm({
@@ -635,6 +636,8 @@ expectType<Promise<unknown>>(
     content: content,
     buttons: {
       button: {
+        icon: icon,
+        label: label,
         callback: (jqOrHtml: JQuery | HTMLElement) => {
           expectType<JQuery | HTMLElement>(jqOrHtml);
         }
@@ -650,6 +653,8 @@ expectType<Promise<unknown>>(
       content: content,
       buttons: {
         button: {
+          icon: icon,
+          label: label,
           callback: (jq) => {
             expectType<JQuery>(jq);
           }
@@ -669,6 +674,8 @@ expectType<Promise<unknown>>(
       content: content,
       buttons: {
         button: {
+          icon: icon,
+          label: label,
           callback: (html) => {
             expectType<HTMLElement>(html);
           }


### PR DESCRIPTION
* resolves #2214

This changeset introduces the following major changes:
* Add new `disabled` property to `Dialog.Button`
* Remove static qualification of `Dialog.title`. From what I can tell, even in V9 this was not static.
* Update `Dialog.getData` to always return an object and not a `MaybePromise`. This is the documented behavior in the V10 API docs and, as far as I can tell, also the implementation behavior. Referring back to V9 again, this was also the case back then, it just wasn't documented that way in the V9 API docs.
* Add an `event` parameter to `Dialog.submit`. Interestingly enough, there seems to be an inconsistency between the V10 API doc and the actual implementation. According to the docs, `Dialog.submit` can receive an optional `event` parameter of type `PointerEvent`. However, the implementation will pass along the event received by `Dialog._onClickButton`. This parameter is of type `MouseEvent`, which is the super class of `PointerEvent`. Thus, in my opinion, we should declare the `event` parameter of `Dialog.submit` to be `MouseEvent`, since there is no obvious guarantee that the value passed to the parameter will always be a `PointerEvent`.
* Add the `wait` factory which was introduced in V10. I'm not entirely happy with the typing of its return type. I chose `Promise<unknown>` since it essentially depends on the return types of the callbacks of the buttons. `Promise<any>` seemed to provide to much leeway in my opinion, and a user should explicitly check what actual types resulted in their use case.