### PR TITLE
V10 typings: update CardConfig

### DIFF
--- a/src/foundry/client/apps/forms/card-config.d.ts
+++ b/src/foundry/client/apps/forms/card-config.d.ts
@@ -33,6 +33,6 @@ declare global {
      * @param event - The originating click event
      * @returns A Promise which resolves once the handler has completed
      */
-    protected _onFaceControl(event: JQuery.ClickEvent): Promise<void>;
+    protected _onFaceControl(event: JQuery.ClickEvent): Promise<unknown>;
   }
 }

--- a/src/foundry/client/apps/forms/card-config.d.ts
+++ b/src/foundry/client/apps/forms/card-config.d.ts
@@ -1,5 +1,4 @@
-import type { ConfiguredDocumentClassForName, ConstructorDataType } from "../../../../types/helperTypes.js";
-import type { CardFaceData } from "../../../common/data/module.mjs.js";
+import type { ConfiguredDocumentClassForName } from "../../../../types/helperTypes.js";
 
 declare global {
   /**
@@ -28,10 +27,6 @@ declare global {
     override getData(options?: Partial<Options>): MaybePromise<object>;
 
     override activateListeners(html: JQuery): void;
-
-    protected override _getSubmitData(
-      updateData?: object | null
-    ): Record<string, unknown> & { faces: ConstructorDataType<CardFaceData>[] };
 
     /**
      * Handle card face control actions which modify single cards on the sheet.


### PR DESCRIPTION
resolves: #1863 

This changeset introduces the following major changes:
* Remove `CardConfig._getSubmitData` as it is no longer present in `CardConfig` in V10 (as in it is no longer overridden by the implementation, it is of course still part of the base `FormApplication`).
* Retype `CardConfig._onFaceControl` to return `Promise<unknown>` instead of `Promise<void>`. The actual implementation returns either the result of updating the `Card` objects (which would yield `Promise<Card>` or more precisely `Promise<InstanceType<ConfiguredDocumentClassForName<"Card">>`) or the result of `Dialog.confirm`. The API documentation describes it as returning `Promise<any>`, which seems unnecessarily open. I am a bit conflicted on whether or not we should return the actual precise types. I feel that it would expose to much of the implementation details. Nonetheless, I do feel that returning `Promise<void>` is too restrictive.