### PR TITLE
Re-enable lib check and fix hidden errors

### DIFF
--- a/src/foundry/client/apps/forms/ownership.d.ts
+++ b/src/foundry/client/apps/forms/ownership.d.ts
@@ -31,7 +31,7 @@ declare global {
   /**
    * @deprecated since v10.
    */
-  class PermissionControl extends DocumentOwnershipConfig {}
+  class PermissionControl extends DocumentOwnershipConfig<any, any> {}
 
   namespace DocumentOwnershipConfig {
     interface FormData {

--- a/src/foundry/client/apps/hud/chatbubble.d.ts
+++ b/src/foundry/client/apps/hud/chatbubble.d.ts
@@ -6,7 +6,7 @@ declare global {
    * This application displays a temporary message sent from a particular Token in the active Scene.
    * The message is displayed on the HUD layer just above the Token.
    */
-  declare class ChatBubbles {
+  class ChatBubbles {
     constructor();
 
     /**
@@ -97,7 +97,7 @@ declare global {
     protected _getDuration(html: JQuery): number;
   }
 
-  declare namespace ChatBubbles {
+  namespace ChatBubbles {
     interface Dimensions {
       width: number;
       height: number;

--- a/src/foundry/client/tours/setup-tour.d.ts
+++ b/src/foundry/client/tours/setup-tour.d.ts
@@ -1,5 +1,4 @@
 import { Tour } from "../core/tour";
-import { Application } from "../apps/app";
 
 declare global {
   class SetupTour extends Tour {

--- a/src/types/augments/tinyMCE.d.ts
+++ b/src/types/augments/tinyMCE.d.ts
@@ -28,7 +28,7 @@ declare global {
     type EditorSelection = _tinymceTypes.EditorSelection;
     type Entities = _tinymceTypes.Entities;
     type Env = _tinymceTypes.Env;
-    type EventDispatcher<T> = _tinymceTypes.EventDispatcher<T>;
+    type EventDispatcher<T extends {}> = _tinymceTypes.EventDispatcher<T>;
     type EventUtils = _tinymceTypes.EventUtils;
     type FakeClipboard = _tinymceTypes.FakeClipboard;
     type FocusManager = _tinymceTypes.FocusManager;
@@ -43,7 +43,7 @@ declare global {
     type NotificationApi = _tinymceTypes.NotificationApi;
     type NotificationManager = _tinymceTypes.NotificationManager;
     type NotificationSpec = _tinymceTypes.NotificationSpec;
-    type Observable<T> = _tinymceTypes.Observable<T>;
+    type Observable<T extends {}> = _tinymceTypes.Observable<T>;
     type Plugin = _tinymceTypes.Plugin;
     type PluginManager = _tinymceTypes.PluginManager;
     type RangeUtils = _tinymceTypes.RangeUtils;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
     "lib": ["DOM", "ES2020"],
     "moduleResolution": "Node",
     "noEmit": true,
-    "skipLibCheck": true,
     "strict": true,
     "target": "ES2020",
     "verbatimModuleSyntax": true


### PR DESCRIPTION
So the tsconfig option `skipLibCheck` skips type checking all `.d.ts` files. This fixed the TinyMCE augments but it also silenced the type checking in every single `.d.ts` file we had, that is to say basically _all_ our Typescript files. This should fix that.