### PR TITLE
Sidebar apps

### DIFF
--- a/src/foundry/client/apps/sidebar/apps/invitation-links.d.mts
+++ b/src/foundry/client/apps/sidebar/apps/invitation-links.d.mts
@@ -1,4 +1,4 @@
-import type { MaybePromise } from "../../../../../types/utils.d.mts";
+export {};
 
 declare global {
   /**
@@ -20,7 +20,8 @@ declare global {
      */
     static override get defaultOptions(): ApplicationOptions;
 
-    override getData(options?: Partial<Options> | undefined): MaybePromise<object>;
+    // TODO: Implement GetDataReturnType
+    override getData(options?: Partial<Options>): Promise<object>;
 
     override activateListeners(html: JQuery): void;
   }

--- a/src/foundry/client/apps/sidebar/apps/keybindings-config.d.mts
+++ b/src/foundry/client/apps/sidebar/apps/keybindings-config.d.mts
@@ -1,4 +1,4 @@
-export {};
+import type { MaybePromise } from "../../../../../types/utils.d.mts";
 
 declare global {
   /**
@@ -13,20 +13,18 @@ declare global {
      * foundry.utils.mergeObject(super.defaultOptions, {
      *   title: game.i18n.localize("SETTINGS.Keybindings"),
      *   id: "keybindings",
-     *   categoryTemplate: "templates/sidebar/apps/keybindings-config-category.html"
-     * })
+     *   categoryTemplate: "templates/sidebar/apps/keybindings-config-category.html",
+     *   scrollY: [".scrollable"]
+     * });
      * ```
      */
     static override get defaultOptions(): FormApplicationOptions;
 
-    /** {@inheritdoc} */
     static override get categoryOrder(): string[];
 
-    /** {@inheritdoc} */
-    protected _categorizeEntry(namespace: string): PackageConfiguration.Category;
+    protected override _categorizeEntry(namespace: string): PackageConfiguration.Category;
 
-    /** {@inheritdoc} */
-    _prepareCategoryData(): PackageConfiguration.Category;
+    protected override _prepareCategoryData(): PackageConfiguration.CategoryData;
 
     /**
      * Add faux-keybind actions that represent the possible Mouse Controls
@@ -65,7 +63,7 @@ declare global {
      * Handle Control clicks
      * @internal
      */
-    protected _onClickBindingControl(event: MouseEvent): void;
+    protected _onClickBindingControl(event: MouseEvent): MaybePromise<void>;
 
     /**
      * Handle left-click events to show / hide a certain category

--- a/src/foundry/client/apps/sidebar/apps/keybindings-config.d.mts
+++ b/src/foundry/client/apps/sidebar/apps/keybindings-config.d.mts
@@ -5,7 +5,7 @@ declare global {
    * Allows for viewing and editing of Keybinding Actions
    */
   class KeybindingsConfig<
-    Options extends FormApplicationOptions = FormApplicationOptions,
+    Options extends PackageConfiguration.Options = PackageConfiguration.Options,
   > extends PackageConfiguration<Options> {
     /**
      * @defaultValue
@@ -18,8 +18,11 @@ declare global {
      * });
      * ```
      */
-    static override get defaultOptions(): FormApplicationOptions;
+    static override get defaultOptions(): PackageConfiguration.Options;
 
+    /**
+     * @returns ["all", "core", "core-mouse", "system", "module", "unmapped"]
+     */
     static override get categoryOrder(): string[];
 
     protected override _categorizeEntry(namespace: string): PackageConfiguration.Category;
@@ -57,7 +60,7 @@ declare global {
 
     override activateListeners(html: JQuery): void;
 
-    protected override _onResetDefaults(event: JQuery.ClickEvent<any, any, any, any>): Promise<any>;
+    protected override _onResetDefaults(event: JQuery.ClickEvent): Promise<void>;
 
     /**
      * Handle Control clicks

--- a/src/foundry/client/apps/sidebar/apps/module-management.d.mts
+++ b/src/foundry/client/apps/sidebar/apps/module-management.d.mts
@@ -11,6 +11,11 @@ declare global {
     Options,
     undefined
   > {
+    /**
+     * @param options - Module Management application options.
+     */
+    constructor(options: Partial<Options>);
+
     /** @internal */
     protected _filter: ModuleManagement.FilterName;
 
@@ -28,7 +33,7 @@ declare global {
     /**
      * @defaultValue
      * ```typescript
-     * mergeObject(super.defaultOptions, {
+     * foundry.utils.mergeObject(super.defaultOptions, {
      *   title: game.i18n.localize("MODMANAGE.Title"),
      *   id: "module-management",
      *   template: "templates/sidebar/apps/module-management.html",
@@ -45,11 +50,28 @@ declare global {
 
     override get isEditable(): boolean;
 
+    // TODO: Implement GetDataReturnType
     override getData(options?: Partial<Options>): MaybePromise<object>;
+
+    /**
+     * Given a module, determines if it meets minimum and maximum compatibility requirements of its dependencies.
+     * If not, it is marked as being unable to be activated.
+     * If the package does not meet verified requirements, it is marked with a warning instead.
+     * @param module  The module.
+     */
+    protected _evaluateDependencies(module: Module): void;
+
+    /**
+     * Given a module, determine if it meets the minimum and maximum system compatibility requirements.
+     * @param module  The module.
+     */
+    protected _evaluateSystemCompatibility(module: Module): void;
 
     override activateListeners(html: JQuery): void;
 
     protected override _renderInner(data: object): Promise<JQuery>;
+
+    protected override _getSubmitData(updateData?: object | null): ModuleManagement.FormData;
 
     protected override _updateObject(event: Event, formData: ModuleManagement.FormData): Promise<unknown>;
 
@@ -57,7 +79,18 @@ declare global {
      * Handle changes to a module checkbox to prompt for whether or not to enable dependencies
      * @internal
      */
-    protected _onChangeCheckbox(event: JQuery.ChangeEvent): unknown;
+    protected _onChangeCheckbox(event: JQuery.ChangeEvent): Promise<unknown>;
+
+    // #checkImpactedDependency
+    // #checkUpstreamPackages
+
+    /**
+     * Indicate if any Documents would become unavailable if the module were disabled, and confirm if the user wishes to
+     * proceed.
+     * @param module The module being disabled.
+     * @returns A Promise which resolves to true if disabling should continue.
+     */
+    protected _confirmDocumentsUnavailable(module: Module): Promise<boolean>;
 
     /**
      * Handle a button-click to deactivate all modules
@@ -78,6 +111,13 @@ declare global {
     protected _onFilterList(event: JQuery.ClickEvent): void;
 
     protected override _onSearchFilter(event: KeyboardEvent, query: string, rgx: RegExp, html: HTMLElement): void;
+
+    /**
+     * Format a document count collection for display.
+     * @param counts  An object of sub-type counts.
+     * @param isActive Whether the module is active.
+     */
+    protected _formatDocumentSummary(counts: ModuleSubTypeCounts, isActive: boolean): string;
   }
 
   namespace ModuleManagement {
@@ -87,4 +127,6 @@ declare global {
       search: string;
     };
   }
+
+  interface ModuleSubTypeCounts extends Record<string, Record<string, number>> {}
 }

--- a/src/foundry/client/apps/sidebar/apps/module-management.d.mts
+++ b/src/foundry/client/apps/sidebar/apps/module-management.d.mts
@@ -57,23 +57,26 @@ declare global {
      * Given a module, determines if it meets minimum and maximum compatibility requirements of its dependencies.
      * If not, it is marked as being unable to be activated.
      * If the package does not meet verified requirements, it is marked with a warning instead.
-     * @param module  The module.
+     * @param module - The module.
      */
     protected _evaluateDependencies(module: Module): void;
 
     /**
      * Given a module, determine if it meets the minimum and maximum system compatibility requirements.
-     * @param module  The module.
+     * @param module - The module.
      */
     protected _evaluateSystemCompatibility(module: Module): void;
 
     override activateListeners(html: JQuery): void;
 
-    protected override _renderInner(data: object): Promise<JQuery>;
+    protected override _renderInner(data: ReturnType<this["getData"]>): Promise<JQuery>;
 
     protected override _getSubmitData(updateData?: object | null): ModuleManagement.FormData;
 
-    protected override _updateObject(event: Event, formData: ModuleManagement.FormData): Promise<unknown>;
+    protected override _updateObject(
+      event: Event,
+      formData: ModuleManagement.FormData,
+    ): Promise<Record<string, boolean> | number>;
 
     /**
      * Handle changes to a module checkbox to prompt for whether or not to enable dependencies
@@ -87,7 +90,7 @@ declare global {
     /**
      * Indicate if any Documents would become unavailable if the module were disabled, and confirm if the user wishes to
      * proceed.
-     * @param module The module being disabled.
+     * @param module - The module being disabled.
      * @returns A Promise which resolves to true if disabling should continue.
      */
     protected _confirmDocumentsUnavailable(module: Module): Promise<boolean>;
@@ -114,8 +117,8 @@ declare global {
 
     /**
      * Format a document count collection for display.
-     * @param counts  An object of sub-type counts.
-     * @param isActive Whether the module is active.
+     * @param counts   - An object of sub-type counts.
+     * @param isActive - Whether the module is active.
      */
     protected _formatDocumentSummary(counts: ModuleSubTypeCounts, isActive: boolean): string;
   }

--- a/src/foundry/client/apps/sidebar/apps/permission-config.d.mts
+++ b/src/foundry/client/apps/sidebar/apps/permission-config.d.mts
@@ -4,7 +4,10 @@ declare global {
   /**
    * An application for configuring the permissions which are available to each User role.
    */
-  class PermissionConfig extends FormApplication<FormApplicationOptions, undefined> {
+  class PermissionConfig<Options extends FormApplicationOptions = FormApplicationOptions> extends FormApplication<
+    Options,
+    undefined
+  > {
     /**
      * @defaultValue
      * ```typescript
@@ -19,14 +22,14 @@ declare global {
      * })
      * ```
      */
-    static override get defaultOptions(): (typeof FormApplication)["defaultOptions"];
+    static override get defaultOptions(): FormApplicationOptions;
 
     // TODO: Implement GetDataReturnType
     override getData(options?: Partial<FormApplicationOptions>): Promise<object>;
 
     /**
      * Prepare the permissions object used to render the configuration template
-     * @param current The current permission configuration
+     * @param current - The current permission configuration
      * @returns Permission data for sheet rendering
      * @internal
      */

--- a/src/foundry/client/apps/sidebar/apps/permission-config.d.mts
+++ b/src/foundry/client/apps/sidebar/apps/permission-config.d.mts
@@ -1,4 +1,4 @@
-import type { MaybePromise } from "../../../../../types/utils.d.mts";
+export {};
 
 declare global {
   /**
@@ -21,10 +21,14 @@ declare global {
      */
     static override get defaultOptions(): (typeof FormApplication)["defaultOptions"];
 
-    override getData(options?: Partial<FormApplicationOptions>): MaybePromise<object>;
+    // TODO: Implement GetDataReturnType
+    override getData(options?: Partial<FormApplicationOptions>): Promise<object>;
 
     /**
      * Prepare the permissions object used to render the configuration template
+     * @param current The current permission configuration
+     * @returns Permission data for sheet rendering
+     * @internal
      */
     protected _getPermissions(current: Game.Permissions): PermissionConfig.Permission[];
 
@@ -34,14 +38,14 @@ declare global {
      * Handle button click to reset default settings
      * @param event - The initial button click event
      */
-    protected _onResetDefaults(event: JQuery.ClickEvent): void;
+    protected _onResetDefaults(event: JQuery.ClickEvent): Promise<Application>;
 
     protected override _onSubmit(
       event: Event,
       options?: FormApplication.OnSubmitOptions,
     ): ReturnType<FormApplication["_onSubmit"]>;
 
-    protected override _updateObject(event: Event, formData: PermissionConfig.FormData): Promise<unknown>;
+    protected override _updateObject(event: Event, formData: PermissionConfig.FormData): Promise<void>;
   }
 
   namespace PermissionConfig {

--- a/src/foundry/client/apps/sidebar/apps/support-details.d.mts
+++ b/src/foundry/client/apps/sidebar/apps/support-details.d.mts
@@ -39,11 +39,11 @@ declare global {
     /**
      * @internal
      */
-    protected override _renderInner(data: object): Promise<JQuery>;
+    protected override _renderInner(data: ReturnType<this["getData"]>): Promise<JQuery>;
 
     /**
      * Handle a button click action.
-     * @param event The click event
+     * @param event - The click event
      */
     protected _onClickAction(event: MouseEvent): void;
 

--- a/src/foundry/client/apps/sidebar/apps/support-details.d.mts
+++ b/src/foundry/client/apps/sidebar/apps/support-details.d.mts
@@ -13,8 +13,11 @@ declare global {
      * options.title = "SUPPORT.Title";
      * options.id = "support-details";
      * options.template = "templates/sidebar/apps/support-details.html";
-     * options.width = 620;
-     * options.height = "auto";
+     * options.width = 780;
+     * options.height = 680;
+     * options.resizable = true;
+     * options.classes = ["sheet"];
+     * options.tabs = [{navSelector: ".tabs", contentSelector: "article", initial: "support"}];
      * return options;
      * ```
      */
@@ -23,12 +26,56 @@ declare global {
     /**
      * Returns the support report data
      */
+    // TODO: Implement GetDataReturnType
     getData(options?: Partial<Options> | undefined): MaybePromise<object>;
 
     /**
      * Binds the Support Report copy button
      */
     override activateListeners(html: JQuery): void;
+
+    protected override _render(force?: boolean, options?: Application.RenderOptions): Promise<void>;
+
+    /**
+     * @internal
+     */
+    protected override _renderInner(data: object): Promise<JQuery>;
+
+    /**
+     * Handle a button click action.
+     * @param event The click event
+     */
+    protected _onClickAction(event: MouseEvent): void;
+
+    /**
+     * Copy the support details report to clipboard.
+     */
+    protected _copyReport(): void;
+
+    /**
+     * Marshal information on Documents that failed validation and format it for display.
+     */
+    protected _getDocumentValidationErrors(): {
+      label: string;
+      documents: {
+        name: string;
+        validationError: string;
+      };
+    }[];
+
+    /**
+     * Marshal package-related warnings and errors and format it for display.
+     */
+    protected _getModuleIssues(): {
+      label: string;
+      issues: {
+        label: string;
+        issues: {
+          severity: "error" | "warning";
+          message: string;
+        }[];
+      }[];
+    }[];
 
     /**
      * Collects a number of metrics that is useful for Support
@@ -53,7 +100,7 @@ declare global {
     maxTextureSize: number | string;
     sceneDimensions: string;
     grid: number;
-    padding: number;
+    padding: number; // note: float in actual code
     walls: number;
     lights: number;
     sounds: number;

--- a/src/foundry/client/apps/sidebar/apps/tours-management.d.mts
+++ b/src/foundry/client/apps/sidebar/apps/tours-management.d.mts
@@ -1,4 +1,4 @@
-export {};
+import type { MaybePromise } from "../../../../../types/utils.d.mts";
 
 declare global {
   /** A management app for configuring which Tours are available or have been completed. */
@@ -18,23 +18,20 @@ declare global {
      */
     static override get defaultOptions(): PackageConfiguration.Options;
 
-    override _prepareCategoryData(): ToursManagement.TourCategory;
+    override _prepareCategoryData(): PackageConfiguration.CategoryData;
 
     override activateListeners(html: JQuery<HTMLElement>): void;
+
+    protected override _onResetDefaults(event: JQuery.ClickEvent): void;
 
     /**
      * Handle Control clicks
      * @internal
      */
-    protected _onClickControl(event: JQuery.ClickEvent): void;
+    protected _onClickControl(event: JQuery.ClickEvent): MaybePromise<unknown>;
   }
 
   namespace ToursManagement {
-    interface TourCategory extends PackageConfiguration.Category {
-      tours: TourData[];
-      count: number;
-    }
-
     interface TourData {
       category: string;
       id: string;

--- a/src/foundry/client/apps/sidebar/apps/tours-management.d.mts
+++ b/src/foundry/client/apps/sidebar/apps/tours-management.d.mts
@@ -18,7 +18,7 @@ declare global {
      */
     static override get defaultOptions(): PackageConfiguration.Options;
 
-    override _prepareCategoryData(): PackageConfiguration.CategoryData;
+    override _prepareCategoryData(): ToursManagement.TourCategoryData;
 
     override activateListeners(html: JQuery<HTMLElement>): void;
 
@@ -32,6 +32,11 @@ declare global {
   }
 
   namespace ToursManagement {
+    interface TourCategory extends PackageConfiguration.Category {
+      tours: TourData[];
+      count: number;
+    }
+
     interface TourData {
       category: string;
       id: string;
@@ -42,6 +47,10 @@ declare global {
       status: string;
       canBePlayed?: boolean;
       startOrResume?: string;
+    }
+
+    interface TourCategoryData extends PackageConfiguration.CategoryData {
+      categories: TourCategory[];
     }
   }
 }

--- a/src/foundry/client/apps/sidebar/package-configuration.d.mts
+++ b/src/foundry/client/apps/sidebar/package-configuration.d.mts
@@ -33,7 +33,7 @@ declare global {
     override getData(): MaybePromise<object>; // TODO: Implement GetDataReturnType
 
     /** Prepare the structure of category data which is rendered in this configuration form. */
-    abstract _prepareCategoryData(): PackageConfiguration.Category;
+    protected abstract _prepareCategoryData(): PackageConfiguration.CategoryData;
 
     /**
      * Classify what Category an Action belongs to
@@ -74,6 +74,11 @@ declare global {
     interface Category {
       id: string;
       title: string;
+    }
+
+    interface CategoryData {
+      categories: Category[];
+      total: number;
     }
   }
 }


### PR DESCRIPTION
Haven't touched world config yet, but all the rest are here. Open questions:

- `categoryOrder` inherits the exact return type definition of a specific string array (just in the type documentation), but we know it's different because it adds one in at index 2. Anything we need to change there?
- the new `CategoryData` interface I've made in `package-configuration`; should categories be `Category[]` or `object[]`?
- Not sure I got the `ModuleManagement` constructor right
- What about `ModuleManagement`'s `_renderInner`? It takes `...args` but eventually that just becomes `data`

Lemme know what I need to fix!
