### PR TITLE
common.abstract.type-data

### DIFF
--- a/src/foundry/client/ui/editor.d.mts
+++ b/src/foundry/client/ui/editor.d.mts
@@ -386,6 +386,51 @@ declare global {
       relativeTo: ClientDocument<foundry.abstract.Document<any, any, any>>;
     }
 
+    interface DocumentHTMLEmbedConfig {
+      /**
+       * Any strings that did not have a key name associated with them.
+       */
+      values: string[];
+
+      /**
+       * Classes to attach to the outermost element.
+       */
+      classes?: string | undefined;
+
+      /**
+       * By default Documents are embedded inside a figure element. If this option is
+       * passed, the embed content will instead be included as part of the rest of the
+       * content flow, but still wrapped in a section tag for styling purposes.
+       * @defaultValue `false`
+       */
+      inline: boolean;
+
+      /**
+       * Whether to include a content link to the original Document as a citation. This
+       * options is ignored if the Document is inlined.
+       * @defaultValue `true`
+       */
+      cite: boolean;
+
+      /**
+       * Whether to include a caption. The caption will depend on the Document being
+       * embedded, but if an explicit label is provided, that will always be used as the
+       * caption. This option is ignored if the Document is inlined.
+       * @defaultValue `true`
+       */
+      caption: boolean;
+
+      /**
+       * Controls whether the caption is rendered above or below the embedded
+       * content.
+       * @defaultValue `"bottom"`
+       */
+      captionPosition: string;
+
+      /** The label. */
+      label: string;
+    }
+
     interface GetContentLinkOptions {
       /** A document to generate the link relative to. */
       relativeTo?: ClientDocument<foundry.abstract.Document<any, any, any>>;

--- a/src/foundry/common/abstract/type-data.d.mts
+++ b/src/foundry/common/abstract/type-data.d.mts
@@ -1,6 +1,9 @@
 import type { Merge } from "../../../types/utils.d.mts";
+import type BaseUser from "../documents/user.d.mts";
 import type DataModel from "./data.d.mts";
 import type Document from "./document.d.mts";
+import type { DocumentModificationOptions } from "./document.d.mts";
+import type { fields } from "../data/module.mts";
 
 type StaticDataModel = typeof DataModel<DataSchema, Document<DataSchema, any, any>>;
 
@@ -87,15 +90,108 @@ export default abstract class TypeDataModel<
   modelProvider: System | Module | null;
 
   /**
-   * Prepare data related to this DataModel itself, before any derived data is computed.
+   * A set of localization prefix paths which are used by this data model.
    */
-  prepareBaseData(this: Merge<DataModel<Schema, Parent>, Partial<DerivedData>>): void;
+  static LOCALIZATION_PREFIXES: string[];
 
-  /* -------------------------------------------- */
+  /**
+   * Prepare data related to this DataModel itself, before any derived data is computed.
+   *
+   * Called before {@link ClientDocument#prepareBaseData} in {@link ClientDocument#prepareData}.
+   * */
+  prepareBaseData(this: Merge<DataModel<Schema, Parent>, Partial<BaseData>>): void;
 
   /**
    * Apply transformations of derivations to the values of the source data object.
    * Compute data fields whose values are not stored to the database.
+   *
+   * Called before {@link ClientDocument#prepareDerivedData} in {@link ClientDocument#prepareData}.
    */
   prepareDerivedData(this: Merge<Merge<DataModel<Schema, Parent>, BaseData>, Partial<DerivedData>>): void;
+
+  /**
+   * Convert this Document to some HTML display for embedding purposes.
+   * @param config  - Configuration for embedding behavior.
+   * @param options - The original enrichment options for cases where the Document embed content
+   *                  also contains text that must be enriched.
+   */
+  toEmbed(
+    config: TextEditor.DocumentHTMLEmbedConfig,
+    options: TextEditor.EnrichmentOptions,
+  ): Promise<HTMLElement | HTMLCollection | null>;
+
+  /* -------------------------------------------- */
+  /*  Database Operations                         */
+  /* -------------------------------------------- */
+
+  /**
+   * Called by {@link ClientDocument#_preCreate}.
+   *
+   * @param data    - The initial data object provided to the document creation request
+   * @param options - Additional options which modify the creation request
+   * @param user    - The User requesting the document creation
+   * @returns Return false to exclude this Document from the creation operation
+   */
+  protected _preCreate(
+    data: fields.SchemaField.AssignmentType<Schema>,
+    options: DocumentModificationOptions,
+    user: BaseUser,
+  ): Promise<boolean | void>;
+
+  /**
+   * Called by {@link ClientDocument#_onCreate}.
+   *
+   * @param data    - The initial data object provided to the document creation request
+   * @param options - Additional options which modify the creation request
+   * @param userId  - The id of the User requesting the document update
+   */
+  protected _onCreate(
+    data: fields.SchemaField.AssignmentType<Schema>,
+    options: DocumentModificationOptions,
+    userId: string,
+  ): void;
+
+  /**
+   * Called by {@link ClientDocument#_preUpdate}.
+   *
+   * @param changes - The candidate changes to the Document
+   * @param options - Additional options which modify the update request
+   * @param user    - The User requesting the document update
+   * @returns A return value of false indicates the update operation should be cancelled.
+   */
+  protected _preUpdate(
+    changes: fields.SchemaField.AssignmentType<Schema>,
+    options: DocumentModificationOptions,
+    userId: string,
+  ): Promise<boolean | void>;
+
+  /**
+   * Called by {@link ClientDocument#_onUpdate}.
+   *
+   * @param changed - The differential data that was changed relative to the documents prior values
+   * @param options - Additional options which modify the update request
+   * @param userId  - The id of the User requesting the document update
+   */
+  protected _onUpdate(
+    changed: fields.SchemaField.AssignmentType<Schema>,
+    options: DocumentModificationOptions,
+    userId: string,
+  ): void;
+
+  /**
+   * Called by {@link ClientDocument#_preDelete}.
+   *
+   * @param options - Additional options which modify the deletion request
+   * @param user    - The User requesting the document deletion
+   * @returns A return value of false indicates the deletion operation should be cancelled.
+   */
+  protected _preDelete(options: DocumentModificationOptions, user: BaseUser): Promise<boolean | void>;
+
+  /**
+   * Called by {@link ClientDocument#_onDelete}.
+   *
+   * @param options - Additional options which modify the deletion request
+   * @param userId  - The id of the User requesting the document update
+   */
+  protected _onDelete(options: DocumentModificationOptions, userId: string): void;
 }

--- a/src/foundry/common/abstract/type-data.d.mts
+++ b/src/foundry/common/abstract/type-data.d.mts
@@ -19,9 +19,10 @@ declare const _InternalTypeDataModelConst: _InternalTypeDataModelInterface;
 declare class _InternalTypeDataModel<
   Schema extends DataSchema,
   Parent extends Document<DataSchema, any, any>,
+  BaseData extends Record<string, unknown> = Record<string, never>,
   DerivedData extends Record<string, unknown> = Record<string, never>,
   // This does not work if inlined. It's weird to put it here but it works.
-  _ComputedInstance extends object = DerivedData,
+  _ComputedInstance extends object = RemoveIndexSignatures<Merge<BaseData, DerivedData>>,
 > extends _InternalTypeDataModelConst<Schema, Parent, _ComputedInstance> {}
 
 /**
@@ -83,8 +84,9 @@ declare class _InternalTypeDataModel<
 export default abstract class TypeDataModel<
   Schema extends DataSchema,
   Parent extends Document<DataSchema, any, any>,
-  DerivedData extends Record<string, unknown> = RemoveIndexSignatures<Record<string, never>>,
-> extends _InternalTypeDataModel<Schema, Parent, DerivedData> {
+  BaseData extends Record<string, unknown> = Record<string, never>,
+  DerivedData extends Record<string, unknown> = Record<string, never>,
+> extends _InternalTypeDataModel<Schema, Parent, BaseData, DerivedData> {
   modelProvider: System | Module | null;
 
   /**
@@ -97,7 +99,7 @@ export default abstract class TypeDataModel<
    *
    * Called before {@link ClientDocument#prepareBaseData} in {@link ClientDocument#prepareData}.
    * */
-  prepareBaseData(this: DataModel<Schema, Parent>): void;
+  prepareBaseData(this: Merge<DataModel<Schema, Parent>, BaseData>): void;
 
   /**
    * Apply transformations of derivations to the values of the source data object.
@@ -105,7 +107,7 @@ export default abstract class TypeDataModel<
    *
    * Called before {@link ClientDocument#prepareDerivedData} in {@link ClientDocument#prepareData}.
    */
-  prepareDerivedData(this: Merge<DataModel<Schema, Parent>, Partial<DerivedData>>): void;
+  prepareDerivedData(this: Merge<Merge<DataModel<Schema, Parent>, BaseData>, Partial<DerivedData>>): void;
 
   /**
    * Convert this Document to some HTML display for embedding purposes.

--- a/src/foundry/common/abstract/type-data.d.mts
+++ b/src/foundry/common/abstract/type-data.d.mts
@@ -1,4 +1,4 @@
-import type { Merge } from "../../../types/utils.d.mts";
+import type { Merge, RemoveIndexSignatures } from "../../../types/utils.d.mts";
 import type BaseUser from "../documents/user.d.mts";
 import type DataModel from "./data.d.mts";
 import type Document from "./document.d.mts";
@@ -19,10 +19,9 @@ declare const _InternalTypeDataModelConst: _InternalTypeDataModelInterface;
 declare class _InternalTypeDataModel<
   Schema extends DataSchema,
   Parent extends Document<DataSchema, any, any>,
-  BaseData extends Record<string, unknown> = Record<string, never>,
   DerivedData extends Record<string, unknown> = Record<string, never>,
   // This does not work if inlined. It's weird to put it here but it works.
-  _ComputedInstance extends object = Merge<BaseData, DerivedData>,
+  _ComputedInstance extends object = DerivedData,
 > extends _InternalTypeDataModelConst<Schema, Parent, _ComputedInstance> {}
 
 /**
@@ -84,9 +83,8 @@ declare class _InternalTypeDataModel<
 export default abstract class TypeDataModel<
   Schema extends DataSchema,
   Parent extends Document<DataSchema, any, any>,
-  BaseData extends Record<string, any> = Record<string, never>,
-  DerivedData extends Record<string, any> = Record<string, never>,
-> extends _InternalTypeDataModel<Schema, Parent, BaseData, DerivedData> {
+  DerivedData extends Record<string, unknown> = RemoveIndexSignatures<Record<string, never>>,
+> extends _InternalTypeDataModel<Schema, Parent, DerivedData> {
   modelProvider: System | Module | null;
 
   /**
@@ -99,7 +97,7 @@ export default abstract class TypeDataModel<
    *
    * Called before {@link ClientDocument#prepareBaseData} in {@link ClientDocument#prepareData}.
    * */
-  prepareBaseData(this: Merge<DataModel<Schema, Parent>, Partial<BaseData>>): void;
+  prepareBaseData(this: DataModel<Schema, Parent>): void;
 
   /**
    * Apply transformations of derivations to the values of the source data object.
@@ -107,7 +105,7 @@ export default abstract class TypeDataModel<
    *
    * Called before {@link ClientDocument#prepareDerivedData} in {@link ClientDocument#prepareData}.
    */
-  prepareDerivedData(this: Merge<Merge<DataModel<Schema, Parent>, BaseData>, Partial<DerivedData>>): void;
+  prepareDerivedData(this: Merge<DataModel<Schema, Parent>, Partial<DerivedData>>): void;
 
   /**
    * Convert this Document to some HTML display for embedding purposes.

--- a/tests/foundry/common/abstract/type-data.mjs.test-d.ts
+++ b/tests/foundry/common/abstract/type-data.mjs.test-d.ts
@@ -1,0 +1,33 @@
+import { expectTypeOf } from "vitest";
+import type DataModel from "../../../../src/foundry/common/abstract/data.d.mts";
+import type TypeDataModel from "../../../../src/foundry/common/abstract/type-data.d.mts";
+import type { fields } from "../../../../src/foundry/common/data/module.d.mts";
+import type { Merge } from "../../../../src/types/utils.d.mts";
+import type BaseJournalEntryPage from "../../../../src/foundry/common/documents/journal-entry-page.d.mts";
+
+/* attempting to use the example as a test */
+
+interface QuestSchema extends BaseJournalEntryPage.Schema {
+  description: fields.HTMLField;
+  steps: fields.ArrayField<fields.StringField>;
+}
+declare class TestModel extends TypeDataModel<
+  QuestSchema,
+  BaseJournalEntryPage,
+  { description: string; steps: string[] },
+  { totalSteps: number }
+> {}
+
+const t = new TestModel();
+
+expectTypeOf(t.prepareBaseData).toEqualTypeOf<
+  (this: Merge<DataModel<QuestSchema, BaseJournalEntryPage>, { description?: string; steps?: string[] }>) => void
+>;
+expectTypeOf(t.prepareDerivedData).toEqualTypeOf<
+  (
+    this: Merge<
+      Merge<DataModel<QuestSchema, BaseJournalEntryPage>, { description: string; steps: string[] }>,
+      { totalSteps?: number }
+    >,
+  ) => void
+>;

--- a/tests/foundry/common/abstract/type-data.mjs.test-d.ts
+++ b/tests/foundry/common/abstract/type-data.mjs.test-d.ts
@@ -1,6 +1,5 @@
 import { expectTypeOf } from "vitest";
 import type DataModel from "../../../../src/foundry/common/abstract/data.d.mts";
-import type TypeDataModel from "../../../../src/foundry/common/abstract/type-data.d.mts";
 import type { fields } from "../../../../src/foundry/common/data/module.d.mts";
 import type { Merge } from "../../../../src/types/utils.d.mts";
 import type BaseJournalEntryPage from "../../../../src/foundry/common/documents/journal-entry-page.d.mts";
@@ -8,26 +7,66 @@ import type BaseJournalEntryPage from "../../../../src/foundry/common/documents/
 /* attempting to use the example as a test */
 
 interface QuestSchema extends BaseJournalEntryPage.Schema {
-  description: fields.HTMLField;
+  description: fields.HTMLField<{ required: false; blank: true; initial: "" }>;
   steps: fields.ArrayField<fields.StringField>;
 }
-declare class TestModel extends TypeDataModel<
-  QuestSchema,
-  BaseJournalEntryPage,
-  { description: string; steps: string[] },
-  { totalSteps: number }
-> {}
 
-const t = new TestModel();
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+class QuestModel extends foundry.abstract.TypeDataModel<QuestSchema, BaseJournalEntryPage, { totalSteps: number }> {
+  prepareBaseData(this: DataModel<QuestSchema, BaseJournalEntryPage>): void {
+    // From JournalEntryPage
+    expectTypeOf(this.flags).toEqualTypeOf<Record<string, unknown>>;
 
-expectTypeOf(t.prepareBaseData).toEqualTypeOf<
-  (this: Merge<DataModel<QuestSchema, BaseJournalEntryPage>, { description?: string; steps?: string[] }>) => void
->;
-expectTypeOf(t.prepareDerivedData).toEqualTypeOf<
-  (
-    this: Merge<
-      Merge<DataModel<QuestSchema, BaseJournalEntryPage>, { description: string; steps: string[] }>,
-      { totalSteps?: number }
-    >,
-  ) => void
->;
+    // From Quest
+    expectTypeOf(this.steps).toEqualTypeOf<string[] | undefined[]>;
+    expectTypeOf(this.description).toEqualTypeOf<string | undefined>;
+
+    // @ts-expect-error Derived Data is not available yet
+    this.totalSteps + 1;
+  }
+
+  prepareDerivedData(this: Merge<DataModel<QuestSchema, BaseJournalEntryPage>, { totalSteps?: number }>): void {
+    // From JournalEntryPage
+    expectTypeOf(this.flags).toEqualTypeOf<Record<string, unknown>>;
+
+    // From Quest
+    expectTypeOf(this.steps).toEqualTypeOf<string[] | undefined[]>;
+    expectTypeOf(this.description).toEqualTypeOf<string | undefined>;
+
+    // Derived from Quest
+    if (this.totalSteps) this.totalSteps + 1;
+  }
+}
+
+/* Test with no DerivedData */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+class QuestModel2 extends foundry.abstract.TypeDataModel<QuestSchema, BaseJournalEntryPage> {
+  prepareDerivedData(this: Merge<DataModel<QuestSchema, BaseJournalEntryPage>, {}>): void {
+    // From JournalEntryPage
+    expectTypeOf(this.flags).toEqualTypeOf<Record<string, unknown>>;
+
+    // From Quest
+    expectTypeOf(this.steps).toEqualTypeOf<string[] | undefined[]>;
+    expectTypeOf(this.description).toEqualTypeOf<string | undefined>;
+
+    // @ts-expect-error Derived data should be declared
+    this.reward + 1;
+  }
+}
+
+/* Test with no DerivedData, with the user screwing up */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+class QuestModel3 extends foundry.abstract.TypeDataModel<QuestSchema, BaseJournalEntryPage> {
+  // FIXME: Here the user can force the derived data.
+  prepareDerivedData(this: Merge<DataModel<QuestSchema, BaseJournalEntryPage>, { reward: number }>): void {
+    // From JournalEntryPage
+    expectTypeOf(this.flags).toEqualTypeOf<Record<string, unknown>>;
+
+    // From Quest
+    expectTypeOf(this.steps).toEqualTypeOf<string[] | undefined[]>;
+    expectTypeOf(this.description).toEqualTypeOf<string | undefined>;
+
+    // No error when there should be one.
+    this.reward + 1;
+  }
+}

--- a/tests/foundry/common/documents/actor.test-d.ts
+++ b/tests/foundry/common/documents/actor.test-d.ts
@@ -1,6 +1,8 @@
 import { expectTypeOf } from "vitest";
 import type EmbeddedCollection from "../../../../src/foundry/common/abstract/embedded-collection.d.mts";
 import type { NumberField, SchemaField } from "../../../../src/foundry/common/data/fields.d.mts";
+import type DataModel from "../../../../src/foundry/common/abstract/data.d.mts";
+import type { Merge } from "../../../../src/types/utils.d.mts";
 
 // @ts-expect-error name and type are required
 new foundry.documents.BaseActor();
@@ -68,7 +70,7 @@ class MyCharacter extends foundry.abstract.TypeDataModel<MyCharacterSchema, Acto
     };
   }
 
-  prepareDerivedData(): void {
+  prepareDerivedData(this: Merge<DataModel<MyCharacterSchema, Actor.ConfiguredInstance>, {}>): void {
     this.abilities.strength.value + 2;
     for (const ability of Object.values(this.abilities)) {
       // @ts-expect-error Derived data must be declared
@@ -101,9 +103,8 @@ declare namespace BoilerplateActorBase {
 
 class BoilerplateActorBase<
   Schema extends BoilerplateActorBase.Schema = BoilerplateActorBase.Schema,
-  BaseData extends Record<string, any> = Record<never, never>,
   DerivedData extends Record<string, any> = Record<never, never>,
-> extends foundry.abstract.TypeDataModel<Schema, Actor.ConfiguredInstance, BaseData, DerivedData> {
+> extends foundry.abstract.TypeDataModel<Schema, Actor.ConfiguredInstance, DerivedData> {
   static defineSchema(): BoilerplateActorBase.Schema {
     const fields = foundry.data.fields;
     const requiredInteger = { required: true, nullable: false, integer: true };


### PR DESCRIPTION
Solves #2579 .

- added hook functions
- Added the `DocumentHTMLEmbedConfig` type in editor
- changed the type of `this` in `prepareBaseData`, as the documentation indicates that derived data should not be computed or present at this step (I might be wrong on this, please advise).