### PR TITLE
Updates `string.mjs`, `number.mjs`, and `math.mjs`

### DIFF
--- a/src/foundry/common/primitives/math.d.mts
+++ b/src/foundry/common/primitives/math.d.mts
@@ -3,11 +3,31 @@ export {};
 declare global {
   interface Math {
     /**
+     * √3
+     */
+    SQRT3: 1.7320508075688772;
+
+    /**
+     * √⅓
+     */
+    SQRT1_3: 0.5773502691896257;
+
+    /**
+     * Bound a number between some minimum and maximum value, inclusively.
+     * @param num - The current value
+     * @param min - The minimum allowed value
+     * @param max - The maximum allowed value
+     * @returns The clamped number
+     */
+    clamp(num: number, min: number, max: number): number;
+
+    /**
      * Bound a number between some minimum and maximum value, inclusively
      * @param num - The current value
      * @param min - The minimum allowed value
      * @param max - The maximum allowed value
      * @returns The clamped number
+     * @deprecated since v12 till v14
      */
     clamped(num: number, min: number, max: number): number;
 
@@ -25,8 +45,17 @@ declare global {
      * @param degrees - An angle in degrees
      * @param base    - The base angle to normalize to, either 0 for [0, 360) or 360 for (0, 360] (default: `0`)
      * @returns The same angle on the range [0, 360) or (0, 360]
+     * @deprecated since v12 until v14.
+     * @remarks Use Math.normalizeDegrees(degrees: number): number.
      */
     normalizeDegrees(degrees: number, base?: number): number;
+
+    /**
+     * Transform an angle in degrees to be bounded within the domain [0, 360]
+     * @param degrees - An angle in degrees
+     * @returns The same angle on the range [0, 360) or (0, 360]
+     */
+    normalizeDegrees(degrees: number): number;
 
     /**
      * Transform an angle in radians to be bounded within the domain [-PI, PI]
@@ -39,19 +68,9 @@ declare global {
      * Round a floating point number to a certain number of decimal places
      * @param number - A floating point number
      * @param places - An integer number of decimal places
+     * @deprecated since v12 till v14
      */
     roundDecimals(number: number, places: number): number;
-
-    /**
-     * To keep compatibility with previous implementation.
-     * roundFast was bugged and the performance advantage was not there.
-     * @param number - A finite number
-     * @returns The rounded number
-     *
-     * @deprecated since v10, will be removed in v12
-     * @remarks roundFast is deprecated in favor of {@link Math.round}
-     */
-    roundFast(number: number): number;
 
     /**
      * Transform an angle in radians to a number in degrees
@@ -72,11 +91,12 @@ declare global {
      * @param  minVal - The minimal value of the oscillation.
      * @param  maxVal - The maximum value of the oscillation.
      * @param  t      - The time value.
-     * @param  p      - The period (can't be equal to 0).
+     * @param  p      - The period (must be nonzero).
      *                  (default: `1`)
      * @param  func   - The optional math function to use for oscillation.
      *                  (default: `Math.cos`)
-     * @returns The oscillation according to t.
+     *                  Its period must be 2π
+     * @returns The oscillation according to t. `((maxValue - minValue) * (f(2π * t / p) + 1) / 2) + minValue`
      */
     oscillation(minVal: number, maxVal: number, t: number, p?: number, func?: (radians: number) => number): number;
   }

--- a/src/foundry/common/primitives/math.d.mts
+++ b/src/foundry/common/primitives/math.d.mts
@@ -43,19 +43,19 @@ declare global {
     /**
      * Transform an angle in degrees to be bounded within the domain [0, 360]
      * @param degrees - An angle in degrees
-     * @param base    - The base angle to normalize to, either 0 for [0, 360) or 360 for (0, 360] (default: `0`)
      * @returns The same angle on the range [0, 360) or (0, 360]
-     * @deprecated since v12 until v14.
-     * @remarks Use Math.normalizeDegrees(degrees: number): number.
      */
-    normalizeDegrees(degrees: number, base?: number): number;
+    normalizeDegrees(degrees: number): number;
 
     /**
      * Transform an angle in degrees to be bounded within the domain [0, 360]
      * @param degrees - An angle in degrees
+     * @param base    - The base angle to normalize to, either 0 for [0, 360) or 360 for (0, 360] (default: `0`)
      * @returns The same angle on the range [0, 360) or (0, 360]
+     * @deprecated since v12, until v14.
+     * @remarks Use Math.normalizeDegrees(degrees: number): number.
      */
-    normalizeDegrees(degrees: number): number;
+    normalizeDegrees(degrees: number, base?: number): number;
 
     /**
      * Transform an angle in radians to be bounded within the domain [-PI, PI]
@@ -68,7 +68,7 @@ declare global {
      * Round a floating point number to a certain number of decimal places
      * @param number - A floating point number
      * @param places - An integer number of decimal places
-     * @deprecated since v12 till v14
+     * @deprecated since v12, until v14
      */
     roundDecimals(number: number, places: number): number;
 

--- a/src/foundry/common/primitives/number.d.mts
+++ b/src/foundry/common/primitives/number.d.mts
@@ -36,6 +36,8 @@ declare global {
 
     /**
      * Round a number to the nearest number which is a multiple of a given interval
+     * This is a convenience function intended to humanize issues of floating point precision.
+     * The interval is treated as a standard string representation to determine the amount of decimal truncation applied.
      * @param interval - The interval to round the number to the nearest multiple of
      *                   (default: `1`)
      * @param method   - The rounding method in: round, ceil, floor

--- a/src/foundry/common/primitives/string.d.mts
+++ b/src/foundry/common/primitives/string.d.mts
@@ -8,6 +8,15 @@ declare global {
     capitalize<S extends string>(this: S): Capitalize<S>;
 
     /**
+     * Compare this string (x) with the other string (y) by comparing each character's Unicode code point value.
+     * This is the same comparison function that used by Array#sort if the compare function argument is omitted.
+     * The result is host/locale-independent.
+     * @param other - The other string to compare this string to.
+     * @returns a negative Number if x < y, a positive Number if x > y, or a zero otherwise.
+     */
+    compare<S extends string>(this: S, other: string): number;
+
+    /**
      * Convert a string to Title Case where the first letter of each word is capitalized
      */
     titleCase<S extends string>(this: S): Titlecase<S>;

--- a/src/foundry/common/primitives/string.d.mts
+++ b/src/foundry/common/primitives/string.d.mts
@@ -12,7 +12,7 @@ declare global {
      * This is the same comparison function that used by Array#sort if the compare function argument is omitted.
      * The result is host/locale-independent.
      * @param other - The other string to compare this string to.
-     * @returns a negative Number if x < y, a positive Number if x > y, or a zero otherwise.
+     * @returns A negative Number if x \< y, a positive Number if x \> y, or a zero otherwise.
      */
     compare<S extends string>(this: S, other: string): number;
 

--- a/tests/foundry/common/primitives/math.mjs.test-d.ts
+++ b/tests/foundry/common/primitives/math.mjs.test-d.ts
@@ -1,0 +1,22 @@
+import { expectTypeOf } from "vitest";
+
+expectTypeOf(Math.SQRT3).toEqualTypeOf<1.7320508075688772>();
+expectTypeOf(Math.SQRT1_3).toEqualTypeOf<0.5773502691896257>();
+
+expectTypeOf(Math.clamp(5, 1, 3)).toEqualTypeOf<number>();
+expectTypeOf(Math.clamped(5, 1, 3)).toEqualTypeOf<number>();
+
+expectTypeOf(Math.mix(5, 10, 0.5)).toEqualTypeOf<number>();
+
+expectTypeOf(Math.normalizeDegrees(240, 360)).toEqualTypeOf<number>();
+expectTypeOf(Math.normalizeDegrees(240)).toEqualTypeOf<number>();
+
+expectTypeOf(Math.normalizeRadians(4.18879)).toEqualTypeOf<number>();
+
+expectTypeOf(Math.toDegrees(4.18879)).toEqualTypeOf<number>();
+
+expectTypeOf(Math.toRadians(240)).toEqualTypeOf<number>();
+
+expectTypeOf(Math.oscillation(0.5, 2.0, 126387.8)).toEqualTypeOf<number>();
+expectTypeOf(Math.oscillation(0.5, 2.0, 126387.8, 2000)).toEqualTypeOf<number>();
+expectTypeOf(Math.oscillation(0.5, 2.0, 126387.8, 2000, Math.sin)).toEqualTypeOf<number>();


### PR DESCRIPTION
Solves #2587, #2586,  and #2585.

### Math.mjs
- Adds SQRT3 and SQRT1_3 values.
- Adds Math.clamp.
- Deprecates Math.clamped.
- Deprecates Math.normalizeDegrees with the base parameter.
- Removes Math.fastRound.

### String.mjs
- Adds compare function.

### Number.mjs
- Updates function definition text.