### PR TITLE
 Update iterable-weak-set.mjs #2607

### DIFF
--- a/src/foundry/common/utils/iterable-weak-set.d.mts
+++ b/src/foundry/common/utils/iterable-weak-set.d.mts
@@ -9,7 +9,7 @@ declare class IterableWeakSet<T extends WeakKey> extends WeakSet<T> {
   /**
    * The backing iterable weak map.
    */
-  #map: IterableWeakMap<T, T>;
+  private map: IterableWeakMap<T, T>;
 
   /**
    * @param entries - The initial entries.
@@ -44,6 +44,11 @@ declare class IterableWeakSet<T extends WeakKey> extends WeakSet<T> {
    * Enumerate the collection.
    */
   values(): Generator<T, void, never>;
+
+  /**
+   * Clear all values from the set.
+   */
+  clear(): void;
 }
 
 export default IterableWeakSet;

--- a/src/foundry/common/utils/iterable-weak-set.d.mts
+++ b/src/foundry/common/utils/iterable-weak-set.d.mts
@@ -1,16 +1,9 @@
-import type IterableWeakMap from "./iterable-weak-map.d.mts";
-
 /**
  * Stores a set of objects with weak references to them, allowing them to be garbage collected. Can be iterated over,
  * unlike a WeakSet.
  * @typeParam T - The type of the objects contained in the WeakSet
  */
 declare class IterableWeakSet<T extends WeakKey> extends WeakSet<T> {
-  /**
-   * The backing iterable weak map.
-   */
-  private map: IterableWeakMap<T, T>;
-
   /**
    * @param entries - The initial entries.
    */

--- a/tests/foundry/common/utils/iterable-weak-set.test-d.ts
+++ b/tests/foundry/common/utils/iterable-weak-set.test-d.ts
@@ -5,3 +5,5 @@ const m = new IterableWeakSet<{ x: number }>();
 expectTypeOf(m.add({ x: 1 })).toEqualTypeOf<IterableWeakSet<{ x: number }>>();
 
 expectTypeOf(m.values()).toEqualTypeOf<Generator<{ x: number }, void, never>>();
+
+expectTypeOf(m.clear()).toBeVoid();


### PR DESCRIPTION
Added method clear() to iterable weak set, and test for signature return value to make sure it's there.