### PR TITLE
Adjusted Document helper types

### DIFF
--- a/src/foundry/common/constants.d.mts
+++ b/src/foundry/common/constants.d.mts
@@ -287,6 +287,7 @@ export type EMBEDDED_DOCUMENT_TYPES = ValueOf<typeof EMBEDDED_DOCUMENT_TYPES>;
 /**
  * A listing of all valid Document types, both primary and embedded.
  */
+export const ALL_DOCUMENT_TYPES: ALL_DOCUMENT_TYPES[];
 export type ALL_DOCUMENT_TYPES = PRIMARY_DOCUMENT_TYPES | EMBEDDED_DOCUMENT_TYPES;
 
 /**

--- a/src/types/helperTypes.d.mts
+++ b/src/types/helperTypes.d.mts
@@ -18,32 +18,10 @@ export type PlaceableObjectConstructor = Pick<typeof PlaceableObject, keyof type
 export type ConfiguredDocumentClass<ConcreteDocument extends DocumentConstructor> =
   ConfiguredDocuments[ConcreteDocument["metadata"]["name"]];
 
-export type DocumentType =
-  | "ActiveEffect"
-  | "ActorDelta"
-  | "Actor"
-  | "Adventure"
-  | "Card"
-  | "Cards"
-  | "ChatMessage"
-  | "Combat"
-  | "Combatant"
-  | "FogExploration"
-  | "Folder"
-  | "Item"
-  | "JournalEntryPage"
-  | "JournalEntry"
-  | "Macro"
-  | "PlaylistSound"
-  | "Playlist"
-  | "RollTable"
-  | "Scene"
-  | "Setting"
-  | "TableResult"
-  | "User"
-  // All placeables also have a corresponding document class.
-  | PlaceableDocumentType;
+// TODO: Remove the Exclude after the appropriate classes are set up
+export type DocumentType = Exclude<foundry.CONST.ALL_DOCUMENT_TYPES, "Region" | "RegionBehavior">;
 
+// TODO: Add Region after the appropriate classes are set up
 export type PlaceableDocumentType =
   | "AmbientLight"
   | "AmbientSound"
@@ -54,7 +32,7 @@ export type PlaceableDocumentType =
   | "Token"
   | "Wall";
 
-// TODO: Probably a way to auto-determine this
+// TODO: Investigate if feasible to determine from the metadata (hasTypeData: true)
 type DocumentTypeWithTypeData = "Actor" | "Card" | "Cards" | "Item" | "JournalEntryPage";
 
 /**


### PR DESCRIPTION
- Adding missing array declaration in CONST
- Adjusted helperTypes to minimize how many places we declare these things now that Foundry has more comprehensive support

Closes #2632 