### PR TITLE
 Update iterable-weak-map.mjs #2606

### DIFF
--- a/src/foundry/common/utils/iterable-weak-map.d.mts
+++ b/src/foundry/common/utils/iterable-weak-map.d.mts
@@ -18,16 +18,6 @@ interface IterableWeakMapHeldValue<K extends WeakKey> {
  */
 declare class IterableWeakMap<K extends WeakKey, V> extends WeakMap<K, V> {
   /**
-   * A set of weak refs to the map's keys, allowing enumeration.
-   */
-  #refs: Set<WeakRef<K>>;
-
-  /**
-   * A FinalizationRegistry instance to clean up the ref set when objects are garbage collected.
-   */
-  #finalizer: FinalizationRegistry<IterableWeakMapHeldValue<K>>;
-
-  /**
    * @param entries - The initial entries.
    */
   constructor(entries?: Iterable<[K, V]>);
@@ -80,6 +70,11 @@ declare class IterableWeakMap<K extends WeakKey, V> extends WeakMap<K, V> {
    * Enumerate the values.
    */
   values(): Generator<V, void, never>;
+
+  /**
+   * Clear all values from the map.
+   */
+  clear(): void;
 }
 
 export default IterableWeakMap;

--- a/tests/foundry/common/utils/iterable-weak-map.test-d.ts
+++ b/tests/foundry/common/utils/iterable-weak-map.test-d.ts
@@ -9,3 +9,6 @@ expectTypeOf(m.set({ x: 1 }, { y: "2" })).toEqualTypeOf<IterableWeakMap<{ x: num
 expectTypeOf(m.entries()).toEqualTypeOf<Generator<[{ x: number }, { y: string }], void, never>>();
 expectTypeOf(m.keys()).toEqualTypeOf<Generator<{ x: number }, void, never>>();
 expectTypeOf(m.values()).toEqualTypeOf<Generator<{ y: string }, void, never>>();
+
+// Make sure void method exists by checking return type
+expectTypeOf(m.clear()).toEqualTypeOf<void>();


### PR DESCRIPTION
Very similar to weak-set, source have added clear() method, removed javascript `#private` props.