### PR TITLE
Audited use of .mjs vs. .mts vs. .d.mts in files

### DIFF
--- a/src/foundry/client-esm/applications/_module.d.mts
+++ b/src/foundry/client-esm/applications/_module.d.mts
@@ -1,6 +1,6 @@
 // In Foundry itself this file contains re-exports of these other modules.
 // Therefore it has a runtime effect and uses `.mjs` instead of `.d.mts`.
-// While `.mts` could work, to avoid `import/no-unresolved from erroring `.mjs` is used.
+// While `.mts` could work, to avoid `import/no-unresolved` from erroring `.mjs` is used.
 /* eslint-disable import/extensions */
 
 export * as types from "./_types.mjs";

--- a/src/foundry/client-esm/applications/api/_module.d.mts
+++ b/src/foundry/client-esm/applications/api/_module.d.mts
@@ -1,6 +1,6 @@
 // In Foundry itself this file contains re-exports of these other modules.
 // Therefore it has a runtime effect and uses `.mjs` instead of `.d.mts`.
-// While `.mts` could work, to avoid `import/no-unresolved from erroring `.mjs` is used.
+// While `.mts` could work, to avoid `import/no-unresolved` from erroring `.mjs` is used.
 /* eslint-disable import/extensions */
 
 export { default as ApplicationV2 } from "./application.mjs";

--- a/src/foundry/client-esm/applications/apps/_module.d.mts
+++ b/src/foundry/client-esm/applications/apps/_module.d.mts
@@ -1,6 +1,6 @@
 // In Foundry itself this file contains re-exports of these other modules.
 // Therefore it has a runtime effect and uses `.mjs` instead of `.d.mts`.
-// While `.mts` could work, to avoid `import/no-unresolved from erroring `.mjs` is used.
+// While `.mts` could work, to avoid `import/no-unresolved` from erroring `.mjs` is used.
 /* eslint-disable import/extensions */
 
 export { default as CompendiumArtConfig } from "./compendium-art-config.mjs";

--- a/src/foundry/client-esm/applications/apps/compendium-art-config.d.mts
+++ b/src/foundry/client-esm/applications/apps/compendium-art-config.d.mts
@@ -1,5 +1,5 @@
 import type ApplicationV2 from "../api/application.d.mts";
-import type HandlebarsApplicationMixin from "../api/handlebars-application.mjs";
+import type HandlebarsApplicationMixin from "../api/handlebars-application.d.mts";
 
 export default class CompendiumArtConfig<
   Configuration extends ApplicationV2.Configuration = ApplicationV2.Configuration,

--- a/src/foundry/client-esm/applications/apps/permission-config.d.mts
+++ b/src/foundry/client-esm/applications/apps/permission-config.d.mts
@@ -1,5 +1,5 @@
 import type ApplicationV2 from "../api/application.d.mts";
-import type HandlebarsApplicationMixin from "../api/handlebars-application.mjs";
+import type HandlebarsApplicationMixin from "../api/handlebars-application.d.mts";
 
 export default class PermissionConfig<
   Configuration extends ApplicationV2.Configuration = ApplicationV2.Configuration,

--- a/src/foundry/client-esm/applications/dice/_module.d.mts
+++ b/src/foundry/client-esm/applications/dice/_module.d.mts
@@ -1,1 +1,6 @@
-export { default as RollResolver } from "./roll-resolver.mts";
+// In Foundry itself this file contains re-exports of these other modules.
+// Therefore it has a runtime effect and uses `.mjs` instead of `.d.mts`.
+// While `.mts` could work, to avoid `import/no-unresolved` from erroring `.mjs` is used.
+/* eslint-disable import/extensions */
+
+export { default as RollResolver } from "./roll-resolver.mjs";

--- a/src/foundry/client-esm/applications/dice/roll-resolver.d.mts
+++ b/src/foundry/client-esm/applications/dice/roll-resolver.d.mts
@@ -1,5 +1,4 @@
 import type { DeepPartial, InexactPartial } from "../../../../types/utils.d.mts";
-import type { ApplicationConfiguration } from "../../../common/config.d.mts";
 import type ApplicationV2 from "../api/application.d.mts";
 import type HandlebarsApplicationMixin from "../api/handlebars-application.d.mts";
 

--- a/src/foundry/client-esm/applications/dice/roll-resolver.d.mts
+++ b/src/foundry/client-esm/applications/dice/roll-resolver.d.mts
@@ -1,7 +1,7 @@
 import type { DeepPartial, InexactPartial } from "../../../../types/utils.d.mts";
 import type { ApplicationConfiguration } from "../../../common/config.d.mts";
 import type ApplicationV2 from "../api/application.d.mts";
-import type HandlebarsApplicationMixin from "../api/handlebars-application.mjs";
+import type HandlebarsApplicationMixin from "../api/handlebars-application.d.mts";
 
 /**
  * An application responsible for handling unfulfilled dice terms in a roll.
@@ -46,15 +46,17 @@ declare class RollResolver<
    * Handle prompting for a single extra result from a term.
    * @param term                - The term.
    * @param method              - The method used to obtain the result.
-   * @param  options            - Optional configuration options
-   * @param  options.reroll     - Defaults to false
-   * @param  options.explode    - Defaults to false
    * @returns
    */
   resolveResult(
     term: DiceTerm,
     method: string,
-    options?: InexactPartial<{ reroll: boolean; explode: boolean }>,
+    options?: InexactPartial<{
+      /** @defaultValue `false` */
+      reroll: boolean;
+      /** @defaultValue `false` */
+      explode: boolean;
+    }>,
   ): Promise<number | void>;
 
   /**

--- a/src/foundry/client-esm/applications/elements/_module.d.mts
+++ b/src/foundry/client-esm/applications/elements/_module.d.mts
@@ -1,6 +1,6 @@
 // In Foundry itself this file contains re-exports of these other modules.
 // Therefore it has a runtime effect and uses `.mjs` instead of `.d.mts`.
-// While `.mts` could work, to avoid `import/no-unresolved from erroring `.mjs` is used.
+// While `.mts` could work, to avoid `import/no-unresolved` from erroring `.mjs` is used.
 /* eslint-disable import/extensions */
 
 export { default as AbstractFormInputElement } from "./form-element.mjs";

--- a/src/foundry/client-esm/applications/elements/color-picker.d.mts
+++ b/src/foundry/client-esm/applications/elements/color-picker.d.mts
@@ -1,5 +1,5 @@
 import type { FormInputConfig } from "../forms/fields.d.mts";
-import AbstractFormInputElement from "./form-element.mjs";
+import type AbstractFormInputElement from "./form-element.d.mts";
 
 /**
  * A custom HTMLElement used to select a color using a linked pair of input fields.

--- a/src/foundry/client-esm/applications/elements/document-tags.d.mts
+++ b/src/foundry/client-esm/applications/elements/document-tags.d.mts
@@ -1,5 +1,5 @@
 import type { FormInputConfig } from "../forms/fields.d.mts";
-import AbstractFormInputElement from "./form-element.mjs";
+import type AbstractFormInputElement from "./form-element.d.mts";
 
 /**
  * A custom HTMLElement used to render a set of associated Documents referenced by UUID.

--- a/src/foundry/client-esm/applications/elements/file-picker.d.mts
+++ b/src/foundry/client-esm/applications/elements/file-picker.d.mts
@@ -1,5 +1,5 @@
 import type { FormInputConfig } from "../forms/fields.d.mts";
-import AbstractFormInputElement from "./form-element.mjs";
+import type AbstractFormInputElement from "./form-element.d.mts";
 
 /**
  * A custom HTML element responsible for rendering a file input field and associated FilePicker button.

--- a/src/foundry/client-esm/applications/elements/hue-slider.d.mts
+++ b/src/foundry/client-esm/applications/elements/hue-slider.d.mts
@@ -1,4 +1,4 @@
-import AbstractFormInputElement from "./form-element.mjs";
+import type AbstractFormInputElement from "./form-element.d.mts";
 
 /**
  * A class designed to standardize the behavior for a hue selector UI component.

--- a/src/foundry/client-esm/applications/elements/multi-select.d.mts
+++ b/src/foundry/client-esm/applications/elements/multi-select.d.mts
@@ -1,5 +1,5 @@
 import type { FormInputConfig, SelectInputConfig } from "../forms/fields.d.mts";
-import AbstractFormInputElement from "./form-element.mjs";
+import type AbstractFormInputElement from "./form-element.d.mts";
 
 /**
  * An abstract base class designed to standardize the behavior for a multi-select UI component.

--- a/src/foundry/client-esm/applications/elements/prosemirror-editor.d.mts
+++ b/src/foundry/client-esm/applications/elements/prosemirror-editor.d.mts
@@ -1,6 +1,6 @@
 import type ProseMirrorPlugin from "../../../prosemirror/plugin.d.mts";
 import type { FormInputConfig } from "../forms/fields.d.mts";
-import AbstractFormInputElement from "./form-element.mjs";
+import type AbstractFormInputElement from "./form-element.d.mts";
 
 /**
  * A custom HTML element responsible displaying a ProseMirror rich text editor.

--- a/src/foundry/client-esm/applications/elements/range-picker.d.mts
+++ b/src/foundry/client-esm/applications/elements/range-picker.d.mts
@@ -1,5 +1,5 @@
 import type { FormInputConfig } from "../forms/fields.d.mts";
-import AbstractFormInputElement from "./form-element.mjs";
+import type AbstractFormInputElement from "./form-element.d.mts";
 
 /**
  * A custom HTML element responsible selecting a value on a range slider with a linked number input field.

--- a/src/foundry/client-esm/applications/elements/string-tags.d.mts
+++ b/src/foundry/client-esm/applications/elements/string-tags.d.mts
@@ -1,5 +1,5 @@
 import type { FormInputConfig } from "../forms/fields.d.mts";
-import AbstractFormInputElement from "./form-element.mjs";
+import type AbstractFormInputElement from "./form-element.d.mts";
 
 /**
  * A custom HTML element which allows for arbitrary assignment of a set of string tags.

--- a/src/foundry/client-esm/applications/sheets/_module.d.mts
+++ b/src/foundry/client-esm/applications/sheets/_module.d.mts
@@ -1,6 +1,6 @@
 // In Foundry itself this file contains re-exports of these other modules.
 // Therefore it has a runtime effect and uses `.mjs` instead of `.d.mts`.
-// While `.mts` could work, to avoid `import/no-unresolved from erroring `.mjs` is used.
+// While `.mts` could work, to avoid `import/no-unresolved` from erroring `.mjs` is used.
 /* eslint-disable import/extensions */
 
 export { default as ActorSheetV2 } from "./actor-sheet.mjs";

--- a/src/foundry/client-esm/applications/sheets/actor-sheet.d.mts
+++ b/src/foundry/client-esm/applications/sheets/actor-sheet.d.mts
@@ -1,4 +1,4 @@
-import type DocumentSheetV2 from "../api/document-sheet.mts";
+import type DocumentSheetV2 from "../api/document-sheet.d.mts";
 
 /**
  * A base class for providing Actor Sheet behavior using ApplicationV2.

--- a/src/foundry/client-esm/applications/sheets/ambient-light-config.d.mts
+++ b/src/foundry/client-esm/applications/sheets/ambient-light-config.d.mts
@@ -1,5 +1,5 @@
-import type DocumentSheetV2 from "../api/document-sheet.mts";
-import type HandlebarsApplicationMixin from "../api/handlebars-application.mts";
+import type DocumentSheetV2 from "../api/document-sheet.d.mts";
+import type HandlebarsApplicationMixin from "../api/handlebars-application.d.mts";
 
 /**
  * The AmbientLight configuration application.

--- a/src/foundry/client-esm/applications/sheets/ambient-sound-config.d.mts
+++ b/src/foundry/client-esm/applications/sheets/ambient-sound-config.d.mts
@@ -1,5 +1,5 @@
-import type DocumentSheetV2 from "../api/document-sheet.mts";
-import type HandlebarsApplicationMixin from "../api/handlebars-application.mts";
+import type DocumentSheetV2 from "../api/document-sheet.d.mts";
+import type HandlebarsApplicationMixin from "../api/handlebars-application.d.mts";
 
 /**
  * The AmbientSound configuration application.

--- a/src/foundry/client-esm/applications/sheets/item-sheet.d.mts
+++ b/src/foundry/client-esm/applications/sheets/item-sheet.d.mts
@@ -1,4 +1,4 @@
-import type DocumentSheetV2 from "../api/document-sheet.mts";
+import type DocumentSheetV2 from "../api/document-sheet.d.mts";
 
 /**
  * A base class for providing Item Sheet behavior using ApplicationV2.

--- a/src/foundry/client-esm/applications/sheets/region-behavior-config.d.mts
+++ b/src/foundry/client-esm/applications/sheets/region-behavior-config.d.mts
@@ -1,5 +1,5 @@
-import type DocumentSheetV2 from "../api/document-sheet.mts";
-import type HandlebarsApplicationMixin from "../api/handlebars-application.mts";
+import type DocumentSheetV2 from "../api/document-sheet.d.mts";
+import type HandlebarsApplicationMixin from "../api/handlebars-application.d.mts";
 
 /**
  * The Scene Region configuration application.

--- a/src/foundry/client-esm/applications/sheets/region-config.d.mts
+++ b/src/foundry/client-esm/applications/sheets/region-config.d.mts
@@ -1,5 +1,5 @@
-import type DocumentSheetV2 from "../api/document-sheet.mts";
-import type HandlebarsApplicationMixin from "../api/handlebars-application.mts";
+import type DocumentSheetV2 from "../api/document-sheet.d.mts";
+import type HandlebarsApplicationMixin from "../api/handlebars-application.d.mts";
 
 /**
  * The Scene Region configuration application.

--- a/src/foundry/client-esm/applications/sheets/user-config.d.mts
+++ b/src/foundry/client-esm/applications/sheets/user-config.d.mts
@@ -1,5 +1,5 @@
-import type DocumentSheetV2 from "../api/document-sheet.mts";
-import type HandlebarsApplicationMixin from "../api/handlebars-application.mts";
+import type DocumentSheetV2 from "../api/document-sheet.d.mts";
+import type HandlebarsApplicationMixin from "../api/handlebars-application.d.mts";
 
 /**
  * The User configuration application.

--- a/src/foundry/client-esm/applications/ui/_module.d.mts
+++ b/src/foundry/client-esm/applications/ui/_module.d.mts
@@ -1,6 +1,6 @@
 // In Foundry itself this file contains re-exports of these other modules.
 // Therefore it has a runtime effect and uses `.mjs` instead of `.d.mts`.
-// While `.mts` could work, to avoid `import/no-unresolved from erroring `.mjs` is used.
+// While `.mts` could work, to avoid `import/no-unresolved` from erroring `.mjs` is used.
 /* eslint-disable import/extensions */
 
 export { default as RegionLegend } from "./region-legend.mjs";

--- a/src/foundry/client-esm/applications/ui/region-legend.d.mts
+++ b/src/foundry/client-esm/applications/ui/region-legend.d.mts
@@ -1,5 +1,5 @@
-import type ApplicationV2 from "../api/application.mts";
-import type HandlebarsApplicationMixin from "../api/handlebars-application.mts";
+import type ApplicationV2 from "../api/application.d.mts";
+import type HandlebarsApplicationMixin from "../api/handlebars-application.d.mts";
 
 /**
  * Scene Region Legend.

--- a/src/foundry/client-esm/audio/_module.d.mts
+++ b/src/foundry/client-esm/audio/_module.d.mts
@@ -1,7 +1,8 @@
 // In Foundry itself this file contains re-exports of these other modules.
 // Therefore it has a runtime effect and uses `.mjs` instead of `.d.mts`.
-// While `.mts` could work, to avoid `import/no-unresolved from erroring `.mjs` is used.
+// While `.mts` could work, to avoid `import/no-unresolved` from erroring `.mjs` is used.
 /* eslint-disable import/extensions */
+/* eslint-disable import/no-unresolved */ // TODO: Remove when the files are instantiated
 
 export * as types from "./_types.mjs";
 export { default as AudioBufferCache } from "./cache.mjs";

--- a/src/foundry/client-esm/canvas/_module.d.mts
+++ b/src/foundry/client-esm/canvas/_module.d.mts
@@ -1,6 +1,6 @@
 // In Foundry itself this file contains re-exports of these other modules.
 // Therefore it has a runtime effect and uses `.mjs` instead of `.d.mts`.
-// While `.mts` could work, to avoid `import/no-unresolved from erroring `.mjs` is used.
+// While `.mts` could work, to avoid `import/no-unresolved` from erroring `.mjs` is used.
 /* eslint-disable import/extensions */
 
 export { default as SceneManager } from "./scene-manager.mjs";

--- a/src/foundry/client-esm/canvas/edges/_module.d.mts
+++ b/src/foundry/client-esm/canvas/edges/_module.d.mts
@@ -1,6 +1,6 @@
 // In Foundry itself this file contains re-exports of these other modules.
 // Therefore it has a runtime effect and uses `.mjs` instead of `.d.mts`.
-// While `.mts` could work, to avoid `import/no-unresolved from erroring `.mjs` is used.
+// While `.mts` could work, to avoid `import/no-unresolved` from erroring `.mjs` is used.
 /* eslint-disable import/extensions */
 
 export { default as CanvasEdges } from "./edges.mjs";

--- a/src/foundry/client-esm/canvas/regions/_module.d.mts
+++ b/src/foundry/client-esm/canvas/regions/_module.d.mts
@@ -1,7 +1,8 @@
 // In Foundry itself this file contains re-exports of these other modules.
 // Therefore it has a runtime effect and uses `.mjs` instead of `.d.mts`.
-// While `.mts` could work, to avoid `import/no-unresolved from erroring `.mjs` is used.
+// While `.mts` could work, to avoid `import/no-unresolved` from erroring `.mjs` is used.
 /* eslint-disable import/extensions */
+/* eslint-disable import/no-unresolved */ // TODO: Remove when the files are instantiated
 
 export { default as RegionGeometry } from "./geometry.mjs";
 export { default as RegionMesh } from "./mesh.mjs";

--- a/src/foundry/client-esm/canvas/sources/_module.d.mts
+++ b/src/foundry/client-esm/canvas/sources/_module.d.mts
@@ -1,6 +1,6 @@
 // In Foundry itself this file contains re-exports of these other modules.
 // Therefore it has a runtime effect and uses `.mjs` instead of `.d.mts`.
-// While `.mts` could work, to avoid `import/no-unresolved from erroring `.mjs` is used.
+// While `.mts` could work, to avoid `import/no-unresolved` from erroring `.mjs` is used.
 /* eslint-disable import/extensions */
 
 export { default as BaseEffectSource } from "./base-effect-source.mjs";

--- a/src/foundry/client-esm/canvas/sources/base-light-source.d.mts
+++ b/src/foundry/client-esm/canvas/sources/base-light-source.d.mts
@@ -1,5 +1,5 @@
 import type { InexactPartial } from "../../../../types/utils.d.mts";
-import RenderedEffectSource from "./rendered-effect-source.mts";
+import type RenderedEffectSource from "./rendered-effect-source.d.mts";
 
 // TODO: Adjust after client/config.js is updated
 type LightSourceAnimationConfig = unknown;

--- a/src/foundry/client-esm/canvas/sources/global-light-source.d.mts
+++ b/src/foundry/client-esm/canvas/sources/global-light-source.d.mts
@@ -1,4 +1,4 @@
-import BaseLightSource from "./base-light-source.mjs";
+import type BaseLightSource from "./base-light-source.d.mts";
 
 /**
  * A specialized subclass of the BaseLightSource which is used to render global light source linked to the scene.

--- a/src/foundry/client-esm/canvas/sources/point-darkness-source.d.mts
+++ b/src/foundry/client-esm/canvas/sources/point-darkness-source.d.mts
@@ -1,6 +1,6 @@
 import type BaseLightSource from "./base-light-source.d.mts";
 import type PointEffectSourceMixin from "./point-effect-source.d.mts";
-import type { PointEffectSourceMixin_BaseLightSource_Interface } from "./point-effect-source.mts";
+import type { PointEffectSourceMixin_BaseLightSource_Interface } from "./point-effect-source.d.mts";
 import type RenderedEffectSource from "./rendered-effect-source.d.mts";
 
 // TODO: Adjust after client/config.js is updated

--- a/src/foundry/client-esm/canvas/sources/point-darkness-source.d.mts
+++ b/src/foundry/client-esm/canvas/sources/point-darkness-source.d.mts
@@ -1,7 +1,6 @@
-import BaseLightSource from "./base-light-source.mts";
-import PointEffectSourceMixin, {
-  type PointEffectSourceMixin_BaseLightSource_Interface,
-} from "./point-effect-source.mts";
+import type BaseLightSource from "./base-light-source.d.mts";
+import type PointEffectSourceMixin from "./point-effect-source.d.mts";
+import type { PointEffectSourceMixin_BaseLightSource_Interface } from "./point-effect-source.mts";
 import type RenderedEffectSource from "./rendered-effect-source.d.mts";
 
 // TODO: Adjust after client/config.js is updated

--- a/src/foundry/client-esm/canvas/sources/point-light-source.d.mts
+++ b/src/foundry/client-esm/canvas/sources/point-light-source.d.mts
@@ -1,4 +1,4 @@
-import BaseLightSource from "./base-light-source.mts";
+import type BaseLightSource from "./base-light-source.d.mts";
 import type { PointEffectSourceMixin_BaseLightSource_Interface } from "./point-effect-source.d.mts";
 import type PointEffectSourceMixin from "./point-effect-source.d.mts";
 

--- a/src/foundry/client-esm/canvas/sources/point-movement-source.d.mts
+++ b/src/foundry/client-esm/canvas/sources/point-movement-source.d.mts
@@ -1,6 +1,6 @@
 import type BaseEffectSource from "./base-effect-source.d.mts";
 import type PointEffectSourceMixin from "./point-effect-source.d.mts";
-import type { PointEffectSourceMixin_BaseEffectSource_Interface } from "./point-effect-source.mts";
+import type { PointEffectSourceMixin_BaseEffectSource_Interface } from "./point-effect-source.d.mts";
 
 declare const PointEffectSourceMixin_BaseEffectSource: PointEffectSourceMixin_BaseEffectSource_Interface;
 

--- a/src/foundry/client-esm/canvas/sources/point-movement-source.d.mts
+++ b/src/foundry/client-esm/canvas/sources/point-movement-source.d.mts
@@ -1,7 +1,6 @@
 import type BaseEffectSource from "./base-effect-source.d.mts";
-import PointEffectSourceMixin, {
-  type PointEffectSourceMixin_BaseEffectSource_Interface,
-} from "./point-effect-source.mts";
+import type PointEffectSourceMixin from "./point-effect-source.d.mts";
+import type { PointEffectSourceMixin_BaseEffectSource_Interface } from "./point-effect-source.mts";
 
 declare const PointEffectSourceMixin_BaseEffectSource: PointEffectSourceMixin_BaseEffectSource_Interface;
 

--- a/src/foundry/client-esm/canvas/sources/point-sound-source.d.mts
+++ b/src/foundry/client-esm/canvas/sources/point-sound-source.d.mts
@@ -1,6 +1,6 @@
 import type BaseEffectSource from "./base-effect-source.d.mts";
 import type PointEffectSourceMixin from "./point-effect-source.d.mts";
-import type { PointEffectSourceMixin_BaseEffectSource_Interface } from "./point-effect-source.mts";
+import type { PointEffectSourceMixin_BaseEffectSource_Interface } from "./point-effect-source.d.mts";
 
 declare const PointEffectSourceMixin_BaseEffectSource: PointEffectSourceMixin_BaseEffectSource_Interface;
 

--- a/src/foundry/client-esm/canvas/sources/point-sound-source.d.mts
+++ b/src/foundry/client-esm/canvas/sources/point-sound-source.d.mts
@@ -1,7 +1,6 @@
 import type BaseEffectSource from "./base-effect-source.d.mts";
-import PointEffectSourceMixin, {
-  type PointEffectSourceMixin_BaseEffectSource_Interface,
-} from "./point-effect-source.mts";
+import type PointEffectSourceMixin from "./point-effect-source.d.mts";
+import type { PointEffectSourceMixin_BaseEffectSource_Interface } from "./point-effect-source.mts";
 
 declare const PointEffectSourceMixin_BaseEffectSource: PointEffectSourceMixin_BaseEffectSource_Interface;
 

--- a/src/foundry/client-esm/canvas/sources/point-vision-source.d.mts
+++ b/src/foundry/client-esm/canvas/sources/point-vision-source.d.mts
@@ -1,7 +1,6 @@
-import RenderedEffectSource from "./rendered-effect-source.mts";
-import PointEffectSourceMixin, {
-  type PointEffectSourceMixin_RenderedEffectSource_Interface,
-} from "./point-effect-source.mts";
+import type RenderedEffectSource from "./rendered-effect-source.d.mts";
+import type PointEffectSourceMixin from "./point-effect-source.d.mts";
+import type { PointEffectSourceMixin_RenderedEffectSource_Interface } from "./point-effect-source.mts";
 
 declare const PointEffectSourceMixin_RenderedEffectSource: PointEffectSourceMixin_RenderedEffectSource_Interface;
 

--- a/src/foundry/client-esm/canvas/sources/point-vision-source.d.mts
+++ b/src/foundry/client-esm/canvas/sources/point-vision-source.d.mts
@@ -1,6 +1,6 @@
 import type RenderedEffectSource from "./rendered-effect-source.d.mts";
 import type PointEffectSourceMixin from "./point-effect-source.d.mts";
-import type { PointEffectSourceMixin_RenderedEffectSource_Interface } from "./point-effect-source.mts";
+import type { PointEffectSourceMixin_RenderedEffectSource_Interface } from "./point-effect-source.d.mts";
 
 declare const PointEffectSourceMixin_RenderedEffectSource: PointEffectSourceMixin_RenderedEffectSource_Interface;
 

--- a/src/foundry/client-esm/canvas/sources/rendered-effect-source.d.mts
+++ b/src/foundry/client-esm/canvas/sources/rendered-effect-source.d.mts
@@ -1,5 +1,5 @@
 import type { InexactPartial } from "../../../../types/utils.d.mts";
-import BaseEffectSource from "./base-effect-source.mjs";
+import type BaseEffectSource from "./base-effect-source.d.mts";
 
 // TODO: Remove after shaders are done
 type AdaptiveDarknessShader = unknown;

--- a/src/foundry/client-esm/canvas/tokens/_module.d.mts
+++ b/src/foundry/client-esm/canvas/tokens/_module.d.mts
@@ -1,6 +1,7 @@
 // In Foundry itself this file contains re-exports of these other modules.
 // Therefore it has a runtime effect and uses `.mjs` instead of `.d.mts`.
-// While `.mts` could work, to avoid `import/no-unresolved from erroring `.mjs` is used.
+// While `.mts` could work, to avoid `import/no-unresolved` from erroring `.mjs` is used.
 /* eslint-disable import/extensions */
+/* eslint-disable import/no-unresolved */ // TODO: Remove when the files are instantiated
 
 export { default as TokenRing } from "./ring.mjs";

--- a/src/foundry/client-esm/client.d.mts
+++ b/src/foundry/client-esm/client.d.mts
@@ -1,6 +1,6 @@
 // In Foundry itself this file contains re-exports of these other modules.
 // Therefore it has a runtime effect and uses `.mjs` instead of `.d.mts`.
-// While `.mts` could work, to avoid `import/no-unresolved from erroring `.mjs` is used.
+// While `.mts` could work, to avoid `import/no-unresolved` from erroring `.mjs` is used.
 /* eslint-disable import/extensions */
 
 import "../common/primitives/module.mjs";
@@ -12,7 +12,7 @@ import * as _utils from "../common/utils/module.mjs";
 import * as _config from "../common/config.mjs";
 // import * as _prosemirror from "../common/prosemirror/_module.mjs";
 // import * as _grid from "../common/grid/_module.mjs";
-import * as _types from "../common/types.mjs";
+// import * as _types from "../common/types.mjs";
 
 // client
 import * as _applications from "./applications/_module.mjs";
@@ -172,7 +172,7 @@ declare global {
     /**
      * Shared importable types.
      */
-    export import types = _types;
+    // export import types = _types;
   }
   /**
    * Constant definitions used throughout the Foundry Virtual Tabletop framework.
@@ -184,65 +184,104 @@ declare global {
   type Collection<T> = _utils.Collection<T>;
   var Collection: typeof _utils.Collection; // eslint-disable-line no-var
 
-  // Sorta deprecated global namespace dump; done programatically by fvtt
-  // will begin proper deprecation process in v12
+  // Deprecated global namespace dump; done programmatically by fvtt
   type Semaphore = _utils.Semaphore;
+  /** @deprecated since v12 will be removed in v14 */
   var Semaphore: typeof _utils.Semaphore; // eslint-disable-line no-var
 
   type IterableWeakMap<K extends WeakKey, V> = _utils.IterableWeakMap<K, V>;
+  /** @deprecated since v12 will be removed in v14 */
   var IterableWeakMap: typeof _utils.IterableWeakMap; // eslint-disable-line no-var
 
   type IterableWeakSet<T extends WeakKey> = _utils.IterableWeakSet<T>;
+  /** @deprecated since v12 will be removed in v14 */
   var IterableWeakSet: typeof _utils.IterableWeakSet; // eslint-disable-line no-var
 
   /* eslint-disable no-var */
   /* --- geometry --- */
+  /** @deprecated since v12 will be removed in v14 */
   var orient2dFast: typeof _utils.orient2dFast;
+  /** @deprecated since v12 will be removed in v14 */
   var lineSegmentIntersects: typeof _utils.lineSegmentIntersects;
+  /** @deprecated since v12 will be removed in v14 */
   var lineLineIntersection: typeof _utils.lineLineIntersection;
+  /** @deprecated since v12 will be removed in v14 */
   var lineSegmentIntersection: typeof _utils.lineSegmentIntersection;
+  /** @deprecated since v12 will be removed in v14 */
   var lineCircleIntersection: typeof _utils.lineCircleIntersection;
+  /** @deprecated since v12 will be removed in v14 */
   var closestPointToSegment: typeof _utils.closestPointToSegment;
+  /** @deprecated since v12 will be removed in v14 */
   var quadraticIntersection: typeof _utils.quadraticIntersection;
 
   /* --- helpers --- */
+  /** @deprecated since v12 will be removed in v14 */
   var benchmark: typeof _utils.benchmark;
+  /** @deprecated since v12 will be removed in v14 */
   var threadLock: typeof _utils.threadLock;
+  /** @deprecated since v12 will be removed in v14 */
   var debounce: typeof _utils.debounce;
+  /** @deprecated since v12 will be removed in v14 */
   var debouncedReload: typeof _utils.debouncedReload;
+  /** @deprecated since v12 will be removed in v14 */
   var deepClone: typeof _utils.deepClone;
+  /** @deprecated since v12 will be removed in v14 */
   var diffObject: typeof _utils.diffObject;
+  /** @deprecated since v12 will be removed in v14 */
   var objectsEqual: typeof _utils.objectsEqual;
+  /** @deprecated since v12 will be removed in v14 */
   var duplicate: typeof _utils.duplicate;
+  /** @deprecated since v12 will be removed in v14 */
   var isSubclass: typeof _utils.isSubclass;
+  /** @deprecated since v12 will be removed in v14 */
   var getDefiningClass: typeof _utils.getDefiningClass;
+  /** @deprecated since v12 will be removed in v14 */
   var encodeURL: typeof _utils.encodeURL;
+  /** @deprecated since v12 will be removed in v14 */
   var expandObject: typeof _utils.expandObject;
+  /** @deprecated since v12 will be removed in v14 */
   var filterObject: typeof _utils.filterObject;
+  /** @deprecated since v12 will be removed in v14 */
   var flattenObject: typeof _utils.flattenObject;
+  /** @deprecated since v12 will be removed in v14 */
   var getParentClasses: typeof _utils.getParentClasses;
+  /** @deprecated since v12 will be removed in v14 */
   var getRoute: typeof _utils.getRoute;
+  /** @deprecated since v12 will be removed in v14 */
   var getType: typeof _utils.getType;
+  /** @deprecated since v12 will be removed in v14 */
   var hasProperty: typeof _utils.hasProperty;
+  /** @deprecated since v12 will be removed in v14 */
   var getProperty: typeof _utils.getProperty;
+  /** @deprecated since v12 will be removed in v14 */
   var setProperty: typeof _utils.setProperty;
+  /** @deprecated since v12 will be removed in v14 */
   var invertObject: typeof _utils.invertObject;
-  var isObjectEmpty: typeof _utils.isObjectEmpty;
+  /** @deprecated since v12 will be removed in v14 */
   var isEmpty: typeof _utils.isEmpty;
+  /** @deprecated since v12 will be removed in v14 */
   var mergeObject: typeof _utils.mergeObject;
+  /** @deprecated since v12 will be removed in v14 */
   var parseS3URL: typeof _utils.parseS3URL;
+  /** @deprecated since v12 will be removed in v14 */
   var randomID: typeof _utils.randomID;
+  /** @deprecated since v12 will be removed in v14 */
   var timeSince: typeof _utils.timeSince;
+  /** @deprecated since v12 will be removed in v14 */
   var formatFileSize: typeof _utils.formatFileSize;
+  /** @deprecated since v12 will be removed in v14 */
   var parseUuid: typeof _utils.parseUuid;
 
   /* --- http --- */
 
+  /** @deprecated since v12 will be removed in v14 */
   var fetchWithTimeout: typeof _utils.fetchWithTimeout;
+  /** @deprecated since v12 will be removed in v14 */
   var fetchJsonWithTimeout: typeof _utils.fetchJsonWithTimeout;
 
   /* --- logging --- */
 
+  /** @deprecated since v12 will be removed in v14 */
   var logCompatibilityWarning: typeof _utils.logCompatibilityWarning;
   /* eslint-enable no-var */
 }

--- a/src/foundry/client-esm/data/_module.d.mts
+++ b/src/foundry/client-esm/data/_module.d.mts
@@ -1,6 +1,6 @@
 // In Foundry itself this file contains re-exports of these other modules.
 // Therefore it has a runtime effect and uses `.mjs` instead of `.d.mts`.
-// While `.mts` could work, to avoid `import/no-unresolved from erroring `.mjs` is used.
+// While `.mts` could work, to avoid `import/no-unresolved` from erroring `.mjs` is used.
 /* eslint-disable import/extensions */
 
 export * from "../../common/data/module.mjs";

--- a/src/foundry/client-esm/data/client-backend.d.mts
+++ b/src/foundry/client-esm/data/client-backend.d.mts
@@ -5,7 +5,7 @@ import type {
   DatabaseCreateOperation,
   DatabaseUpdateOperation,
   DatabaseDeleteOperation,
-} from "../../common/abstract/_types.mjs";
+} from "../../common/abstract/_types.d.mts";
 import type { LoggingLevels } from "../../../types/helperTypes.d.mts";
 
 /**

--- a/src/foundry/client-esm/data/region-behaviors/_module.d.mts
+++ b/src/foundry/client-esm/data/region-behaviors/_module.d.mts
@@ -1,7 +1,8 @@
 // In Foundry itself this file contains re-exports of these other modules.
 // Therefore it has a runtime effect and uses `.mjs` instead of `.d.mts`.
-// While `.mts` could work, to avoid `import/no-unresolved from erroring `.mjs` is used.
+// While `.mts` could work, to avoid `import/no-unresolved` from erroring `.mjs` is used.
 /* eslint-disable import/extensions */
+/* eslint-disable import/no-unresolved */ // TODO: Remove when the files are instantiated
 
 export { default as RegionBehaviorType } from "./base.mjs";
 export { default as AdjustDarknessLevelRegionBehaviorType } from "./adjust-darkness-level.mjs";

--- a/src/foundry/client-esm/dice/_module.d.mts
+++ b/src/foundry/client-esm/dice/_module.d.mts
@@ -1,7 +1,8 @@
 // In Foundry itself this file contains re-exports of these other modules.
 // Therefore it has a runtime effect and uses `.mjs` instead of `.d.mts`.
-// While `.mts` could work, to avoid `import/no-unresolved from erroring `.mjs` is used.
+// While `.mts` could work, to avoid `import/no-unresolved` from erroring `.mjs` is used.
 /* eslint-disable import/extensions */
+/* eslint-disable import/no-unresolved */ // TODO: Remove when the files are instantiated
 
 export * as types from "./_types.mjs";
 export * as terms from "./terms/_module.mjs";

--- a/src/foundry/client-esm/dice/terms/_module.d.mts
+++ b/src/foundry/client-esm/dice/terms/_module.d.mts
@@ -1,7 +1,8 @@
 // In Foundry itself this file contains re-exports of these other modules.
 // Therefore it has a runtime effect and uses `.mjs` instead of `.d.mts`.
-// While `.mts` could work, to avoid `import/no-unresolved from erroring `.mjs` is used.
+// While `.mts` could work, to avoid `import/no-unresolved` from erroring `.mjs` is used.
 /* eslint-disable import/extensions */
+/* eslint-disable import/no-unresolved */ // TODO: Remove when the files are instantiated
 
 export { default as Coin } from "./coin.mjs";
 export { default as DiceTerm } from "./dice.mjs";

--- a/src/foundry/client-esm/helpers/_module.d.mts
+++ b/src/foundry/client-esm/helpers/_module.d.mts
@@ -1,6 +1,6 @@
 // In Foundry itself this file contains re-exports of these other modules.
 // Therefore it has a runtime effect and uses `.mjs` instead of `.d.mts`.
-// While `.mts` could work, to avoid `import/no-unresolved from erroring `.mjs` is used.
+// While `.mts` could work, to avoid `import/no-unresolved` from erroring `.mjs` is used.
 /* eslint-disable import/extensions */
 
 export * as types from "./_types.mjs";

--- a/src/foundry/client/core/packages.d.mts
+++ b/src/foundry/client/core/packages.d.mts
@@ -1,5 +1,5 @@
 import type { AnyConstructorFor, InexactPartial, Mixin } from "../../../types/utils.d.mts";
-import type { CONST } from "../../client-esm/client.mts";
+import type { CONST } from "../../client-esm/client.d.mts";
 
 declare class ClientPackage {
   /** @privateRemarks All mixin classses should accept anything for its constructor. */

--- a/src/foundry/client/data/abstract/index.d.mts
+++ b/src/foundry/client/data/abstract/index.d.mts
@@ -1,5 +1,4 @@
 import "./canvas-document.d.mts";
-import "./client-backend.d.mts";
 import "./client-document.d.mts";
 import "./directory-collection-mixin.d.mts";
 import "./document-collection.d.mts";

--- a/src/foundry/client/pixi/core/shapes/polygon-mesher.d.mts
+++ b/src/foundry/client/pixi/core/shapes/polygon-mesher.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial } from "../../../../../types/utils.mts";
+import type { InexactPartial } from "../../../../../types/utils.d.mts";
 
 declare global {
   /**

--- a/src/foundry/common/abstract/backend.d.mts
+++ b/src/foundry/common/abstract/backend.d.mts
@@ -7,7 +7,7 @@ import type {
   DatabaseGetOperation,
   DatabaseOperation,
   DatabaseUpdateOperation,
-} from "./_types.mjs";
+} from "./_types.d.mts";
 import type { LoggingLevels } from "../../../types/helperTypes.d.mts";
 
 /**

--- a/src/foundry/common/abstract/module.d.mts
+++ b/src/foundry/common/abstract/module.d.mts
@@ -1,6 +1,6 @@
 // In Foundry itself this file contains re-exports of these other modules.
 // Therefore it has a runtime effect and uses `.mjs` instead of `.d.mts`.
-// While `.mts` could work, to avoid `import/no-unresolved from erroring `.mjs` is used.
+// While `.mts` could work, to avoid `import/no-unresolved` from erroring `.mjs` is used.
 /* eslint-disable import/extensions */
 
 export { default as DataModel } from "./data.mjs";

--- a/src/foundry/common/data/data.d.mts
+++ b/src/foundry/common/data/data.d.mts
@@ -1,7 +1,7 @@
 import type { DatabaseBackend } from "../abstract/module.d.mts";
 import type { DataModel } from "../abstract/data.d.mts";
 import type { fields } from "./module.d.mts";
-import type * as documents from "../documents/_module.mjs";
+import type * as documents from "../documents/_module.d.mts";
 import type { ValueOf } from "../../../types/utils.d.mts";
 
 // TODO: Implement all of the necessary options

--- a/src/foundry/common/data/fields.d.mts
+++ b/src/foundry/common/data/fields.d.mts
@@ -8,7 +8,7 @@ import type { DataModel } from "../abstract/data.mts";
 import type Document from "../abstract/document.mts";
 import type { EmbeddedCollection, EmbeddedCollectionDelta } from "../abstract/module.d.mts";
 import type { DOCUMENT_OWNERSHIP_LEVELS } from "../constants.d.mts";
-import type { CONST } from "../../client-esm/client.mjs";
+import type { CONST } from "../../client-esm/client.d.mts";
 import type { DataModelValidationFailure } from "./validation-failure.mts";
 
 declare global {

--- a/src/foundry/common/data/module.d.mts
+++ b/src/foundry/common/data/module.d.mts
@@ -1,6 +1,6 @@
 // In Foundry itself this file contains re-exports of these other modules.
 // Therefore it has a runtime effect and uses `.mjs` instead of `.d.mts`.
-// While `.mts` could work, to avoid `import/no-unresolved from erroring `.mjs` is used.
+// While `.mts` could work, to avoid `import/no-unresolved` from erroring `.mjs` is used.
 /* eslint-disable import/extensions */
 
 export * as validators from "./validators.mjs";

--- a/src/foundry/common/documents/_module.d.mts
+++ b/src/foundry/common/documents/_module.d.mts
@@ -1,6 +1,6 @@
 // In Foundry itself this file contains re-exports of these other modules.
 // Therefore it has a runtime effect and uses `.mjs` instead of `.d.mts`.
-// While `.mts` could work, to avoid `import/no-unresolved from erroring `.mjs` is used.
+// While `.mts` could work, to avoid `import/no-unresolved` from erroring `.mjs` is used.
 /* eslint-disable import/extensions */
 
 export { default as BaseActiveEffect } from "./active-effect.mjs";

--- a/src/foundry/common/documents/actor-delta.d.mts
+++ b/src/foundry/common/documents/actor-delta.d.mts
@@ -3,7 +3,7 @@ import type { InexactPartial, Merge } from "../../../types/utils.d.mts";
 import type { DocumentMetadata } from "../abstract/document.mts";
 import type Document from "../abstract/document.mts";
 import type { fields } from "../data/module.d.mts";
-import type { CONST, documents } from "../../client-esm/client.mjs";
+import type { CONST, documents } from "../../client-esm/client.d.mts";
 
 declare global {
   type ActorDeltaData = documents.BaseActorDelta.Properties;

--- a/src/foundry/common/documents/macro.d.mts
+++ b/src/foundry/common/documents/macro.d.mts
@@ -1,9 +1,9 @@
-import type { InexactPartial, Merge } from "../../../types/utils.mts";
-import type Document from "../abstract/document.mts";
-import type { DocumentMetadata, DocumentModificationOptions } from "../abstract/document.mts";
-import * as CONST from "../constants.mts";
-import * as fields from "../data/fields.mts";
-import * as documents from "./_module.mts";
+import type { InexactPartial, Merge } from "../../../types/utils.d.mts";
+import type Document from "../abstract/document.d.mts";
+import type { DocumentMetadata, DocumentModificationOptions } from "../abstract/document.d.mts";
+import type * as CONST from "../constants.d.mts";
+import type * as fields from "../data/fields.d.mts";
+import type * as documents from "./_module.d.mts";
 
 declare global {
   type MacroData = BaseMacro.Properties;

--- a/src/foundry/common/packages/module.d.mts
+++ b/src/foundry/common/packages/module.d.mts
@@ -1,6 +1,6 @@
 // In Foundry itself this file contains re-exports of these other modules.
 // Therefore it has a runtime effect and uses `.mjs` instead of `.d.mts`.
-// While `.mts` could work, to avoid `import/no-unresolved from erroring `.mjs` is used.
+// While `.mts` could work, to avoid `import/no-unresolved` from erroring `.mjs` is used.
 /* eslint-disable import/extensions */
 
 export { default as BasePackage } from "./base-package.mjs";

--- a/src/foundry/common/utils/bitmask.d.mts
+++ b/src/foundry/common/utils/bitmask.d.mts
@@ -40,14 +40,14 @@ export default class BitMask extends Number {
 
   /**
    * Toggle the state of a specific state in the bitmask.
-   * @param state The state to toggle. Throws an error if the provided state is not valid.
-   * @param enabled   - Toggle on (true) or off (false)? If undefined, the state is switched automatically.
+   * @param state   - The state to toggle. Throws an error if the provided state is not valid.
+   * @param enabled - Toggle on (true) or off (false)? If undefined, the state is switched automatically.
    */
   toggleState(state: string, enabled: boolean): void;
 
   /**
    * Toggle the state of a specific state in the bitmask.
-   * @param state The state to toggle.
+   * @param state - The state to toggle.
    * @returns  The updated bitmask. Throws an error if the provided state is not valid.
    */
   toggleState(state: string): number;
@@ -97,7 +97,7 @@ export default class BitMask extends Number {
 
   /**
    * Creates a clone of this BitMask instance.
-   * @returns {BitMask} A new BitMask instance with the same value and valid states as this instance.
+   * @returns A new BitMask instance with the same value and valid states as this instance.
    */
   clone(): BitMask;
 

--- a/src/foundry/common/utils/module.d.mts
+++ b/src/foundry/common/utils/module.d.mts
@@ -1,6 +1,6 @@
 // In Foundry itself this file contains re-exports of these other modules.
 // Therefore it has a runtime effect and uses `.mjs` instead of `.d.mts`.
-// While `.mts` could work, to avoid `import/no-unresolved from erroring `.mjs` is used.
+// While `.mts` could work, to avoid `import/no-unresolved` from erroring `.mjs` is used.
 /* eslint-disable import/extensions */
 
 export * from "./geometry.mjs";

--- a/src/foundry/common/utils/string-tree.d.mts
+++ b/src/foundry/common/utils/string-tree.d.mts
@@ -6,7 +6,6 @@ import type { InexactPartial } from "../../../types/utils.d.mts";
 declare class StringTree<EntryType> {
   /**
    * The key symbol that stores the leaves of any given node.
-   * @type {symbol}
    */
   // replaced the getter definition with a static property so that
   //    it can be referenced as part of the StringTreeNode interface
@@ -18,7 +17,7 @@ declare class StringTree<EntryType> {
   /**
    * Insert an entry into the tree.
    * @param strings  - The string parents for the entry.
-   * @param entry         - The entry to store.
+   * @param entry    - The entry to store.
    * @returns   The node the entry was added to.
    */
   addLeaf(strings: string[], entry: EntryType): StringTree.StringTreeNode;
@@ -27,21 +26,33 @@ declare class StringTree<EntryType> {
    * Traverse the tree along the given string path and return any entries reachable from the node.
    * @param strings         - The string path to the desired node.
    * @param options         - Additional options to configure behaviour.
-   * @param options.limit   - The maximum number of items to retrieve.
    * @returns    The reachable entries
    */
-  lookup(strings: string[], options?: InexactPartial<{ limit: number }>): StringTree.StringTreeNode[];
+  lookup(
+    strings: string[],
+    options?: InexactPartial<{
+      /** The maximum number of items to retrieve. */
+      limit: number;
+    }>,
+  ): StringTree.StringTreeNode[];
 
   /**
    * Returns the node at the given path through the tree.
    * @param strings                     - The string path to the desired node.
    * @param options                     - Additional options to configure behaviour.
-   * @param options.hasLeaves           - Only return the most recently visited node that has
-   *                                      leaves, otherwise return the exact node at the prefix,
-   *                                      if it exists. Defaults to false.
    * @returns The node at the path, if found
    */
-  nodeAtPrefix(strings: string[], options?: InexactPartial<{ hasLeaves: boolean }>): StringTree.StringTreeNode | void;
+  nodeAtPrefix(
+    strings: string[],
+    options?: InexactPartial<{
+      /**
+       * Only return the most recently visited node that has
+       * leaves, otherwise return the exact node at the prefix,
+       * if it exists. Defaults to false.
+       */
+      hasLeaves: boolean;
+    }>,
+  ): StringTree.StringTreeNode | void;
 
   /**
    * Perform a breadth-first search starting from the given node and retrieving any entries reachable from that node,
@@ -50,22 +61,23 @@ declare class StringTree<EntryType> {
    * @param entries         - The accumulated entries.
    * @param queue           - The working queue of nodes to search.
    * @param options         - Additional options to configure behaviour.
-   * @param options.limit   - The maximum number of entries to retrieve before stopping.
-   * @protected
    */
-  _breadthFirstSearch(
+  protected _breadthFirstSearch(
     node: StringTree.StringTreeNode,
     entries: EntryType[],
     queue: StringTree.StringTreeNode[],
-    options?: InexactPartial<{ limit: number }>,
+    options?: InexactPartial<{
+      /** The maximum number of entries to retrieve before stopping. */
+      limit: number;
+    }>,
   ): void;
 }
 
-/**
- * A string tree node consists of zero-or-more string keys, and a leaves property that contains any objects that
- * terminate at the current node.
- */
 declare namespace StringTree {
+  /**
+   * A string tree node consists of zero-or-more string keys, and a leaves property that contains any objects that
+   * terminate at the current node.
+   */
   interface StringTreeNode {
     [StringTree.leaves]: Record<string, unknown>[];
     [key: string]: StringTreeNode;

--- a/src/foundry/common/utils/word-tree.d.mts
+++ b/src/foundry/common/utils/word-tree.d.mts
@@ -20,12 +20,19 @@ declare class WordTree extends StringTree<WordTree.WordTreeEntry> {
    * Return entries that match the given string prefix.
    * @param prefix              - The prefix.
    * @param options             - Additional options to configure behaviour.
-   * @param options.limit       - The maximum number of items to retrieve. Defaults to 10. It is important
-   *                              to set this value as very short prefixes will naturally match large numbers
-   *                              of entries.
    * @returns                   A number of entries that have the given prefix.
    */
-  lookup(prefix: string, options?: InexactPartial<{ limit: number }>): WordTree.WordTreeEntry[];
+  lookup(
+    prefix: string,
+    options?: InexactPartial<{
+      /**
+       * The maximum number of items to retrieve. Defaults to 10. It is important
+       * to set this value as very short prefixes will naturally match large numbers
+       * of entries.
+       */
+      limit: number;
+    }>,
+  ): WordTree.WordTreeEntry[];
   lookup(strings: string[], options?: InexactPartial<{ limit: number }>): StringTree.StringTreeNode[];
 
   /**
@@ -40,15 +47,15 @@ declare class WordTree extends StringTree<WordTree.WordTreeEntry> {
 declare namespace WordTree {
   /**
    * A leaf entry in the tree.
-   * @property  entry          - An object that this entry represents.
-   * @property  documentName   - The document type.
-   * @property  uuid           - The document's UUID.
-   * @property  pack           - The (optional) pack ID.
    */
   interface WordTreeEntry {
+    /** An object that this entry represents. */
     entry: Document;
+    /** The document type. */
     documentName: string;
+    /** The document's UUID. */
     uuid: string;
+    /** The (optional) pack ID. */
     pack?: string;
   }
 }

--- a/src/foundry/index.d.mts
+++ b/src/foundry/index.d.mts
@@ -1,6 +1,5 @@
 import "./client/index.d.mts";
 import "./client-esm/client.d.mts";
 import "./clipper/index.d.mts";
-import "./common/module.d.mts";
 import "./prosemirror/index.d.mts";
 import "./public/index.d.mts";

--- a/tests/foundry/client-esm/helpers/compendium-art.test-d.ts
+++ b/tests/foundry/client-esm/helpers/compendium-art.test-d.ts
@@ -1,5 +1,5 @@
 import { expectTypeOf } from "vitest";
-import { types } from "../../../../src/foundry/client-esm/helpers/_module.mjs";
+import type { types } from "../../../../src/foundry/client-esm/helpers/_module.d.mts";
 
 const caInfo = { actor: "actorId", token: { randomImg: false }, credit: "Me" };
 expectTypeOf(caInfo).toMatchTypeOf<types.CompendiumArtInfo>;

--- a/tests/foundry/common/documents/actor.test-d.ts
+++ b/tests/foundry/common/documents/actor.test-d.ts
@@ -1,7 +1,7 @@
 import { expectTypeOf } from "vitest";
 import type EmbeddedCollection from "../../../../src/foundry/common/abstract/embedded-collection.d.mts";
 import type { NumberField, SchemaField } from "../../../../src/foundry/common/data/fields.d.mts";
-import type DataModel from "../../../../src/foundry/common/abstract/data.d.mts";
+import type { DataModel } from "../../../../src/foundry/common/abstract/data.d.mts";
 import type { Merge } from "../../../../src/types/utils.d.mts";
 import type { TypeDataModel } from "../../../../src/foundry/common/abstract/type-data.d.mts";
 
@@ -49,7 +49,7 @@ type MyCharacterSchema = {
 };
 
 class MyCharacter extends foundry.abstract.TypeDataModel<MyCharacterSchema, Actor.ConfiguredInstance> {
-  static defineSchema() {
+  static override defineSchema() {
     const { SchemaField, NumberField } = foundry.data.fields;
     return {
       abilities: new SchemaField({
@@ -71,7 +71,7 @@ class MyCharacter extends foundry.abstract.TypeDataModel<MyCharacterSchema, Acto
     };
   }
 
-  prepareDerivedData(this: Merge<DataModel<MyCharacterSchema, Actor.ConfiguredInstance>, {}>): void {
+  override prepareDerivedData(this: Merge<DataModel<MyCharacterSchema, Actor.ConfiguredInstance>, {}>): void {
     this.abilities.strength.value + 2;
     for (const ability of Object.values(this.abilities)) {
       // @ts-expect-error Derived data must be declared
@@ -107,7 +107,7 @@ class BoilerplateActorBase<
   BaseData extends Record<string, unknown> = Record<string, never>,
   DerivedData extends Record<string, unknown> = Record<string, never>,
 > extends foundry.abstract.TypeDataModel<Schema, Actor.ConfiguredInstance, BaseData, DerivedData> {
-  static defineSchema(): BoilerplateActorBase.Schema {
+  static override defineSchema(): BoilerplateActorBase.Schema {
     const fields = foundry.data.fields;
     const requiredInteger = { required: true, nullable: false, integer: true };
     const schema: DataSchema = {};
@@ -183,7 +183,7 @@ class BoilerplateCharacter extends BoilerplateActorBase<
   Record<string, never>,
   BoilerplateCharacter.DerivedProps
 > {
-  static defineSchema() {
+  static override defineSchema() {
     const fields = foundry.data.fields;
     const requiredInteger = { required: true, nullable: false, integer: true };
     const schema = super.defineSchema();
@@ -207,7 +207,7 @@ class BoilerplateCharacter extends BoilerplateActorBase<
     return schema;
   }
 
-  prepareDerivedData(this: TypeDataModel.PrepareDerivedDataThis<this>) {
+  override prepareDerivedData(this: TypeDataModel.PrepareDerivedDataThis<this>) {
     // Loop through ability scores, and add their modifiers to our sheet output.
     for (const [key, abil] of Object.entries(this.abilities)) {
       // Calculate the modifier using d20 rules.


### PR DESCRIPTION
Also threw in a handful of other fixes, e.g. deprecating utils