### PR TITLE
Updated ClientDocument and TextEditor to v12

### DIFF
--- a/src/foundry/client/config.d.mts
+++ b/src/foundry/client/config.d.mts
@@ -2531,7 +2531,7 @@ declare global {
        * A collection of custom enrichers that can be applied to text content, allowing for the matching and handling of
        * custom patterns.
        */
-      enrichers: CONFIG.TextEditor.EnricherConfig[];
+      enrichers: TextEditor.EnricherConfig[];
     };
 
     /**
@@ -2794,30 +2794,6 @@ declare global {
 
       /** A sound path when the door becomes unlocked */
       unlock: string;
-    }
-
-    namespace TextEditor {
-      /**
-       * @param match   - The regular expression match result
-       * @param options - Options provided to customize text enrichment
-       * @returns An HTML element to insert in place of the matched text or null to indicate that
-       *          no replacement should be made.
-       */
-      type Enricher = (
-        match: RegExpMatchArray,
-        options?: globalThis.TextEditor.EnrichmentOptions,
-      ) => Promise<HTMLElement | null>;
-
-      interface EnricherConfig {
-        /** The string pattern to match. Must be flagged as global. */
-        pattern: RegExp;
-
-        /**
-         * The function that will be called on each match. It is expected that this returns an HTML element
-         * to be inserted into the final enriched content.
-         */
-        enricher: Enricher;
-      }
     }
     namespace Dice {
       // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/src/foundry/client/data/abstract/client-document.d.mts
+++ b/src/foundry/client/data/abstract/client-document.d.mts
@@ -24,7 +24,7 @@ declare class ClientDocument<
    * @see {@link Document#render}
    * @defaultValue `{}`
    */
-  readonly apps: Record<string, Application>;
+  readonly apps: Record<string, Application | foundry.applications.api.ApplicationV2>;
 
   /**
    * A cached reference to the FormApplication instance used to configure this Document.
@@ -52,7 +52,7 @@ declare class ClientDocument<
     : undefined;
 
   /**
-   * A boolean indicator for whether or not the current game User has ownership rights for this Document.
+   * A boolean indicator for whether the current game User has ownership rights for this Document.
    * Different Document types may have more specialized rules for what constitutes ownership.
    */
   get isOwner(): boolean;
@@ -88,11 +88,12 @@ declare class ClientDocument<
   /**
    * Lazily obtain a FormApplication instance used to configure this Document, or null if no sheet is available.
    */
-  get sheet(): FormApplication | null; // TODO: Replace mit InstanceType<ConfiguredSheetClass<T>> once the circular reference problem has been solved
+  get sheet(): FormApplication | foundry.applications.api.ApplicationV2 | null;
 
   /**
    * A Universally Unique Identifier (uuid) for this Document instance.
    */
+  // TODO: Move to `src/foundry/common/abstract/document.d.mts` when that file is updated
   get uuid(): string;
 
   /**
@@ -104,7 +105,7 @@ declare class ClientDocument<
   /**
    * Obtain the FormApplication class constructor which should be used to configure this Document.
    */
-  protected _getSheetClass(): ConstructorOf<FormApplication> | null; // TODO: Replace with ConfiguredSheetClass<T> once the circular reference problem has been solved
+  protected _getSheetClass(): ConstructorOf<FormApplication | foundry.applications.api.ApplicationV2> | null;
 
   /**
    * Safely prepare data for a Document, catching any errors.
@@ -136,14 +137,17 @@ declare class ClientDocument<
   prepareDerivedData(): void;
 
   /**
-   * Render all of the Application instances which are connected to this document by calling their respective
+   * Render all Application instances which are connected to this document by calling their respective
    * @see Application#render
    * @param force   - Force rendering
    *                  (default: `false`)
    * @param context - Optional context
    *                  (default: `{}`)
    */
-  render(force?: boolean, context?: Application.RenderOptions): void;
+  render(
+    force?: boolean,
+    context?: Application.RenderOptions | foundry.applications.api.ApplicationV2.RenderOptions,
+  ): void;
 
   /**
    * Determine the sort order for this Document by positioning it relative a target sibling.
@@ -157,7 +161,7 @@ declare class ClientDocument<
    * Construct a UUID relative to another document.
    * @param doc - The document to compare against.
    */
-  getRelativeUuid(doc: ClientDocument): string;
+  getRelativeUuid(relative: ClientDocument): string;
 
   /**
    * Createa  content link for this document
@@ -323,8 +327,20 @@ declare class ClientDocument<
 
   /**
    * Gets the default new name for a Document
+   * @param context - The context for which to create the Document name.
    */
-  static defaultName(): string;
+  static defaultName<T extends DocumentConstructor>(
+    context?: InexactPartial<{
+      this: T;
+      /** The sub-type of the document */
+      // TODO: See if the valid strings can be inferred from T
+      type: string;
+      /** A parent document within which the created Document should belong */
+      parent: foundry.abstract.Document.Any;
+      /** A compendium pack within which the Document should be created */
+      pack: string;
+    }>,
+  ): string;
 
   /**
    * Present a Dialog form to create a new Document of this type.
@@ -339,7 +355,11 @@ declare class ClientDocument<
   static createDialog<T extends DocumentConstructor>(
     this: T,
     data?: DeepPartial<ConstructorDataType<T> | (ConstructorDataType<T> & Record<string, unknown>)>,
-    context?: Pick<DocumentModificationContext, "parent" | "pack"> & Partial<DialogOptions>,
+    context?: Pick<DocumentModificationContext, "parent" | "pack"> &
+      Partial<DialogOptions> & {
+        /** A restriction the selectable sub-types of the Dialog. */
+        types?: string[] | undefined;
+      },
   ): Promise<InstanceType<ConfiguredDocumentClass<T>> | null | undefined>;
 
   /**
@@ -355,43 +375,6 @@ declare class ClientDocument<
    * @param options - Additional options passed to the {@link ClientDocument#toCompendium} method
    */
   exportToJSON(options?: InexactPartial<ClientDocument.CompendiumExportOptions>): void;
-
-  /**
-   * Create a content link for this Document.
-   * @param options - Additional options to configure how the link is constructed.
-   */
-  toAnchor(
-    options?: InexactPartial<{
-      /**
-       * Attributes to set on the link.
-       * @defaultValue `{}`
-       */
-      attrs: Record<string, string>;
-
-      /**
-       * Custom data- attributes to set on the link.
-       * @defaultValue `{}`
-       */
-      dataset: Record<string, string>;
-
-      /**
-       * Additional classes to add to the link.
-       * The `content-link` class is added by default.
-       * @defaultValue `[]`
-       */
-      classes: string[];
-
-      /**
-       * A name to use for the Document, if different from the Document's name.
-       */
-      name: string;
-
-      /**
-       * A font-awesome icon class to use as the icon, if different to the Document's configured sidebarIcon.
-       */
-      icon: string;
-    }>,
-  ): HTMLAnchorElement;
 
   /**
    * Serialize salient information about this Document when dragging it.
@@ -415,6 +398,28 @@ declare class ClientDocument<
     options?: FromDropDataOptions,
   ): Promise<InstanceType<ConfiguredDocumentClass<T>> | undefined>;
 
+  /**
+   * Create the Document from the given source with migration applied to it.
+   * Only primary Documents may be imported.
+   *
+   * This function must be used to create a document from data that predates the current core version.
+   * It must be given nonpartial data matching the schema it had in the core version it is coming from.
+   * It applies legacy migrations to the source data before calling {@link Document.fromSource}.
+   * If this function is not used to import old data, necessary migrations may not applied to the data
+   * resulting in an incorrectly imported document.
+   *
+   * The core version is recorded in the `_stats` field, which all primary documents have. If the given source data
+   * doesn't contain a `_stats` field, the data is assumed to be pre-V10, when the `_stats` field didn't exist yet.
+   * The `_stats` field must not be stripped from the data before it is exported!
+   * @param source - The document data that is imported.
+   * @param context - The model construction context passed to {@link Document.fromSource}.
+   *                  (default: `context.strict=true`) Strict validation is enabled by default.
+   */
+  static fromImport<T extends DocumentConstructor>(
+    this: T,
+    source: Record<string, unknown>,
+    context?: DocumentConstructionContext & DataValidationOptions,
+  ): Promise<InstanceType<T>>;
   /**
    * Update this Document using a provided JSON string.
    * @param json - JSON data string
@@ -457,6 +462,58 @@ declare class ClientDocument<
     | ClientDocument.OmitProperty<OwnershipOpt, "ownership">
     | ClientDocument.OmitProperty<StateOpt, "active" | "fogReset" | "playing"> // helping out Playlist, Scene
   >;
+
+  /**
+   * Create a content link for this Document.
+   * @param options - Additional options to configure how the link is constructed.
+   */
+  toAnchor(options?: TextEditor.EnrichmentAnchorOptions): HTMLAnchorElement;
+
+  /**
+   * Convert a Document to some HTML display for embedding purposes.
+   * @param config  - Configuration for embedding behavior.
+   * @param options - The original enrichment options for cases where the Document embed content also contains text that must be enriched.
+   * @returns A representation of the Document as HTML content, or null if such a representation could not be generated.
+   */
+  toEmbed(
+    config: TextEditor.DocumentHTMLEmbedConfig,
+    options?: TextEditor.EnrichmentOptions,
+  ): Promise<HTMLElement | null>;
+
+  /**
+   * A method that can be overridden by subclasses to customize embedded HTML generation.
+   * @param config  - Configuration for embedding behavior.
+   * @param options - The original enrichment options for cases where the Document embed content also contains text that must be enriched.
+   * @returns Either a single root element to append, or a collection of elements that comprise the embedded content
+   */
+  protected _buildEmbedHTML(
+    config: TextEditor.DocumentHTMLEmbedConfig,
+    options?: TextEditor.EnrichmentOptions,
+  ): Promise<HTMLElement | HTMLCollection | null>;
+
+  /**
+   * A method that can be overridden by subclasses to customize inline embedded HTML generation.
+   * @param content - The embedded content.
+   * @param config  - Configuration for embedding behavior.
+   * @param options - The original enrichment options for cases where the Document embed content also contains text that must be enriched.
+   */
+  protected _createInlineEmbed(
+    content: HTMLElement | HTMLCollection,
+    config: TextEditor.DocumentHTMLEmbedConfig,
+    options?: TextEditor.EnrichmentOptions,
+  ): Promise<HTMLElement | null>;
+
+  /**
+   * A method that can be overridden by subclasses to customize the generation of the embed figure.
+   * @param content - The embedded content.
+   * @param config  - Configuration for embedding behavior.
+   * @param options - The original enrichment options for cases where the Document embed content also contains text that must be enriched.
+   */
+  protected _createFigureEmbed(
+    content: HTMLElement | HTMLCollection,
+    config: TextEditor.DocumentHTMLEmbedConfig,
+    options?: TextEditor.EnrichmentOptions,
+  ): Promise<HTMLElement | null>;
 
   /**
    * Preliminary actions taken before a set of embedded Documents in this parent Document are created.
@@ -598,7 +655,7 @@ declare global {
       clearFlags: FlagsOpt;
 
       /**
-       * Clear any prior sourceId flag
+       * Clear any prior source information
        * @defaultValue `true`
        */
       clearSource: SourceOpt;

--- a/src/foundry/client/data/abstract/client-document.d.mts
+++ b/src/foundry/client/data/abstract/client-document.d.mts
@@ -329,11 +329,10 @@ declare class ClientDocument<
    * Gets the default new name for a Document
    * @param context - The context for which to create the Document name.
    */
-  static defaultName<T extends DocumentConstructor>(
+  static defaultName(
     context?: InexactPartial<{
-      this: T;
       /** The sub-type of the document */
-      // TODO: See if the valid strings can be inferred from T
+      // TODO: See if the valid strings can be inferred from this type
       type: string;
       /** A parent document within which the created Document should belong */
       parent: foundry.abstract.Document.Any;
@@ -356,10 +355,12 @@ declare class ClientDocument<
     this: T,
     data?: DeepPartial<ConstructorDataType<T> | (ConstructorDataType<T> & Record<string, unknown>)>,
     context?: Pick<DocumentModificationContext, "parent" | "pack"> &
-      Partial<DialogOptions> & {
-        /** A restriction the selectable sub-types of the Dialog. */
-        types?: string[] | undefined;
-      },
+      InexactPartial<
+        DialogOptions & {
+          /** A restriction the selectable sub-types of the Dialog. */
+          types: string[];
+        }
+      >,
   ): Promise<InstanceType<ConfiguredDocumentClass<T>> | null | undefined>;
 
   /**

--- a/src/foundry/client/ui/editor.d.mts
+++ b/src/foundry/client/ui/editor.d.mts
@@ -1,6 +1,5 @@
 import type { EditorView } from "prosemirror-view";
 import type { AnyObject, InexactPartial, MaybePromise } from "../../../types/utils.d.mts";
-import type { ClientDocument } from "../data/abstract/client-document.d.mts";
 import type { ConfiguredDocumentClassForName } from "../../../types/helperTypes.d.mts";
 
 declare global {
@@ -240,11 +239,7 @@ declare global {
      * @returns The replaced match. Returns null if the contained command is not a valid roll expression.
      * @internal
      */
-    protected static _createInlineRoll(
-      match: RegExpMatchArray,
-      rollData: object,
-      options: TextEditor.CreateInlineRollOptions,
-    ): Promise<HTMLAnchorElement | null>;
+    protected static _createInlineRoll(match: RegExpMatchArray, rollData: object): Promise<HTMLAnchorElement | null>;
 
     /**
      * Activate listeners for the interior content of the editor frame.
@@ -303,7 +298,13 @@ declare global {
      * @param options   - Additional options to configure link creation.
      */
     // TODO: improve as part of https://github.com/League-of-Foundry-Developers/foundry-vtt-types/issues/928
-    static getContentLink(eventData: object, options?: TextEditor.GetContentLinkOptions): Promise<string | null>;
+    static getContentLink(
+      eventData: object,
+      options?: InexactPartial<{
+        /** A document to generate the link relative to. */
+        relativeTo?: foundry.abstract.Document.Any;
+      }>,
+    ): Promise<string | null>;
 
     /**
      * Upload an image to a document's asset path.
@@ -501,14 +502,6 @@ declare global {
       label: string;
     }
 
-    interface GetContentLinkOptions {
-      /** A document to generate the link relative to. */
-      relativeTo?: ClientDocument<foundry.abstract.Document<any, any, any>>;
-
-      /** A custom label to use instead of the document's name. */
-      label?: string;
-    }
-
     interface EnrichmentAnchorOptions {
       /** Attributes to set on the anchor. */
       attrs?: Record<string, string> | undefined;
@@ -524,10 +517,6 @@ declare global {
 
       /** A font-awesome icon class to use as the icon. */
       icon?: string | undefined;
-    }
-
-    interface CreateInlineRollOptions {
-      async: boolean;
     }
 
     /**

--- a/src/foundry/client/ui/editor.d.mts
+++ b/src/foundry/client/ui/editor.d.mts
@@ -302,7 +302,7 @@ declare global {
       eventData: object,
       options?: InexactPartial<{
         /** A document to generate the link relative to. */
-        relativeTo?: foundry.abstract.Document.Any;
+        relativeTo: foundry.abstract.Document.Any;
       }>,
     ): Promise<string | null>;
 


### PR DESCRIPTION
Also included significant type fixes to TextEditor now that I understand partials better :)

(a v11 backport would also want to tackle changing all the MaybePromise into using EnrichmentOptions as a generic to discriminate promise & non-promise returns)

Resolves #2725 and #2679 