### PR TITLE
Replaced all instances of Document<any, any, any> with Document.Any

### DIFF
--- a/src/foundry/client-esm/applications/api/document-sheet.d.mts
+++ b/src/foundry/client-esm/applications/api/document-sheet.d.mts
@@ -2,9 +2,8 @@ import type { AnyObject, DeepPartial, EmptyObject } from "../../../../types/util
 import type ApplicationV2 from "./application.d.mts";
 
 declare namespace DocumentSheetV2 {
-  export interface Configuration<
-    Document extends foundry.abstract.Document<any, any, any> = foundry.abstract.Document<any, any, any>,
-  > extends ApplicationV2.Configuration {
+  export interface Configuration<Document extends foundry.abstract.Document.Any = foundry.abstract.Document.Any>
+    extends ApplicationV2.Configuration {
     /**
      * The Document instance associated with this sheet
      */
@@ -39,7 +38,7 @@ declare namespace DocumentSheetV2 {
  * The Application class is responsible for rendering an HTMLElement into the Foundry Virtual Tabletop user interface.
  */
 declare class DocumentSheetV2<
-  Document extends foundry.abstract.Document<any, any, any>,
+  Document extends foundry.abstract.Document.Any,
   RenderContext extends AnyObject = EmptyObject,
   Configuration extends DocumentSheetV2.Configuration<Document> = DocumentSheetV2.Configuration<Document>,
   RenderOptions extends DocumentSheetV2.RenderOptions = DocumentSheetV2.RenderOptions,

--- a/src/foundry/client/apps/form.d.mts
+++ b/src/foundry/client/apps/form.d.mts
@@ -320,9 +320,8 @@ declare global {
     }
   }
 
-  interface DocumentSheetOptions<
-    ConcreteDocument extends foundry.abstract.Document<any, any, any> = foundry.abstract.Document<any, any, any>,
-  > extends FormApplicationOptions {
+  interface DocumentSheetOptions<ConcreteDocument extends foundry.abstract.Document.Any = foundry.abstract.Document.Any>
+    extends FormApplicationOptions {
     /**
      * The default permissions required to view this Document sheet.
      * @defaultValue {@link CONST.DOCUMENT_OWNERSHIP_LEVELS.LIMITED}
@@ -342,7 +341,7 @@ declare global {
    */
   abstract class DocumentSheet<
     Options extends DocumentSheetOptions<ConcreteDocument>,
-    ConcreteDocument extends foundry.abstract.Document<any, any, any> = foundry.abstract.Document<any, any, any>,
+    ConcreteDocument extends foundry.abstract.Document.Any = foundry.abstract.Document.Any,
   > extends FormApplication<Options, ConcreteDocument> {
     /**
      * @param object  - A Document instance which should be managed by this form.
@@ -449,7 +448,7 @@ declare global {
   namespace DocumentSheet {
     interface DocumentSheetData<
       Options extends DocumentSheetOptions<ConcreteDocument>,
-      ConcreteDocument extends foundry.abstract.Document<any, any, any> = foundry.abstract.Document<any, any, any>,
+      ConcreteDocument extends foundry.abstract.Document.Any = foundry.abstract.Document.Any,
     > extends FormApplication.FormApplicationData {
       cssClass: string;
       editable: boolean;

--- a/src/foundry/client/apps/forms/image-popout.d.mts
+++ b/src/foundry/client/apps/forms/image-popout.d.mts
@@ -78,7 +78,7 @@ declare global {
     /**
      * Provide a reference to the Document referenced by this popout, if one exists
      */
-    getRelatedObject(): Promise<foundry.abstract.Document<any, any, any> | null>;
+    getRelatedObject(): Promise<foundry.abstract.Document.Any | null>;
 
     protected override _render(force?: boolean, options?: Application.RenderOptions<Options>): Promise<void>;
 

--- a/src/foundry/client/apps/forms/ownership.d.mts
+++ b/src/foundry/client/apps/forms/ownership.d.mts
@@ -8,7 +8,7 @@ declare global {
    */
   class DocumentOwnershipConfig<
     Options extends DocumentSheetOptions<ConcreteDocument>,
-    ConcreteDocument extends foundry.abstract.Document<any, any, any> = foundry.abstract.Document<any, any, any>,
+    ConcreteDocument extends foundry.abstract.Document.Any = foundry.abstract.Document.Any,
   > extends DocumentSheet<Options, ConcreteDocument> {
     /**
      * @defaultValue

--- a/src/foundry/client/apps/forms/sheet-config.d.mts
+++ b/src/foundry/client/apps/forms/sheet-config.d.mts
@@ -9,7 +9,7 @@ declare global {
    */
   class DocumentSheetConfig<
     Options extends FormApplicationOptions = FormApplicationOptions,
-    ConcreteDocument extends foundry.abstract.Document<any, any, any> = foundry.abstract.Document<any, any, any>,
+    ConcreteDocument extends foundry.abstract.Document.Any = foundry.abstract.Document.Any,
   > extends FormApplication<Options, ConcreteDocument> {
     /**
      * @defaultValue

--- a/src/foundry/client/core/document-index.d.mts
+++ b/src/foundry/client/core/document-index.d.mts
@@ -66,19 +66,19 @@ declare global {
      * Add an entry to the index.
      * @param doc - The document entry.
      */
-    addDocument(doc: foundry.abstract.Document<any, any, any>): void;
+    addDocument(doc: foundry.abstract.Document.Any): void;
 
     /**
      * Remove an entry from the index.
      * @param doc - The document entry.
      */
-    removeDocument(doc: foundry.abstract.Document<any, any, any>): void;
+    removeDocument(doc: foundry.abstract.Document.Any): void;
 
     /**
      * Replace an entry in the index with an updated one.
      * @param doc - The document entry.
      */
-    replaceDocument(doc: foundry.abstract.Document<any, any, any>): void;
+    replaceDocument(doc: foundry.abstract.Document.Any): void;
 
     /**
      * Add a leaf node to the word tree index.
@@ -87,7 +87,7 @@ declare global {
      * @internal
      */
     protected _addLeaf(
-      doc: foundry.abstract.Document<any, any, any>,
+      doc: foundry.abstract.Document.Any,
       options?: {
         /** The compendium that the index belongs to. */
         pack?: CompendiumCollection<any>;
@@ -106,7 +106,7 @@ declare global {
      * @param parent - The parent document.
      * @internal
      */
-    protected _indexEmbeddedDocuments(parent: foundry.abstract.Document<any, any, any>): void;
+    protected _indexEmbeddedDocuments(parent: foundry.abstract.Document.Any): void;
 
     /**
      * Aggregate all documents and embedded documents in a world collection and add them to the index.

--- a/src/foundry/client/core/utils.d.mts
+++ b/src/foundry/client/core/utils.d.mts
@@ -29,7 +29,7 @@ declare global {
       /** Allow retrieving an invalid Document. (default: `false`) */
       invalid?: boolean;
     },
-  ): Promise<foundry.abstract.Document<any, any, any> | null>;
+  ): Promise<foundry.abstract.Document.Any | null>;
 
   /**
    * Retrieve a Document by its Universally Unique Identifier (uuid) synchronously. If the uuid resolves to a compendium
@@ -49,7 +49,7 @@ declare global {
       /** Throw an error if the UUID cannot be resolved synchronously. (default: `true`) */
       strict?: boolean;
     },
-  ): foundry.abstract.Document<any, any, any> | Record<string, unknown> | null;
+  ): foundry.abstract.Document.Any | Record<string, unknown> | null;
 
   /**
    * Resolve a series of embedded document UUID parts against a parent Document.
@@ -58,10 +58,7 @@ declare global {
    * @returns The resolved Embedded Document.
    * @internal
    */
-  function _resolveEmbedded(
-    parent: foundry.abstract.Document<any, any, any>,
-    parts: string[],
-  ): foundry.abstract.Document<any, any, any>;
+  function _resolveEmbedded(parent: foundry.abstract.Document.Any, parts: string[]): foundry.abstract.Document.Any;
 
   /**
    * Return a reference to the Document class implementation which is configured for use.

--- a/src/foundry/client/data/abstract/client-document.d.mts
+++ b/src/foundry/client/data/abstract/client-document.d.mts
@@ -5,15 +5,9 @@ import type {
 } from "../../../../types/helperTypes.d.mts";
 import type { ConstructorOf, DeepPartial, InexactPartial, Mixin, ValueOf } from "../../../../types/utils.d.mts";
 import type Document from "../../../common/abstract/document.d.mts";
-import type { AnyMetadata, DocumentModificationOptions } from "../../../common/abstract/document.d.mts";
+import type { DocumentModificationOptions } from "../../../common/abstract/document.d.mts";
 
-declare class ClientDocument<
-  BaseDocument extends foundry.abstract.Document<any, AnyMetadata, any> = foundry.abstract.Document<
-    any,
-    AnyMetadata,
-    any
-  >,
-> {
+declare class ClientDocument<BaseDocument extends foundry.abstract.Document.Any = foundry.abstract.Document.Any> {
   /** @privateRemarks All mixin classses should accept anything for its constructor. */
   constructor(...args: any[]);
 
@@ -536,7 +530,7 @@ declare class ClientDocument<
    */
   protected _onCreateEmbeddedDocuments(
     embeddedName: string,
-    documents: foundry.abstract.Document<any, any, any>[],
+    documents: foundry.abstract.Document.Any[],
     result: Record<string, unknown>[],
     options: DocumentModificationOptions,
     userId: string,
@@ -568,7 +562,7 @@ declare class ClientDocument<
    */
   protected _onUpdateEmbeddedDocuments(
     embeddedName: string,
-    documents: foundry.abstract.Document<any, any, any>[],
+    documents: foundry.abstract.Document.Any[],
     result: Record<string, unknown>[],
     options: DocumentModificationContext,
     userId: string,
@@ -600,7 +594,7 @@ declare class ClientDocument<
    */
   protected _onDeleteEmbeddedDocuments(
     embeddedName: string,
-    documents: foundry.abstract.Document<any, any, any>[],
+    documents: foundry.abstract.Document.Any[],
     result: string[],
     options: DocumentModificationContext,
     userId: string,
@@ -688,12 +682,12 @@ declare global {
   }
 }
 
-export type DropData<T extends foundry.abstract.Document<any, any, any>> = T extends { id: string | undefined }
+export type DropData<T extends foundry.abstract.Document.Any> = T extends { id: string | undefined }
   ? DropData.Data<T> & DropData.UUID
   : DropData.Data<T>;
 
 declare namespace DropData {
-  interface Data<T extends foundry.abstract.Document<any, any, any>> {
+  interface Data<T extends foundry.abstract.Document.Any> {
     type: T["documentName"];
     data: T["_source"];
   }

--- a/src/foundry/client/hooks.d.mts
+++ b/src/foundry/client/hooks.d.mts
@@ -293,7 +293,7 @@ declare global {
        */
       updateCompendium: (
         pack: CompendiumCollection<any>,
-        documents: foundry.abstract.Document<any, any, any>[],
+        documents: foundry.abstract.Document.Any[],
         options: DocumentModificationOptions,
         userId: string,
       ) => void;

--- a/src/foundry/client/ui/secrets.d.mts
+++ b/src/foundry/client/ui/secrets.d.mts
@@ -13,11 +13,11 @@ declare global {
    * @returns The updated Document.
    */
   type HTMLSecretUpdateCallback<
-    ConcreteDocument extends foundry.abstract.Document<any, any, any> = foundry.abstract.Document<any, any, any>,
+    ConcreteDocument extends foundry.abstract.Document.Any = foundry.abstract.Document.Any,
   > = (secret: HTMLElement, content: string) => Promise<ConcreteDocument>;
 
   interface HTMLSecretConfiguration<
-    ConcreteDocument extends foundry.abstract.Document<any, any, any> = foundry.abstract.Document<any, any, any>,
+    ConcreteDocument extends foundry.abstract.Document.Any = foundry.abstract.Document.Any,
   > {
     /** The CSS selector used to target content that contains secret blocks. */
     parentSelector: string;
@@ -44,9 +44,7 @@ declare global {
    * secrets.bind(html);
    * ```
    */
-  class HTMLSecret<
-    ConcreteDocument extends foundry.abstract.Document<any, any, any> = foundry.abstract.Document<any, any, any>,
-  > {
+  class HTMLSecret<ConcreteDocument extends foundry.abstract.Document.Any = foundry.abstract.Document.Any> {
     /**
      * @param config - Configuration options.
      */

--- a/src/foundry/common/abstract/embedded-collection-delta.d.mts
+++ b/src/foundry/common/abstract/embedded-collection-delta.d.mts
@@ -6,8 +6,8 @@ import type EmbeddedCollection from "./embedded-collection.d.mts";
  * embedded collection, and generate new embedded Documents by combining them.
  */
 export default class EmbeddedCollectionDelta<
-  ContainedDocument extends foundry.abstract.Document<any, any, any>,
-  ParentDataModel extends foundry.abstract.Document<any, any, any>,
+  ContainedDocument extends foundry.abstract.Document.Any,
+  ParentDataModel extends foundry.abstract.Document.Any,
 > extends EmbeddedCollection<ContainedDocument, ParentDataModel> {
   /**
    * A convenience getter to return the corresponding base collection.

--- a/src/foundry/common/types.d.mts
+++ b/src/foundry/common/types.d.mts
@@ -8,7 +8,7 @@ declare global {
      * The parent Document of this one, if this one is embedded
      * @defaultValue `null`
      */
-    parent?: foundry.abstract.Document<any, any, any> | null | undefined;
+    parent?: foundry.abstract.Document.Any | null | undefined;
 
     /**
      * The compendium collection ID which contains this Document, if any
@@ -28,7 +28,7 @@ declare global {
     /**
      * A parent Document within which these Documents should be embedded
      */
-    parent?: foundry.abstract.Document<any, any, any> | undefined;
+    parent?: foundry.abstract.Document.Any | undefined;
 
     /**
      * A Compendium pack identifier within which the Documents should be modified


### PR DESCRIPTION
Simple find and replace, left out the handful of uses in prosemirror since those are handled in #2739 