### PR TITLE
Use `GetDataReturnType` in `GridConfig`

### DIFF
--- a/src/foundry/client/apps/forms/grid-config.d.mts
+++ b/src/foundry/client/apps/forms/grid-config.d.mts
@@ -1,5 +1,5 @@
 import type { ConfiguredDocumentClass, InterfaceToObject } from "../../../../types/helperTypes.d.mts";
-import type { AnyObject, MaybePromise } from "../../../../types/utils.d.mts";
+import type { AnyObject, GetDataReturnType, MaybePromise } from "../../../../types/utils.d.mts";
 
 declare global {
   /**
@@ -38,7 +38,7 @@ declare global {
 
     protected override _render(force?: boolean, options?: Application.RenderOptions<Options>): Promise<void>;
 
-    override getData(options?: Partial<Options>): MaybePromise<AnyObject>;
+    override getData(options?: Partial<Options>): MaybePromise<GetDataReturnType<GridConfig.GridConfigData>>;
 
     protected override _getSubmitData(updateData?: AnyObject | null): InterfaceToObject<GridConfig.FormData>;
 
@@ -133,6 +133,12 @@ declare global {
       scale: Scene["width"];
       "background.offsetX": Scene["background"]["offsetX"];
       "background.offsetY": Scene["background"]["offsetY"];
+    }
+
+    interface GridConfigData {
+      gridTypes: Record<foundry.CONST.GRID_TYPES, string>;
+      scale: number;
+      scene: Scene;
     }
   }
 }

--- a/src/foundry/client/apps/forms/grid-config.d.mts
+++ b/src/foundry/client/apps/forms/grid-config.d.mts
@@ -138,7 +138,7 @@ declare global {
     interface GridConfigData {
       gridTypes: Record<foundry.CONST.GRID_TYPES, string>;
       scale: number;
-      scene: Scene;
+      scene: Scene.ConfiguredInstance;
     }
   }
 }


### PR DESCRIPTION
## What issue does this pull request correspond to (if any)?

Part of #2546

## What does this pull request implement?

We migrate `GridConfig#getData` to use `GetDataReturnType`. We're
following the pattern laid out in the other subclasses of `Application`.

## What changes are made in this pull request?

- Addition: Added `GridConfig.GridConfigData`.
- Breaking: The return type of `GridConfig#getData` is more precise now.
