### PR TITLE
Fix most type errors

### DIFF
--- a/src/foundry/client/apps/placeables/token-config.d.mts
+++ b/src/foundry/client/apps/placeables/token-config.d.mts
@@ -141,7 +141,7 @@ declare global {
   namespace TokenConfig {
     type Any = TokenConfig<any>;
 
-    interface FormData {
+    interface FormData extends AnyObject {
       // TODO: Update
       actorId: string;
       actorLink: boolean;

--- a/src/foundry/client/pixi/perception/vision-mode.d.mts
+++ b/src/foundry/client/pixi/perception/vision-mode.d.mts
@@ -1,5 +1,4 @@
 import type { AnyObject, InexactPartial, SimpleMerge, ValueOf } from "../../../../types/utils.d.mts";
-import type { DataField } from "../../../common/data/fields.d.mts";
 import type { fields } from "../../../common/data/module.d.mts";
 
 declare global {
@@ -99,7 +98,7 @@ declare global {
   }
 
   namespace ShaderField {
-    type Options = DataField.Options<typeof AbstractBaseShader>;
+    type Options = DataFieldOptions<typeof AbstractBaseShader>;
 
     type DefaultOptions = SimpleMerge<
       foundry.data.fields.DataField.DefaultOptions,

--- a/src/foundry/common/packages/base-package.d.mts
+++ b/src/foundry/common/packages/base-package.d.mts
@@ -516,7 +516,7 @@ declare class BasePackage<
    * @deprecated since v10, will be removed in v13
    * @remarks `"You are accessing BasePackage#name which is now deprecated in favor of id."`
    */
-  get name(): this["id"];
+  get name(): PackageSchema["id"];
 
   /**
    * A flag which defines whether this package is unavailable to be used.


### PR DESCRIPTION
## What issue does this pull request correspond to (if any)?

No issue, as far as I can tell.

## What does this pull request implement?

The `typecheck` script had a few errors:

<details>
<summary>Typecheck errors</summary>

```Console
$ npm run typecheck

> @league-of-foundry-developers/foundry-vtt-types@11.315.0 typecheck
> ./node_modules/typescript/bin/tsc

src/foundry/client/apps/placeables/token-config.d.mts:84:24 - error TS2416: Property '_getSubmitData' in type 'TokenConfig<Options>' is not assignable to the same property in base type 'DocumentSheet<Options, Actor | TokenDocument>'.
  Type '(updateData?: AnyObject | null | undefined) => FormData' is not assignable to type '(updateData?: AnyObject | null | undefined) => AnyObject'.
    Type 'FormData' is not assignable to type 'AnyObject'.
      Index signature for type 'string' is missing in type 'FormData'.

84     protected override _getSubmitData(updateData?: AnyObject | null): TokenConfig.FormData;
                          ~~~~~~~~~~~~~~

src/foundry/client/pixi/perception/vision-mode.d.mts:102:30 - error TS2694: Namespace 'DataField' has no exported member 'Options'.

102     type Options = DataField.Options<typeof AbstractBaseShader>;
                                 ~~~~~~~

src/foundry/common/data/fields.d.mts:1697:49 - error TS2344: Type 'InstanceType<ConfiguredDocumentClass<ElementFieldType>>' does not satisfy the constraint 'Document<DataSchema, AnyMetadata, any>'.
  Type 'Combat | Actor | Item | Cards | ChatMessage | Folder | JournalEntry | Macro | Playlist | RollTable | ... 19 more ... | WallDocument' is not assignable to type 'Document<DataSchema, AnyMetadata, any>'.
    Type 'Combat' is not assignable to type 'Document<DataSchema, AnyMetadata, any>'.
      Types of property 'singletons' are incompatible.
        Type 'Record<string, AnyChild<Combat>>' is not assignable to type 'Record<string, AnyChild<InstanceType<ConfiguredDocumentClass<ElementFieldType>>>>'.
          'string' index signatures are incompatible.
            Type 'AnyChild<Combat>' is not assignable to type 'AnyChild<InstanceType<ConfiguredDocumentClass<ElementFieldType>>>'.

1697   InitializedElementType extends Document.Any = EmbeddedCollectionField.InitializedElementType<ElementFieldType>,
                                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

src/foundry/common/data/fields.d.mts:1904:49 - error TS2344: Type 'InstanceType<ConfiguredDocumentClass<ElementFieldType>>' does not satisfy the constraint 'Document<DataSchema, AnyMetadata, any>'.
  Type 'Combat | Actor | Item | Cards | ChatMessage | Folder | JournalEntry | Macro | Playlist | RollTable | ... 19 more ... | WallDocument' is not assignable to type 'Document<DataSchema, AnyMetadata, any>'.
    Type 'Combat' is not assignable to type 'Document<DataSchema, AnyMetadata, any>'.
      Types of property 'singletons' are incompatible.
        Type 'Record<string, AnyChild<Combat>>' is not assignable to type 'Record<string, AnyChild<InstanceType<ConfiguredDocumentClass<ElementFieldType>>>>'.
          'string' index signatures are incompatible.
            Type 'AnyChild<Combat>' is not assignable to type 'AnyChild<InstanceType<ConfiguredDocumentClass<ElementFieldType>>>'.

1904   InitializedElementType extends Document.Any = EmbeddedCollectionDeltaField.InitializedElementType<ElementFieldType>,
                                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

src/foundry/common/packages/base-package.d.mts:519:15 - error TS2536: Type '"id"' cannot be used to index type 'this'.

519   get name(): this["id"];
                  ~~~~~~~~~~


Found 5 errors in 4 files.

Errors  Files
     1  src/foundry/client/apps/placeables/token-config.d.mts:84
     1  src/foundry/client/pixi/perception/vision-mode.d.mts:102
     2  src/foundry/common/data/fields.d.mts:1697
     1  src/foundry/common/packages/base-package.d.mts:519
```

</details>


This PR fixes the errors in:
- `src/foundry/client/apps/placeables/token-config.d.mts`
- `src/foundry/client/pixi/perception/vision-mode.d.mts`
- `src/foundry/common/packages/base-package.d.mts`

There are still two errors in `src/foundry/common/data/fields.d.mts`
that I cannot figure out. I'm not familiar enough with this stuff to
really suggest what the change should be. If someone knows what change
should be made, I'm down to make it.

## What changes are made in this pull request?

The change to `TokenConfig.FormData` is that it inherits from its
parent. We add the `extends AnyObject` since that's what its parent
returns. The more robust way would likely be to define a `FormData` type
in the `DocumentSheet` namespace, and reference that instead. But,
that's a slightly bigger change than fixing things that are broken.

The change to `ShaderField.Options` is that `DataField.Options` doesn't
exist, but `DataFieldOptions` does.

The change to `BasePackage#name` is that it doesn't seem to be inferring
the correct type from the `this` context. Since the `name` comes from
whatever the `PackageSchema` is, we use that instead.
