### PR TITLE
feature/update data data to 331

### DIFF
--- a/src/foundry/common/abstract/data.d.mts
+++ b/src/foundry/common/abstract/data.d.mts
@@ -119,6 +119,11 @@ declare abstract class DataModel<
   #validationFailures: { fields: DataModelValidationFailure | null; joint: DataModelValidationFailure | null };
 
   /**
+   * A set of localization prefix paths which are used by this DataModel.
+   */
+  static LOCALIZATION_PREFIXES: string[];
+
+  /**
    * Initialize the source data for a new DataModel instance.
    * One-time migrations and initial cleaning operations are applied to the source data.
    * @param data    - The candidate source data from which the model will be constructed

--- a/src/foundry/common/data/data.d.mts
+++ b/src/foundry/common/data/data.d.mts
@@ -14,153 +14,149 @@ declare namespace LightData {
   export interface LightAnimationDataSchema extends DataSchema {
     /**
      * The animation type which is applied
+     * @defaultValue `null`
      */
-    type: fields.StringField<{ nullable: true; blank: false; initial: null; label: "LIGHT.AnimationType" }>;
+    type: fields.StringField<{ nullable: true; blank: false; initial: null }>;
 
     /**
      * The speed of the animation, a number between 0 and 10
+     * @defaultValue `5`
      */
     speed: fields.NumberField<{
       required: true;
+      nullable: false;
       integer: true;
       initial: 5;
       min: 0;
       max: 10;
-      label: "LIGHT.AnimationSpeed";
       validationError: "Light animation speed must be an integer between 0 and 10";
     }>;
 
     /**
      * The intensity of the animation, a number between 1 and 10
+     * @defaultValue `5`
      */
     intensity: fields.NumberField<{
       required: true;
+      nullable: false;
       integer: true;
       initial: 5;
-      min: 0;
+      min: 1;
       max: 10;
-      label: "LIGHT.AnimationIntensity";
       validationError: "Light animation intensity must be an integer between 1 and 10";
     }>;
 
     /**
      * Reverse the direction of animation.
+     * @defaultValue `false`
      */
-    reverse: fields.BooleanField<{ label: "LIGHT.AnimationReverse" }>;
+    reverse: fields.BooleanField;
   }
 
   export interface DarknessSchema extends DataSchema {
+    /**
+     * @defaultValue `0`
+     */
     min: fields.NumberField<{ initial: 0 }>;
+
+    /**
+     * @defaultValue `1`
+     */
     max: fields.NumberField<{ initial: 1 }>;
   }
 
   interface Schema extends DataSchema {
     /**
-     * An opacity for the emitted light, if any
+     * Is this light source a negative source? (i.e. darkness source)
+     * @defaultValue `false`
      */
-    alpha: fields.AlphaField<{ initial: 0.5; label: "LIGHT.Alpha" }>;
+    negative: fields.BooleanField;
+
+    /**
+     * @defaultValue `0`
+     */
+    // TODO: report undocumented
+    priority: fields.NumberField<{ required: true; nullable: false; integer: true; initial: 0; min: 0 }>;
+
+    /**
+     * An opacity for the emitted light, if any
+     * @defaultValue `0.5`
+     */
+    alpha: fields.AlphaField<{ initial: 0.5 }>;
 
     /**
      * The angle of emission for this point source
+     * @defaultValue `0`
      */
-    angle: fields.AngleField<{ initial: 360; base: 360; label: "LIGHT.Angle" }>;
+    angle: fields.AngleField<{ initial: 360; normalize: false }>;
 
     /**
      * The allowed radius of bright vision or illumination
+     * @defaultValue `0`
      */
-    bright: fields.NumberField<{ required: true; initial: 0; min: 0; step: 0.01; label: "LIGHT.Bright" }>;
+    bright: fields.NumberField<{ required: true; nullable: false; initial: 0; min: 0; step: 0.01 }>;
 
     /**
      * A tint color for the emitted light, if any
+     * @defaultValue `null`
      */
-    color: fields.ColorField<{ label: "LIGHT.Color" }>;
+    color: fields.ColorField;
 
     /**
      * The coloration technique applied in the shader
+     * @defaultValue `1`
      */
-    coloration: fields.NumberField<{
-      required: true;
-      integer: true;
-      initial: 1;
-      label: "LIGHT.ColorationTechnique";
-      hint: "LIGHT.ColorationTechniqueHint";
-    }>;
-
-    /**
-     * The amount of contrast this light applies to the background texture
-     */
-    dim: fields.NumberField<{ required: true; initial: 0; min: 0; step: 0.01; label: "LIGHT.Dim" }>;
+    coloration: fields.NumberField<{ required: true; integer: true; initial: 1 }>;
 
     /**
      * The allowed radius of dim vision or illumination
+     * @defaultValue `0`
      */
-    attenuation: fields.AlphaField<{ initial: 0.5; label: "LIGHT.Attenuation"; hint: "LIGHT.AttenuationHint" }>;
+    dim: fields.NumberField<{ required: true; nullable: false; initial: 0; min: 0; step: 0.01 }>;
 
     /**
      * Fade the difference between bright, dim, and dark gradually?
+     * @defaultValue `0.5`
      */
-    luminosity: fields.NumberField<{
-      required: true;
-      nullable: false;
-      initial: 0.5;
-      min: -1;
-      max: 1;
-      label: "LIGHT.Luminosity";
-      hint: "LIGHT.LuminosityHint";
-    }>;
+    attenuation: fields.AlphaField<{ initial: 0.5 }>;
 
     /**
      * The luminosity applied in the shader
+     * @defaultValue `0.5`
      */
-    saturation: fields.NumberField<{
-      required: true;
-      nullable: false;
-      initial: 0;
-      min: -1;
-      max: 1;
-      label: "LIGHT.Saturation";
-      hint: "LIGHT.SaturationHint";
-    }>;
+    luminosity: fields.NumberField<{ required: true; nullable: false; initial: 0.5; min: 0; max: 1 }>;
 
     /**
      * The amount of color saturation this light applies to the background texture
+     * @defaultValue `0`
      */
-    contrast: fields.NumberField<{
-      required: true;
-      nullable: false;
-      initial: 0;
-      min: -1;
-      max: 1;
-      label: "LIGHT.Contrast";
-      hint: "LIGHT.ContrastHint";
-    }>;
+    saturation: fields.NumberField<{ required: true; nullable: false; initial: 0; min: -1; max: 1 }>;
+
+    /**
+     * The amount of contrast this light applies to the background texture
+     * @defaultValue `0`
+     */
+    contrast: fields.NumberField<{ required: true; nullable: false; initial: 0; min: -1; max: 1 }>;
 
     /**
      * The depth of shadows this light applies to the background texture
+     * @defaultValue `0`
      */
-    shadows: fields.NumberField<{
-      required: true;
-      nullable: false;
-      initial: 0;
-      min: 0;
-      max: 1;
-      label: "LIGHT.Shadows";
-      hint: "LIGHT.ShadowsHint";
-    }>;
+    shadows: fields.NumberField<{ required: true; nullable: false; initial: 0; min: 0; max: 1 }>;
 
     /**
      * An animation configuration for the source
+     * @defaultValue see properties
      */
     animation: fields.SchemaField<LightAnimationDataSchema>;
 
     /**
      * A darkness range (min and max) for which the source should be active
+     * @defaultValue see properties
      */
     darkness: fields.SchemaField<
       DarknessSchema,
       {
-        label: "LIGHT.DarknessRange";
-        hint: "LIGHT.DarknessRangeHint";
         validate: (d: fields.SchemaField.InnerAssignmentType<DarknessSchema>) => boolean;
         validationError: "darkness.max may not be less than darkness.min";
       }
@@ -168,8 +164,17 @@ declare namespace LightData {
   }
 }
 
+/**
+ * A reusable document structure for the internal data used to render the appearance of a light source.
+ * This is re-used by both the AmbientLightData and TokenData classes.
+ */
 declare class LightData extends DataModel<LightData.Schema> {
-  static defineSchema(): LightData.Schema;
+  static override defineSchema(): LightData.Schema;
+
+  /**
+   * @defaultValue `["LIGHT"]`
+   */
+  static override LOCALIZATION_PREFIXES: string[];
 
   static migrateData(source: AnyObject): AnyObject;
 }
@@ -181,26 +186,31 @@ declare namespace ShapeData {
      * For rectangles, the x/y coordinates are the top-left corner.
      * For circles, the x/y coordinates are the center of the circle.
      * For polygons, the x/y coordinates are the first point of the polygon.
+     * @defaultValue `"r"`
      */
     type: fields.StringField<{ required: true; blank: false; choices: ValueOf<TYPES>[]; initial: "r" }>;
 
     /**
      * For rectangles, the pixel width of the shape.
+     * @defaultValue `null`
      */
     width: fields.NumberField<{ required: false; integer: true; min: 0 }>;
 
     /**
      * For rectangles, the pixel width of the shape.
+     * @defaultValue `null`
      */
     height: fields.NumberField<{ required: false; integer: true; min: 0 }>;
 
     /**
      * For circles, the pixel radius of the shape.
+     * @defaultValue `null`
      */
     radius: fields.NumberField<{ required: false; integer: true; positive: true }>;
 
     /**
      * For polygons, the array of polygon coordinates which comprise the shape.
+     * @defaultValue `[]`
      */
     points: fields.ArrayField<fields.NumberField<{ nullable: false }>>;
   }
@@ -213,16 +223,220 @@ declare namespace ShapeData {
   }
 }
 
+// TODO: report additional, nonexistent `elevation` property documenation
+/**
+ * A data model intended to be used as an inner EmbeddedDataField which defines a geometric shape.
+ */
 declare class ShapeData extends DataModel<ShapeData.Schema> {
-  static defineSchema(): ShapeData.Schema;
+  static override defineSchema(): ShapeData.Schema;
 
   static TYPES: ShapeData.TYPES;
+}
+
+declare namespace BaseShapeData {
+  interface Schema extends DataSchema {
+    /**
+     * The type of shape, a value in BaseShapeData.TYPES.
+     * @defaultValue `this.TYPE`
+     */
+    type: fields.StringField<{
+      required: true;
+      blank: false;
+      initial: string;
+      validate: (value: string) => boolean;
+      validationError: `must be equal to "${string}"`;
+    }>;
+
+    /**
+     * Is this shape a hole?
+     * @defaultValue `false`
+     */
+    hole: fields.BooleanField;
+  }
+
+  interface Types {
+    rectangle: RectangleShapeData;
+    circle: CircleShapeData;
+    ellipse: EllipseShapeData;
+    polygon: PolygonShapeData;
+  }
+}
+
+/**
+ * A data model intended to be used as an inner EmbeddedDataField which defines a geometric shape.
+ */
+declare abstract class BaseShapeData extends DataModel<BaseShapeData.Schema> {
+  /**
+   * The possible shape types.
+   */
+  static get TYPES(): Readonly<BaseShapeData.Types>;
+
+  static #TYPES: Readonly<BaseShapeData.Types>;
+
+  /**
+   * The type of this shape.
+   */
+  static TYPE: string;
+
+  static override defineSchema(): BaseShapeData.Schema;
+}
+
+declare namespace RectangleShapeData {
+  interface Schema extends BaseShapeData.Schema {
+    /**
+     * The top-left x-coordinate in pixels before rotation.
+     * @defaultValue `undefined`
+     */
+    x: fields.NumberField<{ required: true; nullable: false; initial: undefined }>;
+
+    /**
+     * The top-left y-coordinate in pixels before rotation.
+     * @defaultValue `undefined`
+     */
+    y: fields.NumberField<{ required: true; nullable: false; initial: undefined }>;
+
+    /**
+     * The width of the rectangle in pixels.
+     * @defaultValue `undefined`
+     */
+    width: fields.NumberField<{ required: true; nullable: false; initial: undefined; positive: true }>;
+
+    /**
+     * The height of the rectangle in pixels.
+     * @defaultValue `undefined`
+     */
+    height: fields.NumberField<{ required: true; nullable: false; initial: undefined; positive: true }>;
+
+    /**
+     * The rotation around the center of the rectangle in degrees.
+     * @defaultValue `0`
+     */
+    rotation: fields.AngleField;
+  }
+}
+
+/**
+ * The data model for a rectangular shape.
+ */
+declare class RectangleShapeData extends BaseShapeData {
+  /**
+   * @defaultValue `"rectangle"`
+   */
+  static override TYPE: string;
+
+  static override defineSchema(): RectangleShapeData.Schema;
+}
+
+declare namespace CircleShapeData {
+  interface Schema extends BaseShapeData.Schema {
+    /**
+     * The x-coordinate of the center point in pixels.
+     * @defaultValue `undefined`
+     */
+    x: fields.NumberField<{ required: true; nullable: false; initial: undefined }>;
+
+    /**
+     * The y-coordinate of the center point in pixels.
+     * @defaultValue `undefined`
+     */
+    y: fields.NumberField<{ required: true; nullable: false; initial: undefined }>;
+
+    /**
+     * The radius of the circle in pixels.
+     * @defaultValue `undefined`
+     */
+    radius: fields.NumberField<{ required: true; nullable: false; initial: undefined; positive: true }>;
+  }
+}
+
+/**
+ * The data model for a circle shape.
+ */
+declare class CircleShapeData extends BaseShapeData {
+  /**
+   * @defaultValue `"circle"`
+   */
+  static override TYPE: string;
+
+  static override defineSchema(): CircleShapeData.Schema;
+}
+
+declare namespace EllipseShapeData {
+  interface Schema extends BaseShapeData.Schema {
+    /**
+     * The x-coordinate of the center point in pixels.
+     * @defaultValue `undefined`
+     */
+    x: fields.NumberField<{ required: true; nullable: false; initial: undefined }>;
+
+    /**
+     * The y-coordinate of the center point in pixels.
+     * @defaultValue `undefined`
+     */
+    y: fields.NumberField<{ required: true; nullable: false; initial: undefined }>;
+
+    /**
+     * The x-radius of the circle in pixels.
+     * @defaultValue `undefined`
+     */
+    radiusX: fields.NumberField<{ required: true; nullable: false; initial: undefined; positive: true }>;
+
+    /**
+     * The y-radius of the circle in pixels.
+     * @defaultValue `undefined`
+     */
+    radiusY: fields.NumberField<{ required: true; nullable: false; initial: undefined; positive: true }>;
+
+    /**
+     * The rotation around the center of the rectangle in degrees.
+     * @defaultValue `0`
+     */
+    rotation: fields.AngleField;
+  }
+}
+
+/**
+ * The data model for an ellipse shape.
+ */
+declare class EllipseShapeData extends BaseShapeData {
+  /**
+   * @defaultValue `"ellipse"`
+   */
+  static override TYPE: string;
+
+  static override defineSchema(): EllipseShapeData.Schema;
+}
+
+declare namespace PolygonShapeData {
+  interface Schema extends BaseShapeData.Schema {
+    /**
+     * The points of the polygon ([x0, y0, x1, y1, ...]).
+     * The polygon must not be self-intersecting.
+     * @defaultValue `[]`
+     */
+    points: fields.ArrayField<
+      fields.NumberField<{ required: true; nullable: false; initial: undefined }>,
+      { validate: (value: []) => void }
+    >;
+  }
+}
+
+/**
+ * The data model for a polygon shape.
+ */
+declare class PolygonShapeData extends BaseShapeData {
+  /**
+   * @defaultValue `"polygon"`
+   */
+  static override TYPE: string;
+
+  static override defineSchema(): PolygonShapeData.Schema;
 }
 
 declare namespace TextureData {
   interface DefaultOptions {
     categories: ["IMAGE", "VIDEO"];
-    // initial: null;
+    // initial: {};
     wildcard: false;
     label: "";
   }
@@ -230,45 +444,86 @@ declare namespace TextureData {
   interface Schema<SrcOptions extends FilePathFieldOptions> extends DataSchema {
     /**
      * The URL of the texture source.
+     * @defaultValue `initial.src ?? null`
      */
     src: fields.FilePathField<SrcOptions>;
 
     /**
-     * The scale of the texture in the X dimension.
+     * The X coordinate of the texture anchor.
+     * @defaultValue `initial.anchorX ?? 0`
      */
-    scaleX: fields.NumberField<{ nullable: false; initial: 1 }>;
+    anchorX: fields.NumberField<{ nullable: false; initial: number }>;
 
     /**
-     * The scale of the texture in the Y dimension.
+     * The Y coordinate of the texture anchor.
+     * @defaultValue `initial.anchorY ?? 0`
      */
-    scaleY: fields.NumberField<{ nullable: false; initial: 1 }>;
+    anchorY: fields.NumberField<{ nullable: false; initial: number }>;
 
     /**
      * The X offset of the texture with (0,0) in the top left.
+     * @defaultValue `initial.offsetX ?? 0`
      */
-    offsetX: fields.NumberField<{ nullable: false; integer: true; initial: 0 }>;
+    offsetX: fields.NumberField<{ nullable: false; integer: true; initial: number }>;
 
     /**
      * The Y offset of the texture with (0,0) in the top left.
+     * @defaultValue `initial.offsetY ?? 0`
      */
-    offsetY: fields.NumberField<{ nullable: false; integer: true; initial: 0 }>;
+    offsetY: fields.NumberField<{ nullable: false; integer: true; initial: number }>;
+
+    /**
+     * @defaultValue `initial.fit ?? "fill"`
+     */
+    // TODO: report missing documentation
+    fit: fields.StringField<{ initial: string; choices: typeof CONST.TEXTURE_DATA_FIT_MODES }>;
+
+    /**
+     * The scale of the texture in the X dimension.
+     * @defaultValue `initial.scaleX ?? 1`
+     */
+    scaleX: fields.NumberField<{ nullable: false; initial: number }>;
+
+    /**
+     * The scale of the texture in the Y dimension.
+     * @defaultValue `initial.scaleY ?? 1`
+     */
+    scaleY: fields.NumberField<{ nullable: false; initial: number }>;
 
     /**
      * An angle of rotation by which this texture is rotated around its center.
+     * @defaultValue `initial.rotation ?? 0`
      */
-    rotation: fields.AngleField;
+    rotation: fields.AngleField<{ initial: number }>;
 
     /**
-     * An optional color string used to tint the texture.
+     * The tint applied to the texture.
+     * @defaultValue `initial.tint ?? "#ffffff"`
      */
-    tint: fields.ColorField;
+    tint: fields.ColorField<{ nullable: false; initial: string }>;
+
+    /**
+     * Only pixels with an alpha value at or above this value are consider solid
+     * w.r.t. to occlusion testing and light/weather blocking.
+     * @defaultValue `initial.alphaThreshold ?? 0`
+     */
+    alphaThreshold: fields.AlphaField<{ nullable: false; initial: number }>;
+
+    // NOTE: continue here
   }
 }
 
+/**
+ * A {@link fields.SchemaField} subclass used to represent texture data.
+ */
 declare class TextureData<
   SrcOptions extends FilePathFieldOptions = TextureData.DefaultOptions,
   SchemaOptions extends fields.SchemaField.Options<TextureData.Schema<SrcOptions>> = EmptyObject,
 > extends fields.SchemaField<TextureData.Schema<SrcOptions>, SchemaOptions> {
+  /**
+   * @param options    - Options which are forwarded to the SchemaField constructor
+   * @param srcOptions - Additional options for the src field
+   */
   constructor(options?: SchemaOptions, srcOptions?: SrcOptions);
 }
 
@@ -283,16 +538,17 @@ declare namespace PrototypeToken {
     | "x"
     | "y"
     | "elevation"
-    | "effects"
-    | "overlayEffect"
-    | "hidden";
+    | "sort"
+    | "hidden"
+    | "locked"
+    | "_regions";
 
   interface Schema extends foundry.documents.BaseToken.SharedProtoSchema {
-    // Name is technically redefined but with the same options so it's ignored here
-    // name: fields.StringField<{ required: true; blank: true }>;
+    name: fields.StringField<{ required: true; blank: true; textSearch: boolean }>;
 
     /**
      * Does the prototype token use a random wildcard image?
+     * @defaultValue `false`
      */
     randomImg: fields.BooleanField;
   }
@@ -300,6 +556,9 @@ declare namespace PrototypeToken {
   type ConstructorData = fields.SchemaField.InnerAssignmentType<Schema>;
 }
 
+/**
+ * Extend the base TokenData to define a PrototypeToken which exists within a parent Actor.
+ */
 declare class PrototypeToken extends DataModel<PrototypeToken.Schema, any> {
   constructor(data?: PrototypeToken.ConstructorData, options?: DataModel.ConstructorOptions<PrototypeToken.Parent>);
 
@@ -307,6 +566,13 @@ declare class PrototypeToken extends DataModel<PrototypeToken.Schema, any> {
 
   /** @defaultValue `{}` */
   apps: Record<string, Application>;
+
+  static override defineSchema(): PrototypeToken.Schema;
+
+  /**
+   * @defaultValue `["TOKEN"]`
+   */
+  static override LOCALIZATION_PREFIXES: string[];
 
   /**
    * The Actor which owns this Prototype Token
@@ -318,18 +584,11 @@ declare class PrototypeToken extends DataModel<PrototypeToken.Schema, any> {
 
   static get database(): DatabaseBackend;
 
-  static override migrateData(source: AnyObject): AnyObject;
-
-  static override shimData(
-    data: AnyObject,
-    options?: {
-      /**
-       * Apply shims to embedded models?
-       * @defaultValue `true`
-       */
-      embedded?: boolean;
-    },
-  ): AnyObject;
+  /**
+   * Apply configured default token settings to the schema.
+   * @param schema - The schema to apply the settings to.
+   */
+  static #applyDefaultTokenSettings(schema: DataSchema): void;
 
   /**
    * @see foundry.abstract.Document#update
@@ -376,30 +635,38 @@ declare namespace TombstoneData {
   interface Schema extends DataSchema {
     /**
      * The _id of the base Document that this tombstone represents.
+     * @defaultValue `null`
      */
     _id: fields.DocumentIdField;
 
     /**
      * A property that identifies this entry as a tombstone.
+     * @defaultValue `true`
      */
-    _tombstone: fields.BooleanField;
-
-    /**
-     * An object of creation and access information.
-     */
-    _stats: fields.DocumentStatsField;
+    _tombstone: fields.BooleanField<{
+      initial: true;
+      validate: (v: boolean) => boolean;
+      validationError: "must be true";
+    }>;
   }
 }
 
+/**
+ * A minimal data model used to represent a tombstone entry inside an EmbeddedCollectionDelta.
+ */
 declare class TombstoneData extends DataModel<TombstoneData.Schema> {
-  static defineSchema(): TombstoneData.Schema;
+  static override defineSchema(): TombstoneData.Schema;
 }
 
 export {
   LightData,
   PrototypeToken,
-  // PrototypeTokenData,
   ShapeData,
+  BaseShapeData,
+  RectangleShapeData,
+  CircleShapeData,
+  EllipseShapeData,
+  PolygonShapeData,
   TextureData,
   TombstoneData,
 };

--- a/src/foundry/common/documents/token.d.mts
+++ b/src/foundry/common/documents/token.d.mts
@@ -168,12 +168,6 @@ declare namespace BaseToken {
     prependAdjective: fields.BooleanField;
 
     /**
-     * The token's texture on the canvas.
-     * @defaultValue `BaseToken.DEFAULT_ICON`
-     */
-    texture: TextureData<{ initial: () => typeof BaseToken.DEFAULT_ICON; wildcard: true }>;
-
-    /**
      * The width of the Token in grid units
      * @defaultValue `1`
      */
@@ -184,6 +178,21 @@ declare namespace BaseToken {
      * @defaultValue `1`
      */
     height: fields.NumberField<{ positive: true; initial: 1; label: "Height" }>;
+
+    /**
+     * The token's texture on the canvas.
+     * @defaultValue `BaseToken.DEFAULT_ICON`
+     */
+    texture: TextureData<{ initial: () => typeof BaseToken.DEFAULT_ICON; wildcard: true }>;
+
+    /**
+     * @defaultValue `CONST.TOKEN_HEXAGONAL_SHAPES.ELLIPSE_1`
+     */
+    // TODO: report undocumented
+    hexagonalShape: fields.NumberField<{
+      initial: typeof CONST.TOKEN_HEXAGONAL_SHAPES.ELLIPSE_1;
+      choices: CONST.TOKEN_HEXAGONAL_SHAPES[];
+    }>;
 
     /**
      * Prevent the Token image from visually rotating?
@@ -393,6 +402,63 @@ declare namespace BaseToken {
         validate: () => void;
       }
     >;
+
+    /**
+     * @defaultValue see properties
+     */
+    // TODO: report undocumented
+    occludable: fields.SchemaField<{
+      /**
+       * @defaultValue `0`
+       */
+      radius: fields.NumberField<{ nullable: false; min: 0; step: 0.01; initial: 0 }>;
+    }>;
+
+    /**
+     * @defaultValue see properties
+     */
+    // TODO: report undocumented
+    ring: fields.SchemaField<{
+      /**
+       * @defaultValue `false`
+       */
+      enabled: fields.BooleanField;
+
+      /**
+       * @defaultValue see properties
+       */
+      colors: fields.SchemaField<{
+        /**
+         * @defaultValue `null`
+         */
+        ring: fields.ColorField;
+
+        /**
+         * @defaultValue `null`
+         */
+        background: fields.ColorField;
+      }>;
+
+      /**
+       * @defaultValue `1`
+       */
+      effects: fields.NumberField<{ initial: 1; min: 0; max: 8388607; integer: true }>;
+
+      /**
+       * @defaultValue see properties
+       */
+      subject: fields.SchemaField<{
+        /**
+         * @defaultValue `1`
+         */
+        scale: fields.NumberField<{ initial: 1; min: 0.5 }>;
+
+        /**
+         * @defaultValue `null`
+         */
+        texture: fields.FilePathField<{ categories: ["IMAGE"] }>;
+      }>;
+    }>;
 
     /**
      * An object of optional key/value flags


### PR DESCRIPTION
- **V12/client esm (#2575)**
- **Updated DocumentSheetV2 to use a generic on the Document**
- **Adjusted types in HandlebarsApplicationMixin**
- **Created blank classes for missing files**
- **common.constants (#2584)**
- **Synching updates to v11/data-models (#2589)**
- **first pass at prosemirror schema (#2557) (#2590)**
- **Removed deprecated field functions**
- **Fix HandlebarsApplicationMixin constructor and add regression test**
- **Foundry Custom Elements and Fields**
- **Added DialogV2 alongside tests**
- **Moved all types and interfaces in HandlebarsApplicationMixin to namespace**
- **Updates `string.mjs`, `number.mjs`, and `math.mjs` (#2592)**
- **Migrated common/module.mjs to client-esm/client.mjs**
- **Add Type Data to V12 (#2617)**
- **Match generic letter to source v12 (#2622)**
- **common.utils.colors (#2623)**
- **Geometry to v12 (#2624)**
- **getting rid of symlink#2619 (#2625)**
- **Delete the tests/node_modules/@types/fvtt symlink**
- ** Update logging.mjs #2608 (#2628)**
- **V12/dependencies (#2633)**
- **Canvas/edges (#2631)**
- ** Update iterable-weak-set.mjs #2607 (#2630)**
- **update-helpers#2604 (#2627)**
- **Adjusted Document helper types (#2636)**
- **Client-esm/Canvas/Sources (#2635)**
- ** Update iterable-weak-map.mjs #2606 (#2642)**
- ** Update http.mjs #2605 (#2643)**
- **V12/backend (#2648)**
- **client-esm.helpers.compendium-art (#2616)**
- **Added DocumentSocketResponse (#2657)**
- **V12/329 (#2656)**
- **Make @types/fvtt-types a devDependency only**
- **v12/application.dice.roll-resolver (#2653)**
- **V12/common.utils.bitmask-wordtree-stringtree (#2651)**
- **Partial audit and refactor of ApplicationV2**
- **Fix all re-exports**
- **Add a tsconfig.eslint.json to tests**
- **Simplify usage of PointEffectSourceMixin**
- **Audited use of .mjs vs. .mts vs. .d.mts in files (#2659)**
- **Add unexported types matching Foundry for reference**
- **Updated appv2 _types (#2672)**
- **Make  and  optional in**
- **added apps files (#2655)**
- **Audit Application V2 Again (#2684)**
- **Use AnyMutableObject**
- **Remove extends Record<string, HandlebarsApplicationMixin.HandlebarsTemplatePart> from PARTS**
- **Updates foundry.dice to v12 (#2660)**
- **Updates dragdrop.js (#2692)**
- **Updates client ChatMessage. (#2695)**
- **Update `ActiveEffect` to v12 (#2697)**
- **Updates TokenDocument to v12 (#2723)**
- **Update common/types.d.mts for v12 (#2600)**
- **Lint fixes**
- **Updates User, RollTable, Setting and PlaylistSound to v12 (#2724)**
- **smaa (#2654)**
- **Fix for new BooleanField({ label: ... })**
- **Updated ClientDocument and TextEditor to v12 (#2729)**
- **updated journal entry (#2733)**
- **V12/embedded collection (#2735)**
- **V12/documents/journal entry page (#2737)**
- **Make RenderContext the first generic parameter in ApplicationV2**
- **Removed CanvasDocument event handlers (#2738)**
- **Updated Document to v12 (#2742)**
- **Folder, FogExploration, and DrawingDocument (#2741)**
- **V12/documents/cards (#2744)**
- **documents/adventure.js (#2745)**
- **playlist, measured template (#2740)**
- **Add schemaVersion to all BaseDocuments' metadata (#2746)**
- **Adjusted return type of ActiveEffect.fromStatusEffect**
- **Formdataextended (#2750)**
- **workers (#2772)**
- **V12/client/core/keybindings, keyboard, issues, socket, documentindex (#2771)**
- **Linting, Roll Migration (#2774)**
- **V12/prosemirror to common (#2739)**
- **Replaced all instances of Document<any, any, any> with Document.Any (#2779)**
- **ui/Filepicker and Dialog (#2749)**
- **More type fixes (#2781)**
- **Remove document modification context (#2775)**
- **Remaining lint errors**
- **Fixed vitest issue**
- **Adds BaseGrid to common.**
- **Adds Grid#Gridless to common.**
- **Updates interface names to be simpler.**
- **Updates Grid#Gridless to extend interfaces for ease of subclassing.**
- **Adds Grid#HexagonalGrid to common.**
- **Adds Grid#SquareGrid to common.**
- **Adds Grid#GridHex to common.**
- **Adds grid exports to common.**
- **Remove exports from the package.json**
- **V12/common/packages (#2789)**
- **v12.331.0-beta**
- **Adds a helper type for grid Dimensions.**
- **Removes ?: from InexactPartial.**
- **Updates actor.d.mts.**
- **Updates macro.d.ts.**
- **Updates item.d.ts.**
- **Updates combat.d.ts.**
- **Updates actor-delta.d.ts.**
- **Fixes some issues.**
- **Changes Document to Document.Any.**
- **Fixes issues with pr.**
- **Fix Actor circularity by trivializing the string constraint on TypeNames**
- **Various compilation fixes**
- **Rename AnyDocumentConstructor to AnyDocument for better error messages**
- **Fix issue where `PlaceableObject#sheet` was assumed to not include ApplicationV2**
- **Improve CONFIG slightly**
- **Deprecate more globals**
- **Remove overloads for shorter errors**
- **Stymy some circularities**
- **Freshen up Mixin and Internal logic**
- **Minor TypeDataModel fix**
- **Increase circularity detection and minor fixes elsewhere**
- **Update TypeScript version**
- **Fix initialized type in ForeignDocumentField**
- **Update to @typescript-eslint/no-empty-object-type rule**
- **Allow only DataModel constructors rather than instances**
- **Minor settings updates**
- **ActorSheetV2**
- **ItemSheetV2**
- **Minor updates**
- **Clean ESLint errors**
- **Get rid of usages of deprecated ConfiguredDocumentInstance**
- **Fix a second Folder circularity**
- **feat: update common/data/data.mjs to 331**
