### PR TITLE
Combatant to v12

### DIFF
--- a/src/foundry/client/data/documents/combatant.d.mts
+++ b/src/foundry/client/data/documents/combatant.d.mts
@@ -1,3 +1,4 @@
+import type { ValueOf } from "../../../../types/utils.d.mts";
 import type Document from "../../../common/abstract/document.d.mts";
 import type { DocumentDatabaseOperations } from "../../../common/abstract/document.d.mts";
 
@@ -37,6 +38,11 @@ declare global {
 
     /** This is treated as a non-player combatant if it has no associated actor and no player users who can control it */
     get isNPC(): boolean;
+
+    /**
+     * Eschew `ClientDocument`'s redirection to `Combat#permission` in favor of special ownership determination.
+     */
+    override get permission(): ValueOf<typeof CONST.DOCUMENT_OWNERSHIP_LEVELS>;
 
     override get visible(): boolean;
 

--- a/src/foundry/client/data/documents/combatant.d.mts
+++ b/src/foundry/client/data/documents/combatant.d.mts
@@ -6,7 +6,13 @@ declare global {
     type ConfiguredClass = Document.ConfiguredClassForName<"Combatant">;
     type ConfiguredInstance = Document.ConfiguredInstanceForName<"Combatant">;
 
-    interface DatabaseOperations extends DocumentDatabaseOperations<Combatant> {}
+    interface DatabaseOperations
+      extends DocumentDatabaseOperations<
+        Combatant,
+        { combatTurn: number },
+        { combatTurn: number },
+        { combatTurn: number }
+      > {}
   }
 
   /**


### PR DESCRIPTION
While Combatant does override the various `operation` calls, I've left those out for performance reasons since they usually cause problems and there's no signature changes. The relevant impact has been added to the DatabaseOperations interface at the top.

Closes #2704