### PR TITLE
Updated `client/data/abstract`

### DIFF
--- a/src/foundry/client/data/abstract/document-collection.d.mts
+++ b/src/foundry/client/data/abstract/document-collection.d.mts
@@ -178,9 +178,9 @@ declare global {
      * @param operation - Database operation details
      * @param user      - The User who performed the operation
      */
-    _onModifyContents<T extends foundry.abstract.Document.Any, A extends DatabaseAction>(
+    _onModifyContents<A extends DatabaseAction>(
       action: A,
-      documents: T[],
+      documents: InstanceType<T>[],
       result: AnyObject[] | readonly string[],
       operation: DatabaseOperationMap[A],
       user: User.ConfiguredInstance,

--- a/src/foundry/client/data/abstract/document-collection.d.mts
+++ b/src/foundry/client/data/abstract/document-collection.d.mts
@@ -1,4 +1,5 @@
 import type { DeepPartial, InexactPartial } from "../../../../types/utils.d.mts";
+import type { DatabaseAction, DatabaseOperationMap } from "../../../common/abstract/_types.d.mts";
 import type Document from "../../../common/abstract/document.d.mts";
 
 declare global {
@@ -120,9 +121,9 @@ declare global {
      * @returns The dot-delimited property paths of searchable fields
      */
     // TODO: Could significantly improve this with type defs
-    static getSearchableFields(
-      documentName: foundry.CONST.DOCUMENT_TYPES,
-      documentSubtype?: string,
+    static getSearchableFields<T extends foundry.abstract.Document.Type>(
+      documentName: T,
+      documentSubtype?: foundry.abstract.Document.SubTypesOf<T>,
       isEmbedded?: boolean,
     ): Set<string>;
 
@@ -168,6 +169,22 @@ declare global {
       condition?: ((obj: Document.ToConfiguredStored<T>) => boolean) | null,
       options?: Document.OnUpdateOptions<T["metadata"]["name"]>,
     ): ReturnType<this["documentClass"]["updateDocuments"]>;
+
+    /**
+     * Follow-up actions to take when a database operation modifies Documents in this DocumentCollection.
+     * @param action    - The database action performed
+     * @param documents - The array of modified Documents
+     * @param result    - The result of the database operation
+     * @param operation - Database operation details
+     * @param user      - The User who performed the operation
+     */
+    _onModifyContents<T extends foundry.abstract.Document.Any, A extends DatabaseAction>(
+      action: A,
+      documents: T[],
+      result: Record<string, unknown>[] | string[],
+      operation: DatabaseOperationMap[A],
+      user: User.ConfiguredInstance,
+    ): void;
   }
 
   namespace DocumentCollection {

--- a/src/foundry/client/data/abstract/document-collection.d.mts
+++ b/src/foundry/client/data/abstract/document-collection.d.mts
@@ -1,4 +1,4 @@
-import type { DeepPartial, InexactPartial } from "../../../../types/utils.d.mts";
+import type { AnyObject, DeepPartial, InexactPartial } from "../../../../types/utils.d.mts";
 import type { DatabaseAction, DatabaseOperationMap } from "../../../common/abstract/_types.d.mts";
 import type Document from "../../../common/abstract/document.d.mts";
 
@@ -181,7 +181,7 @@ declare global {
     _onModifyContents<T extends foundry.abstract.Document.Any, A extends DatabaseAction>(
       action: A,
       documents: T[],
-      result: Record<string, unknown>[] | string[],
+      result: AnyObject[] | readonly string[],
       operation: DatabaseOperationMap[A],
       user: User.ConfiguredInstance,
     ): void;

--- a/src/foundry/client/data/abstract/world-collection.d.mts
+++ b/src/foundry/client/data/abstract/world-collection.d.mts
@@ -133,36 +133,30 @@ declare global {
       StateOpt extends boolean = false,
     > {
       /**
-       * Add flags which track the import source
-       * @defaultValue `false`
-       */
-      addFlags: boolean;
-
-      /**
        * Clear the currently assigned folder
-       * @defaultValue
+       * @defaultValue `false`
        */
       clearFolder: FolderOpt;
 
       /**
-       * Clear the currently assigned folder and sort order
+       * Clear the currently sort order
        * @defaultValue `true`
        */
       clearSort: SortOpt;
 
       /**
-       * Clear document permissions
+       * Clear Document ownership
        * @defaultValue `true`
        */
       clearOwnership: OwnershipOpt;
 
       /**
-       * Retain the Document id from the source Compendium
+       * Retain the Document ID from the source Compendium
        * @defaultValue `false`
        */
       keepId: IdOpt;
 
-      /** @remarks used by Scene#fromCompendium */
+      /** @remarks used by Scenes#fromCompendium */
       clearState: StateOpt;
     }
   }

--- a/src/foundry/common/abstract/socket.d.mts
+++ b/src/foundry/common/abstract/socket.d.mts
@@ -1,4 +1,4 @@
-import type { DocumentType } from "../../../types/helperTypes.d.mts";
+import type { AnyObject } from "../../../types/utils.d.mts";
 import type { DatabaseAction, DatabaseOperation, DocumentSocketRequest } from "./_types.d.mts";
 
 /**
@@ -12,7 +12,7 @@ declare class DocumentSocketResponse<Action extends DatabaseAction> {
   constructor(request: DocumentSocketRequest<Action>);
 
   /** The type of Document being transacted. */
-  type: DocumentType | undefined;
+  type: foundry.abstract.Document.Type | undefined;
 
   /** The database action that was performed. */
   action: Action | undefined;
@@ -27,7 +27,7 @@ declare class DocumentSocketResponse<Action extends DatabaseAction> {
   userId: string | undefined;
 
   /** The result of the request. Present if successful */
-  result: Record<string, unknown>[] | string[] | undefined;
+  result: AnyObject[] | readonly string[] | undefined;
 
   /** An error that occurred. Present if unsuccessful */
   error: Error | undefined;


### PR DESCRIPTION
- DirectoryCollectionMixin did not need updates
- Foundry formally implemented `FromCompendiumOptions` as a typedef themselves, but we had already abstracted it out with a matching name.

Closes #2874 