### PR TITLE
Update `client/pixi/layers/**`

### DIFF
--- a/src/foundry/client/config.d.mts
+++ b/src/foundry/client/config.d.mts
@@ -2663,6 +2663,7 @@ declare global {
         weather: LayerDefinition<typeof WeatherEffects>;
 
         /** @defaultValue `{ layerClass: GridLayer, group: "interface" }` */
+        // @ts-expect-error see https://github.com/foundryvtt/foundryvtt/issues/11794
         grid: LayerDefinition<typeof GridLayer>;
 
         /** @defaultValue `{ layerClass: DrawingsLayer, group: "interface" }` */

--- a/src/foundry/client/config.d.mts
+++ b/src/foundry/client/config.d.mts
@@ -2663,7 +2663,6 @@ declare global {
         weather: LayerDefinition<typeof WeatherEffects>;
 
         /** @defaultValue `{ layerClass: GridLayer, group: "interface" }` */
-        // @ts-expect-error see https://github.com/foundryvtt/foundryvtt/issues/11794
         grid: LayerDefinition<typeof GridLayer>;
 
         /** @defaultValue `{ layerClass: DrawingsLayer, group: "interface" }` */

--- a/src/foundry/client/hooks.d.mts
+++ b/src/foundry/client/hooks.d.mts
@@ -478,7 +478,7 @@ declare global {
        */
       initializeWeatherEffects: (
         weatherEffect: WeatherEffects,
-        weatherEffectsConfig?: WeatherLayer.WeatherEffectsConfig | null,
+        weatherEffectsConfig?: WeatherEffects.WeatherEffectsConfig | null,
       ) => void;
 
       /** Adventure */

--- a/src/foundry/client/pixi/core/containers/full-canvas-container.d.mts
+++ b/src/foundry/client/pixi/core/containers/full-canvas-container.d.mts
@@ -15,12 +15,14 @@ declare global {
    * @param Base - Any PIXI DisplayObject subclass
    * @returns The decorated subclass with full canvas bounds
    */
-  function FullCanvasObjectMixin<BaseClass extends FullCanvasObjectMixin.BaseClass>(
+  function FullCanvasObjectMixin<BaseClass extends FullCanvasObject.BaseClass>(
     Base: BaseClass,
   ): Mixin<typeof FullCanvasObject, BaseClass>;
 
-  namespace FullCanvasObjectMixin {
-    type BaseClass = typeof AnyDisplayObject;
+  namespace FullCanvasObject {
+    type AnyConstructor = typeof AnyFullCanvasObject;
+
+    type BaseClass = PIXI.DisplayObject.AnyConstructor;
   }
 
   /**
@@ -30,6 +32,6 @@ declare global {
   class FullCanvasContainer extends FullCanvasObjectMixin(PIXI.Container) {}
 }
 
-declare abstract class AnyDisplayObject extends PIXI.DisplayObject {
+declare abstract class AnyFullCanvasObject extends FullCanvasObject {
   constructor(arg0: never, ...args: never[]);
 }

--- a/src/foundry/client/pixi/core/interaction/control-icon.d.mts
+++ b/src/foundry/client/pixi/core/interaction/control-icon.d.mts
@@ -37,7 +37,7 @@ declare global {
     /**
      * @defaultValue `static`
      */
-    override eventMode: "none" | "passive" | "auto" | "static" | "dynamic";
+    override eventMode: PIXI.EventMode;
 
     /**
      * @defaultValue `false`

--- a/src/foundry/client/pixi/layers/base/canvas-layer.d.mts
+++ b/src/foundry/client/pixi/layers/base/canvas-layer.d.mts
@@ -1,10 +1,17 @@
 export {};
 
+declare abstract class AnyCanvasLayer extends CanvasLayer {
+  constructor(arg0: never, ...args: never[]);
+}
+
 declare global {
   /**
    * An abstract pattern for primary layers of the game canvas to implement
    */
-  abstract class CanvasLayer extends PIXI.Container {
+  abstract class CanvasLayer<
+    DrawOptions extends CanvasLayer.DrawOptions = CanvasLayer.DrawOptions,
+    TearDownOptions extends CanvasLayer.TearDownOptions = CanvasLayer.TearDownOptions,
+  > extends PIXI.Container {
     constructor();
 
     /**
@@ -45,28 +52,30 @@ declare global {
      * The Promise resolves to the drawn layer once its contents are successfully rendered.
      * @param options - Options which configure how the layer is drawn
      */
-    draw(options?: Record<string, unknown>): Promise<this>;
+    draw(options?: DrawOptions): Promise<this>;
 
     /**
      * The inner _draw method which must be defined by each CanvasLayer subclass.
      * @param options - Options which configure how the layer is drawn
      */
-    protected abstract _draw(options?: Record<string, unknown>): Promise<void>;
+    protected abstract _draw(options?: DrawOptions): Promise<void>;
 
     /**
      * Deconstruct data used in the current layer in preparation to re-draw the canvas
      * @param options - Options which configure how the layer is deconstructed
      * @remarks ControlsLayer returns void. See https://gitlab.com/foundrynet/foundryvtt/-/issues/6939
      */
-    tearDown(options?: Record<string, unknown>): Promise<this | void>;
+    tearDown(options?: TearDownOptions): Promise<this | void>;
 
     /**
      * The inner _tearDown method which may be customized by each CanvasLayer subclass.
      * @param options - Options which configure how the layer is deconstructed
      */
-    protected _tearDown(options?: Record<string, unknown>): Promise<void>;
+    protected _tearDown(options?: TearDownOptions): Promise<void>;
   }
   namespace CanvasLayer {
+    type AnyConstructor = typeof AnyCanvasLayer;
+
     interface LayerOptions {
       /**
        * The layer name by which the instance is referenced within the Canvas
@@ -75,5 +84,11 @@ declare global {
 
       baseClass: typeof CanvasLayer;
     }
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+    interface DrawOptions {}
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+    interface TearDownOptions {}
   }
 }

--- a/src/foundry/client/pixi/layers/base/canvas-layer.d.mts
+++ b/src/foundry/client/pixi/layers/base/canvas-layer.d.mts
@@ -1,9 +1,5 @@
 export {};
 
-declare abstract class AnyCanvasLayer extends CanvasLayer {
-  constructor(arg0: never, ...args: never[]);
-}
-
 declare global {
   /**
    * An abstract pattern for primary layers of the game canvas to implement
@@ -73,6 +69,7 @@ declare global {
      */
     protected _tearDown(options?: TearDownOptions): Promise<void>;
   }
+
   namespace CanvasLayer {
     type AnyConstructor = typeof AnyCanvasLayer;
 
@@ -91,4 +88,8 @@ declare global {
     // eslint-disable-next-line @typescript-eslint/no-empty-object-type
     interface TearDownOptions {}
   }
+}
+
+declare abstract class AnyCanvasLayer extends CanvasLayer {
+  constructor(arg0: never, ...args: never[]);
 }

--- a/src/foundry/client/pixi/layers/base/interaction-layer.d.mts
+++ b/src/foundry/client/pixi/layers/base/interaction-layer.d.mts
@@ -25,6 +25,13 @@ declare global {
 
     /**
      * Customize behaviors of this CanvasLayer by modifying some behaviors at a class level.
+     * @defaultValue
+     * ```js
+     * {
+     *   baseClass: InteractionLayer,
+     *   zIndex: 0,
+     * }
+     * ```
      */
     static get layerOptions(): InteractionLayer.LayerOptions;
 

--- a/src/foundry/client/pixi/layers/base/interaction-layer.d.mts
+++ b/src/foundry/client/pixi/layers/base/interaction-layer.d.mts
@@ -1,10 +1,17 @@
 import type { InexactPartial } from "../../../../../types/utils.d.mts";
 
+declare abstract class AnyInteractionLayer extends InteractionLayer {
+  constructor(arg0: never, ...args: never[]);
+}
+
 declare global {
   /**
    * A subclass of CanvasLayer which provides support for user interaction with its contained objects.
    */
-  class InteractionLayer extends CanvasLayer {
+  class InteractionLayer<
+    DrawOptions extends CanvasLayer.DrawOptions = InteractionLayer.DrawOptions,
+    TearDownOptions extends CanvasLayer.TearDownOptions = CanvasLayer.TearDownOptions,
+  > extends CanvasLayer<DrawOptions, TearDownOptions> {
     /**
      * Is this layer currently active
      */
@@ -50,7 +57,7 @@ declare global {
      */
     protected _deactivate(): void;
 
-    protected override _draw(options?: Record<string, unknown>): Promise<void>;
+    protected override _draw(options?: DrawOptions): Promise<void>;
 
     /**
      * Get the zIndex that should be used for ordering this layer vertically relative to others in the same Container.
@@ -71,12 +78,12 @@ declare global {
      */
     protected _onClickLeft2(event: PIXI.FederatedEvent): void;
 
-  /**
-   * Does the User have permission to left-click drag on the Canvas?
-   * @param user  - The User performing the action.
-   * @param event - The event object.
-   */
-  protected _canDragLeftStart(user: User.ConfiguredInstance, event: PIXI.FederatedEvent): boolean;
+    /**
+     * Does the User have permission to left-click drag on the Canvas?
+     * @param user  - The User performing the action.
+     * @param event - The event object.
+     */
+    protected _canDragLeftStart(user: User.ConfiguredInstance, event: PIXI.FederatedEvent): boolean;
 
     /**
      * Start a left-click drag workflow originating from the Canvas stage.
@@ -130,10 +137,16 @@ declare global {
   }
 
   namespace InteractionLayer {
+    type AnyConstructor = typeof AnyInteractionLayer;
+
     interface LayerOptions extends CanvasLayer.LayerOptions {
       zIndex: number;
 
       baseClass: typeof InteractionLayer;
     }
+
+    interface DrawOptions extends CanvasLayer.DrawOptions {}
+
+    interface TearDownOptions extends CanvasLayer.TearDownOptions {}
   }
 }

--- a/src/foundry/client/pixi/layers/base/interaction-layer.d.mts
+++ b/src/foundry/client/pixi/layers/base/interaction-layer.d.mts
@@ -1,15 +1,11 @@
-import type { InexactPartial } from "../../../../../types/utils.d.mts";
-
-declare abstract class AnyInteractionLayer extends InteractionLayer {
-  constructor(arg0: never, ...args: never[]);
-}
+import type { NullishProps } from "../../../../../types/utils.d.mts";
 
 declare global {
   /**
    * A subclass of CanvasLayer which provides support for user interaction with its contained objects.
    */
   class InteractionLayer<
-    DrawOptions extends CanvasLayer.DrawOptions = InteractionLayer.DrawOptions,
+    DrawOptions extends InteractionLayer.DrawOptions = InteractionLayer.DrawOptions,
     TearDownOptions extends CanvasLayer.TearDownOptions = CanvasLayer.TearDownOptions,
   > extends CanvasLayer<DrawOptions, TearDownOptions> {
     /**
@@ -23,6 +19,11 @@ declare global {
     override options: InteractionLayer.LayerOptions;
 
     /**
+     * @defaultValue `"passive"`
+     */
+    override eventMode: PIXI.EventMode;
+
+    /**
      * Customize behaviors of this CanvasLayer by modifying some behaviors at a class level.
      */
     static get layerOptions(): InteractionLayer.LayerOptions;
@@ -33,7 +34,7 @@ declare global {
      * @returns - The layer instance, now activated
      */
     activate(
-      options?: InexactPartial<{
+      options?: NullishProps<{
         /**
          * A specific tool in the control palette to set as active
          */
@@ -146,7 +147,9 @@ declare global {
     }
 
     interface DrawOptions extends CanvasLayer.DrawOptions {}
-
-    interface TearDownOptions extends CanvasLayer.TearDownOptions {}
   }
+}
+
+declare abstract class AnyInteractionLayer extends InteractionLayer {
+  constructor(arg0: never, ...args: never[]);
 }

--- a/src/foundry/client/pixi/layers/base/placeables-layer.d.mts
+++ b/src/foundry/client/pixi/layers/base/placeables-layer.d.mts
@@ -213,7 +213,6 @@ declare global {
      *                  (default: `{}`)
      * @returns The number of PlaceableObject instances which were released
      */
-    //todo: audit release options
     releaseAll(options?: PlaceableObject.ReleaseOptions): number;
 
     /**

--- a/src/foundry/client/pixi/layers/base/placeables-layer.d.mts
+++ b/src/foundry/client/pixi/layers/base/placeables-layer.d.mts
@@ -1,3 +1,4 @@
+import type { ArrayOverlaps } from "../../../../../types/helperTypes.d.mts";
 import type { ConstructorOf, InexactPartial, NullishProps, ValueOf } from "../../../../../types/utils.d.mts";
 import type Document from "../../../../common/abstract/document.d.mts";
 import type EmbeddedCollection from "../../../../common/abstract/embedded-collection.d.mts";
@@ -46,15 +47,13 @@ declare global {
      * Keep track of an object copied with CTRL+C which can be pasted later
      * @defaultValue `[]`
      */
-    protected _copy: ConcretePlaceableOrPlaceableObject<
-      InstanceType<Document.ConfiguredObjectClassForName<DocumentName>>
-    >[];
+    protected _copy: ConcretePlaceableOrPlaceableObject<Document.ConfiguredObjectInstanceForName<DocumentName>>[];
 
     /**
      * A Quadtree which partitions and organizes Walls into quadrants for efficient target identification.
      */
     quadtree: Quadtree<
-      ConcretePlaceableOrPlaceableObject<InstanceType<Document.ConfiguredObjectClassForName<DocumentName>>>
+      ConcretePlaceableOrPlaceableObject<Document.ConfiguredObjectInstanceForName<DocumentName>>
     > | null;
 
     /**
@@ -92,7 +91,7 @@ declare global {
      * Obtain a reference to the Collection of embedded Document instances within the currently viewed Scene
      */
     get documentCollection(): EmbeddedCollection<
-      InstanceType<Document.ConfiguredClassForName<DocumentName>>,
+      Document.ConfiguredInstanceForName<DocumentName>,
       Scene.ConfiguredInstance
     > | null;
 
@@ -105,17 +104,17 @@ declare global {
      * If objects on this PlaceablesLayer have a HUD UI, provide a reference to its instance
      * @remarks Returns `null` unless overridden
      */
-    get hud(): BasePlaceableHUD<InstanceType<Document.ConfiguredObjectClassForName<DocumentName>>> | null;
+    get hud(): BasePlaceableHUD<Document.ConfiguredObjectInstanceForName<DocumentName>> | null;
 
     /**
      * A convenience method for accessing the placeable object instances contained in this layer
      */
-    get placeables(): InstanceType<Document.ConfiguredObjectClassForName<DocumentName>>[];
+    get placeables(): Document.ConfiguredObjectInstanceForName<DocumentName>[];
 
     /**
      * An Array of placeable objects in this layer which have the _controlled attribute
      */
-    get controlled(): InstanceType<Document.ConfiguredObjectClassForName<DocumentName>>[];
+    get controlled(): Document.ConfiguredObjectInstanceForName<DocumentName>[];
 
     /**
      * Iterates over placeable objects that are eligible for control/select.
@@ -176,8 +175,8 @@ declare global {
      * @param document - The Document instance used to create the placeable object
      */
     createObject(
-      document: InstanceType<Document.ConfiguredClassForName<DocumentName>>,
-    ): InstanceType<Document.ConfiguredObjectClassForName<DocumentName>> | null;
+      document: Document.ConfiguredInstanceForName<DocumentName>,
+    ): Document.ConfiguredObjectInstanceForName<DocumentName>;
 
     override _tearDown(options?: TearDownOptions): Promise<void>;
 
@@ -196,7 +195,7 @@ declare global {
      * @param objectId - The ID of the contained object to retrieve
      * @returns The object instance, or undefined
      */
-    get(objectId: string): InstanceType<Document.ConfiguredObjectClassForName<DocumentName>> | undefined;
+    get(objectId: string): Document.ConfiguredObjectInstanceForName<DocumentName> | undefined;
 
     /**
      * Acquire control over all PlaceableObject instances which are visible and controllable within the layer.
@@ -205,9 +204,7 @@ declare global {
      *                  (default: `{}`)
      * @returns An array of objects that were controlled
      */
-    controlAll(
-      options?: PlaceableObject.ControlOptions,
-    ): InstanceType<Document.ConfiguredObjectClassForName<DocumentName>>[];
+    controlAll(options?: PlaceableObject.ControlOptions): Document.ConfiguredObjectInstanceForName<DocumentName>[];
 
     /**
      * Release all controlled PlaceableObject instance from this layer.
@@ -230,7 +227,7 @@ declare global {
      */
     rotateMany(
       options?: InexactPartial<RotationOptions>,
-    ): Promise<InstanceType<Document.ConfiguredObjectClassForName<DocumentName>>[]>;
+    ): Promise<Document.ConfiguredObjectInstanceForName<DocumentName>[]>;
 
     /**
      * Simultaneously move multiple PlaceableObjects via keyboard movement offsets.
@@ -243,7 +240,7 @@ declare global {
      */
     moveMany(
       options?: InexactPartial<MovementOptions>,
-    ): Promise<InstanceType<Document.ConfiguredObjectClassForName<DocumentName>>[]> | undefined;
+    ): Promise<Document.ConfiguredObjectInstanceForName<DocumentName>[]> | undefined;
 
     /**
      * An internal helper method to identify the array of PlaceableObjects which can be moved or rotated.
@@ -254,8 +251,8 @@ declare global {
      * @remarks Any non-array input for `ids` will default to using currently controlled objects,
      * allowing you to provide `true` to the includeLocked
      */
-    protected _getMovableObjects(
-      ids?: string[] | null,
+    protected _getMovableObjects<T>(
+      ids?: ArrayOverlaps<T, string>,
       includeLocked?: boolean,
     ): Document.ConfiguredObjectInstanceForName<DocumentName>[];
 
@@ -263,30 +260,29 @@ declare global {
      * Undo a change to the objects in this layer
      * This method is typically activated using CTRL+Z while the layer is active
      */
-    undoHistory(): Promise<InstanceType<Document.ConfiguredClassForName<DocumentName>>[]>;
+    undoHistory(): Promise<Document.ConfiguredInstanceForName<DocumentName>[]>;
 
     /**
      * A helper method to prompt for deletion of all PlaceableObject instances within the Scene
      * Renders a confirmation dialogue to confirm with the requester that all objects will be deleted
      * @returns An array of Document objects which were deleted by the operation
+     * @throws An error if the calling user is not a GM or Assistant GM
      */
-    deleteAll(): Promise<InstanceType<Document.ConfiguredClassForName<DocumentName>>[] | false | null>;
+    deleteAll(): Promise<undefined | false | null>;
 
     /**
      * Record a new CRUD event in the history log so that it can be undone later
      * @param type - The event type (create, update, delete)
      * @param data - The object data
+     * @throws An error if any of the objects in the `data` array lack an `_id` key
      */
-    storeHistory(
-      type: PlaceablesLayer.HistoryEventType,
-      data: InstanceType<Document.ConfiguredClassForName<DocumentName>>["_source"],
-    ): void;
+    storeHistory(type: PlaceablesLayer.HistoryEventType, data: Document.ConfiguredSourceForName<DocumentName>[]): void;
 
     /**
      * Copy currently controlled PlaceableObjects to a temporary Array, ready to paste back into the scene later
      * @returns The Array of copied PlaceableObject instances
      */
-    copyObjects(): InstanceType<Document.ConfiguredObjectClassForName<DocumentName>>[];
+    copyObjects(): Document.ConfiguredObjectInstanceForName<DocumentName>[];
 
     /**
      * Paste currently copied PlaceableObjects back to the layer by creating new copies
@@ -309,7 +305,7 @@ declare global {
          */
         snap: boolean;
       }>,
-    ): Promise<InstanceType<Document.ConfiguredClassForName<DocumentName>>[]>;
+    ): Promise<Document.ConfiguredInstanceForName<DocumentName>[]>;
 
     /**
      * Get the data of the copied object pasted at the position given by the offset.
@@ -343,39 +339,21 @@ declare global {
      * @returns A boolean for whether the controlled set was changed in the operation
      */
     selectObjects(
-      options?: InexactPartial<{
-        /**
-         * The top-left x-coordinate of the selection rectangle
-         */
-        x: number;
+      options?: InexactPartial<
+        Canvas.Rectangle & {
+          /**
+           * Optional arguments provided to any called release() method
+           * @defaultValue `{}`
+           */
+          releaseOptions: PlaceableObject.ReleaseOptions;
 
-        /**
-         * The top-left y-coordinate of the selection rectangle
-         */
-        y: number;
-
-        /**
-         * The width of the selection rectangle
-         */
-        width: number;
-
-        /**
-         * The height of the selection rectangle
-         */
-        height: number;
-
-        /**
-         * Optional arguments provided to any called release() method
-         * @defaultValue `{}`
-         */
-        releaseOptions: PlaceableObject.ReleaseOptions;
-
-        /**
-         * Optional arguments provided to any called control() method
-         * @defaultValue `{ releaseOthers: false }`
-         */
-        controlOptions: PlaceableObject.ControlOptions;
-      }>,
+          /**
+           * Optional arguments provided to any called control() method
+           * @defaultValue `{ releaseOthers: false }`
+           */
+          controlOptions: PlaceableObject.ControlOptions;
+        }
+      >,
       secondOptions?: NullishProps<{
         /**
          * Whether to release other selected objects.
@@ -394,16 +372,17 @@ declare global {
      * @param options        - Additional options passed to Document.update
      *                         (default: `{}`)
      * @returns An array of updated data once the operation is complete
+     * @throws An error if the `transformation` paramater is neither a function nor a plain object
      */
     updateAll(
       transformation:
         | ((
-            placeable: InstanceType<Document.ConfiguredObjectClassForName<DocumentName>>,
-          ) => Partial<InstanceType<Document.ConfiguredClassForName<DocumentName>>["_source"]>)
-        | Partial<InstanceType<Document.ConfiguredClassForName<DocumentName>>["_source"]>,
-      condition?: ((placeable: InstanceType<Document.ConfiguredObjectClassForName<DocumentName>>) => boolean) | null,
+            placeable: Document.ConfiguredObjectInstanceForName<DocumentName>,
+          ) => Partial<Document.ConfiguredSourceForName<DocumentName>>)
+        | Partial<Document.ConfiguredSourceForName<DocumentName>>,
+      condition?: ((placeable: Document.ConfiguredObjectInstanceForName<DocumentName>) => boolean) | null,
       options?: Document.OnUpdateOptions<DocumentName>,
-    ): Promise<Array<InstanceType<Document.ConfiguredClassForName<DocumentName>>>>;
+    ): Promise<Array<Document.ConfiguredInstanceForName<DocumentName>>>;
 
     /**
      * Get the world-transformed drop position.
@@ -453,7 +432,7 @@ declare global {
 
     protected override _canDragLeftStart(user: User.ConfiguredInstance, event: PIXI.FederatedEvent): boolean;
 
-    protected override _onDragLeftStart(event: PIXI.FederatedEvent): unknown;
+    protected override _onDragLeftStart(event: PIXI.FederatedEvent): void;
 
     protected override _onDragLeftMove(event: PIXI.FederatedEvent): void;
 
@@ -463,7 +442,7 @@ declare global {
 
     protected override _onClickRight(event: PIXI.FederatedEvent): void;
 
-    protected override _onMouseWheel(event: WheelEvent): void;
+    protected override _onMouseWheel(event: WheelEvent): ReturnType<this["rotateMany"]>;
 
     protected override _onDeleteKey(event: KeyboardEvent): Promise<void>;
 

--- a/src/foundry/client/pixi/layers/base/placeables-layer.d.mts
+++ b/src/foundry/client/pixi/layers/base/placeables-layer.d.mts
@@ -225,11 +225,10 @@ declare global {
      *                  (default: `{}`)
      * @returns An array of objects which were rotated
      * @throws An error if explicitly provided id is not valid
+     * @remarks Overload is necessary to ensure that one of `angle` or `delta` are numeric in `options`
      */
-    rotateMany(
-      /** @privateRemarks Can't be NullishProps because at least one of `angle` or `delta` must be numeric */
-      options?: InexactPartial<RotationOptions>,
-    ): Promise<Document.ConfiguredObjectInstanceForName<DocumentName>[]>;
+    rotateMany(options?: RotationOptionsWithAngle): Promise<Document.ConfiguredObjectInstanceForName<DocumentName>[]>;
+    rotateMany(options?: RotationOptionsWithDelta): Promise<Document.ConfiguredObjectInstanceForName<DocumentName>[]>;
 
     /**
      * Simultaneously move multiple PlaceableObjects via keyboard movement offsets.
@@ -241,7 +240,7 @@ declare global {
      * @throws An error if explicitly provided id is not valid
      */
     moveMany(
-      /** @privateRemarks can't be NullishProps becuase `dx` and `dy` must be in `[-1, 0, 1]` */
+      /** @remarks can't be NullishProps becuase `dx` and `dy` must be in `[-1, 0, 1]` */
       options?: InexactPartial<MovementOptions>,
     ): Promise<Document.ConfiguredObjectInstanceForName<DocumentName>[]> | undefined;
 
@@ -342,7 +341,10 @@ declare global {
      * @returns A boolean for whether the controlled set was changed in the operation
      */
     selectObjects(
-      /** @privateRemarks Can't be NullishProps because `PlaceableObject#control` accesses `controlOptions.releaseOthers` without further checks */
+      /**
+       * @remarks Can't be NullishProps because `controlOptions` is passed on to `PlaceableObject#control`
+       * which provides  a default of `{}` and then checks for `.releaseOthers` without further checks
+       * */
       options?: InexactPartial<
         Canvas.Rectangle & {
           /**
@@ -553,11 +555,11 @@ declare abstract class AnyPlaceablesLayer extends PlaceablesLayer<any> {
   constructor(arg0: never, ...args: never[]);
 }
 
-interface RotationOptions {
+interface RotationOptionsWithDelta {
   /**
    * A target angle of rotation (in degrees) where zero faces "south"
    */
-  angle: number;
+  angle?: number | null | undefined;
 
   /**
    * An incremental angle of rotation (in degrees)
@@ -567,18 +569,46 @@ interface RotationOptions {
   /**
    * Snap the resulting angle to a multiple of some increment (in degrees)
    */
-  snap: number;
+  snap?: number | null | undefined;
 
   /**
    * An Array of object IDs to target for rotation
    */
-  ids: string[];
+  ids?: string[] | null | undefined;
 
   /**
    * Rotate objects whose documents are locked?
    * @defaultValue `false`
    */
-  includeLocked: boolean;
+  includeLocked?: boolean | null | undefined;
+}
+
+interface RotationOptionsWithAngle {
+  /**
+   * A target angle of rotation (in degrees) where zero faces "south"
+   */
+  angle: number;
+
+  /**
+   * An incremental angle of rotation (in degrees)
+   */
+  delta?: number | null | undefined;
+
+  /**
+   * Snap the resulting angle to a multiple of some increment (in degrees)
+   */
+  snap?: number | null | undefined;
+
+  /**
+   * An Array of object IDs to target for rotation
+   */
+  ids?: string[] | null | undefined;
+
+  /**
+   * Rotate objects whose documents are locked?
+   * @defaultValue `false`
+   */
+  includeLocked?: boolean | null | undefined;
 }
 
 interface MovementOptions {

--- a/src/foundry/client/pixi/layers/base/placeables-layer.d.mts
+++ b/src/foundry/client/pixi/layers/base/placeables-layer.d.mts
@@ -168,7 +168,7 @@ declare global {
       | Exclude<this["documentCollection"], null>
       | InstanceType<Document.ConfiguredClassForName<DocumentName>>[];
 
-    override _draw(options?: DrawOptions): Promise<void>;
+    protected override _draw(options?: DrawOptions): Promise<void>;
 
     /**
      * Draw a single placeable object
@@ -178,11 +178,11 @@ declare global {
       document: Document.ConfiguredInstanceForName<DocumentName>,
     ): Document.ConfiguredObjectInstanceForName<DocumentName>;
 
-    override _tearDown(options?: TearDownOptions): Promise<void>;
+    protected override _tearDown(options?: TearDownOptions): Promise<void>;
 
-    override _activate(): void;
+    protected override _activate(): void;
 
-    override _deactivate(): void;
+    protected override _deactivate(): void;
 
     /**
      * Clear the contents of the preview container, restoring visibility of original (non-preview) objects.
@@ -213,6 +213,7 @@ declare global {
      *                  (default: `{}`)
      * @returns The number of PlaceableObject instances which were released
      */
+    //todo: audit release options
     releaseAll(options?: PlaceableObject.ReleaseOptions): number;
 
     /**
@@ -226,6 +227,7 @@ declare global {
      * @throws An error if explicitly provided id is not valid
      */
     rotateMany(
+      /** @privateRemarks Can't be NullishProps because at least one of `angle` or `delta` must be numeric */
       options?: InexactPartial<RotationOptions>,
     ): Promise<Document.ConfiguredObjectInstanceForName<DocumentName>[]>;
 
@@ -239,6 +241,7 @@ declare global {
      * @throws An error if explicitly provided id is not valid
      */
     moveMany(
+      /** @privateRemarks can't be NullishProps becuase `dx` and `dy` must be in `[-1, 0, 1]` */
       options?: InexactPartial<MovementOptions>,
     ): Promise<Document.ConfiguredObjectInstanceForName<DocumentName>[]> | undefined;
 
@@ -339,6 +342,7 @@ declare global {
      * @returns A boolean for whether the controlled set was changed in the operation
      */
     selectObjects(
+      /** @privateRemarks Can't be NullishProps because `PlaceableObject#control` accesses `controlOptions.releaseOthers` without further checks */
       options?: InexactPartial<
         Canvas.Rectangle & {
           /**
@@ -406,7 +410,7 @@ declare global {
      * @returns The created preview object
      */
     protected _createPreview(
-      createData: InstanceType<Document.ConfiguredClassForName<DocumentName>>["_source"],
+      createData: Document.ConfiguredSourceForName<DocumentName>,
       options?: NullishProps<{
         /**
          * Render the preview object config sheet?
@@ -426,7 +430,7 @@ declare global {
          */
         left: number;
       }>,
-    ): Promise<DocumentName>;
+    ): Promise<Document.ConfiguredObjectInstanceForName<DocumentName>>;
 
     protected override _onClickLeft(event: PIXI.FederatedEvent): void;
 

--- a/src/foundry/client/pixi/layers/base/placeables-layer.d.mts
+++ b/src/foundry/client/pixi/layers/base/placeables-layer.d.mts
@@ -62,6 +62,19 @@ declare global {
      */
     override options: PlaceablesLayer.LayerOptions.Any;
 
+    /**
+     * @defaultValue
+     * ```js
+     * foundry.utils.mergeObject(super.layerOptions, {
+     *   baseClass: PlaceablesLayer,
+     *   controllableObjects: false,
+     *   rotatableObjects: false,
+     *   confirmDeleteKey: false,
+     *   objectClass: CONFIG[this.documentName]?.objectClass,
+     *   quadtree: true,
+     * }
+     * ```
+     */
     static override get layerOptions(): PlaceablesLayer.LayerOptions.Any;
 
     /**
@@ -244,7 +257,7 @@ declare global {
     protected _getMovableObjects(
       ids?: string[] | null,
       includeLocked?: boolean,
-    ): Document.ConfiguredObjectInstanceForName<DocumentName>;
+    ): Document.ConfiguredObjectInstanceForName<DocumentName>[];
 
     /**
      * Undo a change to the objects in this layer
@@ -530,12 +543,13 @@ declare global {
 
       /**
        * Confirm placeable object deletion with a dialog?
+       * @defaultValue `false`
        */
       confirmDeleteKey: boolean;
 
       /**
        * The class used to represent an object on this layer.
-       * @defaultValue `getDocumentClass(this.documentName)`
+       * @defaultValue `CONFIG[this.documentName]?.objectClass`
        */
       objectClass: Document.ConfiguredObjectClassForName<DocumentName>;
 

--- a/src/foundry/client/pixi/layers/controls/cursor.d.mts
+++ b/src/foundry/client/pixi/layers/controls/cursor.d.mts
@@ -28,6 +28,6 @@ declare global {
      */
     protected _animate(): void;
 
-    override destroy(options?: Parameters<PIXI.Container["destroy"]>[0]): void;
+    override destroy(options?: PIXI.DisplayObject.DestroyOptions): void;
   }
 }

--- a/src/foundry/client/pixi/layers/controls/door.d.mts
+++ b/src/foundry/client/pixi/layers/controls/door.d.mts
@@ -43,28 +43,26 @@ declare global {
      * Handle mouse over events on a door control icon.
      * @param event - The originating interaction event
      */
-    protected _onMouseOver(event: PIXI.FederatedEvent): false | void;
+    protected _onMouseOver(event: PIXI.FederatedEvent): false | undefined;
 
     /**
      * Handle mouse out events on a door control icon.
      * @param event - The originating interaction event
      */
-    protected _onMouseOut(event: PIXI.FederatedEvent): false | void;
+    protected _onMouseOut(event: PIXI.FederatedEvent): false | undefined;
 
     /**
      * Handle left mouse down events on a door control icon.
      * This should only toggle between the OPEN and CLOSED states.
      * @param event - The originating interaction event
      */
-    protected _onMouseDown(
-      event: PIXI.FederatedEvent,
-    ): false | void | Promise<WallDocument.ConfiguredInstance | undefined>;
+    protected _onMouseDown(event: PIXI.FederatedEvent): false | undefined | Promise<WallDocument.ConfiguredInstance>;
 
     /**
      * Handle right mouse down events on the door control icon
      * This should toggle whether the door is LOCKED or CLOSED
      * @param event - The originating interaction event
      */
-    protected _onRightDown(event: PIXI.FederatedEvent): void | Promise<WallDocument.ConfiguredInstance | undefined>;
+    protected _onRightDown(event: PIXI.FederatedEvent): undefined | Promise<WallDocument.ConfiguredInstance>;
   }
 }

--- a/src/foundry/client/pixi/layers/controls/layer.d.mts
+++ b/src/foundry/client/pixi/layers/controls/layer.d.mts
@@ -196,8 +196,7 @@ declare global {
            * The style of ping to draw, from CONFIG.Canvas.pings.
            * @defaultValue `"arrow"`
            */
-          //TODO: eventually replace with a type like `keyof CONFIG.Canvas.pings` but something mergable?
-          style: string;
+          style: keyof RemoveIndexSignatures<typeof CONFIG.Canvas.pings.styles>;
 
           /**
            * The user who pinged.

--- a/src/foundry/client/pixi/layers/controls/layer.d.mts
+++ b/src/foundry/client/pixi/layers/controls/layer.d.mts
@@ -174,7 +174,7 @@ declare global {
       user: User.ConfiguredInstance,
       position: Canvas.Point,
       data?: InexactPartial<User.PingData & PingOptions>,
-    ): Promise<boolean>;
+    ): ReturnType<this["drawPing"]>;
 
     /**
      * Draw a ping at the edge of the viewport, pointing to the location of an off-screen ping.

--- a/src/foundry/client/pixi/layers/controls/layer.d.mts
+++ b/src/foundry/client/pixi/layers/controls/layer.d.mts
@@ -1,5 +1,5 @@
 import type { IntentionalPartial } from "../../../../../types/helperTypes.d.mts";
-import type { InexactPartial, NullishProps } from "../../../../../types/utils.d.mts";
+import type { InexactPartial, NullishProps, RemoveIndexSignatures } from "../../../../../types/utils.d.mts";
 import type { LineIntersection } from "../../../../common/utils/geometry.d.mts";
 
 declare global {
@@ -189,7 +189,7 @@ declare global {
      */
     drawOffscreenPing(
       position: Canvas.Point,
-      options?: /** @privateRemarks PingOptions gets spread */
+      options?: /** @remarks Can't be NullishProps or InexactPartial because PingOptions gets spread into an object with existing values for some keys */
       IntentionalPartial<PingOptions> &
         NullishProps<{
           /**
@@ -215,15 +215,14 @@ declare global {
      */
     drawPing(
       position: PIXI.Point,
-      options?: /** @privateRemarks PingOptions gets spread */
+      options?: /** @remarks Can't be NullishProps or InexactPartial because PingOptions gets `mergeObject`ed */
       IntentionalPartial<PingOptions> &
         NullishProps<{
           /**
            * The style of ping to draw, from CONFIG.Canvas.pings.
            * @defaultValue `"pulse"`
            */
-          //TODO: eventually replace with a type like `keyof CONFIG.Canvas.pings` but something mergable?
-          style: string;
+          style: keyof RemoveIndexSignatures<typeof CONFIG.Canvas.pings.styles>;
 
           /**
            * The user who pinged.

--- a/src/foundry/client/pixi/layers/controls/layer.d.mts
+++ b/src/foundry/client/pixi/layers/controls/layer.d.mts
@@ -1,4 +1,5 @@
-import type { InexactPartial } from "../../../../../types/utils.d.mts";
+import type { IntentionalPartial } from "../../../../../types/helperTypes.d.mts";
+import type { InexactPartial, NullishProps } from "../../../../../types/utils.d.mts";
 import type { LineIntersection } from "../../../../common/utils/geometry.d.mts";
 
 declare global {
@@ -173,7 +174,10 @@ declare global {
     handlePing(
       user: User.ConfiguredInstance,
       position: Canvas.Point,
-      data?: InexactPartial<User.PingData & PingOptions>,
+      /**
+       * @privateRemarks User.PingData is InexactPartial because `zoom` is assumed to be number
+       * PingOptions is IntentionalPartial because it gets `mergeObject`ed with some defaults */
+      data?: InexactPartial<User.PingData> & IntentionalPartial<PingOptions>,
     ): ReturnType<this["drawPing"]>;
 
     /**
@@ -185,8 +189,9 @@ declare global {
      */
     drawOffscreenPing(
       position: Canvas.Point,
-      options?: InexactPartial<
-        PingOptions & {
+      options?: /** @privateRemarks PingOptions gets spread */
+      IntentionalPartial<PingOptions> &
+        NullishProps<{
           /**
            * The style of ping to draw, from CONFIG.Canvas.pings.
            * @defaultValue `"arrow"`
@@ -198,8 +203,7 @@ declare global {
            * The user who pinged.
            */
           user: User.ConfiguredInstance;
-        }
-      >,
+        }>,
     ): ReturnType<this["drawPing"]>;
 
     /**
@@ -211,19 +215,21 @@ declare global {
      */
     drawPing(
       position: PIXI.Point,
-      options?: PingOptions & {
-        /**
-         * The style of ping to draw, from CONFIG.Canvas.pings.
-         * @defaultValue `"pulse"`
-         */
-        //TODO: eventually replace with a type like `keyof CONFIG.Canvas.pings` but something mergable?
-        style?: string;
+      options?: /** @privateRemarks PingOptions gets spread */
+      IntentionalPartial<PingOptions> &
+        NullishProps<{
+          /**
+           * The style of ping to draw, from CONFIG.Canvas.pings.
+           * @defaultValue `"pulse"`
+           */
+          //TODO: eventually replace with a type like `keyof CONFIG.Canvas.pings` but something mergable?
+          style: string;
 
-        /**
-         * The user who pinged.
-         */
-        user?: User.ConfiguredInstance;
-      },
+          /**
+           * The user who pinged.
+           */
+          user: User.ConfiguredInstance;
+        }>,
     ): ReturnType<Ping["animate"]>;
 
     /**

--- a/src/foundry/client/pixi/layers/controls/ruler.d.mts
+++ b/src/foundry/client/pixi/layers/controls/ruler.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial, ValueOf } from "../../../../../types/utils.d.mts";
+import type { NullishProps, ValueOf } from "../../../../../types/utils.d.mts";
 
 declare global {
   /**
@@ -12,7 +12,7 @@ declare global {
      */
     constructor(
       user?: User.ConfiguredInstance,
-      options?: InexactPartial<{
+      options?: NullishProps<{
         /**
          * The color of the ruler (defaults to the color of the User)
          */
@@ -51,12 +51,7 @@ declare global {
     /**
      * The possible Ruler measurement states.
      */
-    static get STATES(): {
-      INACTIVE: 0;
-      STARTING: 1;
-      MEASURING: 2;
-      MOVING: 3;
-    };
+    static get STATES(): Ruler.STATES;
 
     /**
      * Is the ruler ready for measure?
@@ -108,12 +103,13 @@ declare global {
     /**
      * The current state of the Ruler (one of {@link Ruler.STATES}).
      */
-    get state(): ValueOf<(typeof Ruler)["STATES"]>;
+    get state(): ValueOf<Ruler.STATES>;
 
     /**
      * The current state of the Ruler (one of {@link Ruler.STATES}).
+     * @defaultValue `Ruler.STATES.INACTIVE`
      */
-    protected _state: ValueOf<(typeof Ruler)["STATES"]>;
+    protected _state: ValueOf<Ruler.STATES>;
 
     /**
      * Is the Ruler being actively used to measure distance?
@@ -143,7 +139,7 @@ declare global {
      */
     measure(
       destination: Canvas.Point,
-      options?: InexactPartial<{
+      options?: NullishProps<{
         /**
          * Snap the destination?
          * @defaultValue `true`
@@ -165,7 +161,7 @@ declare global {
      */
     protected _getMeasurementOrigin(
       point: Canvas.Point,
-      options?: InexactPartial<{
+      options?: NullishProps<{
         /**
          * Snap the waypoint?
          * @defaultValue `true`
@@ -182,7 +178,7 @@ declare global {
      */
     protected _getMeasurementDestination(
       point: Canvas.Point,
-      options?: InexactPartial<{
+      options?: NullishProps<{
         /**
          * Snap the point?
          * @defaultValue `true`
@@ -204,7 +200,7 @@ declare global {
      */
     protected _startMeasurement(
       origin: Canvas.Point,
-      options?: InexactPartial<{
+      options?: NullishProps<{
         /**
          * Snap the origin?
          * @defaultValue `true`
@@ -230,7 +226,7 @@ declare global {
      */
     protected _addWaypoint(
       point: Canvas.Point,
-      options?: InexactPartial<{
+      options?: NullishProps<{
         /**
          * Snap the waypoint?
          * @defaultValue `true`
@@ -275,7 +271,7 @@ declare global {
      * @returns An indicator for whether a token was successfully moved or not. If True the event should be
      *          prevented from propagating further, if False it should move on to other handlers.
      */
-    moveToken(): Promise<false | undefined>;
+    moveToken(): Promise<boolean>;
 
     /**
      * Acquire a Token, if any, which is eligible to perform a movement based on the starting point of the Ruler
@@ -283,7 +279,7 @@ declare global {
      * @returns The Token that is to be moved, if any
      *
      */
-    protected _getMovementToken(origin: Canvas.Point): Token.ConfiguredInstance | null | undefined;
+    protected _getMovementToken(origin: Canvas.Point): Token.ConfiguredInstance | null;
 
     /**
      * Get the current measurement history.
@@ -303,14 +299,14 @@ declare global {
      * @returns Whether the movement is allowed
      * @throws  A specific Error message used instead of returning false
      */
-    protected _canMove(token: Token): true;
+    protected _canMove(token: Token.ConfiguredInstance): boolean;
 
     /**
      * Animate piecewise Token movement along the measured segment path.
      * @param token - The Token being animated
      * @returns A Promise which resolves once all animation is completed
      */
-    protected _animateMovement(token: Token): Promise<void>;
+    protected _animateMovement(token: Token.ConfiguredInstance): Promise<void>;
 
     /**
      * Update Token position and configure its animation properties for the next leg of its animation.
@@ -321,7 +317,7 @@ declare global {
      * @returns A Promise that resolves once the animation for this segment is done
      */
     protected _animateSegment(
-      token: Token,
+      token: Token.ConfiguredInstance,
       segment: Ruler.MeasurementSegment,
       destination: Canvas.Point,
       updateOptions: TokenDocument.DatabaseOperations["update"],
@@ -375,7 +371,7 @@ declare global {
      * @param event - The pointer-down event
      * @see Canvas._onClickRight
      */
-    protected _onClickRight(event: PIXI.FederatedEvent): boolean | void;
+    protected _onClickRight(event: PIXI.FederatedEvent): void;
 
     /**
      * Continue a Ruler measurement workflow for left-mouse movements on the Canvas.
@@ -398,6 +394,15 @@ declare global {
   }
 
   namespace Ruler {
+    type AnyConstructor = typeof AnyRuler;
+
+    interface STATES {
+      readonly INACTIVE: 0;
+      readonly STARTING: 1;
+      readonly MEASURING: 2;
+      readonly MOVING: 3;
+    }
+
     interface MeasurementSegment {
       /** The Ray which represents the point-to-point line segment */
       ray: Ray;
@@ -448,7 +453,7 @@ declare global {
 
     interface MeasurementData {
       /** The state ({@link Ruler#state}) */
-      state: number;
+      state: ValueOf<Ruler.STATES>;
 
       /** The token ID ({@link Ruler#token}) */
       token: string | null;
@@ -463,4 +468,8 @@ declare global {
       destination: Canvas.Point | null;
     }
   }
+}
+
+declare abstract class AnyRuler extends Ruler {
+  constructor(arg0: never, ...args: never[]);
 }

--- a/src/foundry/client/pixi/layers/effects/background-effects.d.mts
+++ b/src/foundry/client/pixi/layers/effects/background-effects.d.mts
@@ -4,7 +4,11 @@ declare global {
   /**
    * A layer of background alteration effects which change the appearance of the primary group render texture.
    */
-  class CanvasBackgroundAlterationEffects extends CanvasLayer {
+  class CanvasBackgroundAlterationEffects<
+    DrawOptions extends CanvasBackgroundAlterationEffects.DrawOptions = CanvasBackgroundAlterationEffects.DrawOptions,
+    TearDownOptions extends
+      CanvasBackgroundAlterationEffects.TearDownOptions = CanvasBackgroundAlterationEffects.TearDownOptions,
+  > extends CanvasLayer<DrawOptions, TearDownOptions> {
     /**
      * A collection of effects which provide background vision alterations.
      * @defaultValue `vision.sortableChildren = true`
@@ -22,13 +26,25 @@ declare global {
      */
     lighting: PIXI.Container;
 
-    protected override _draw(options?: Record<string, unknown>): Promise<void>;
+    protected override _draw(options?: DrawOptions): Promise<void>;
 
-    protected override _tearDown(options?: Record<string, unknown>): Promise<void>;
+    protected override _tearDown(options?: TearDownOptions): Promise<void>;
 
     /**
      * Clear background alteration effects vision and lighting containers
      */
     clear(): void;
   }
+
+  namespace CanvasBackgroundAlterationEffects {
+    type AnyConstructor = typeof AnyCanvasBackgroundAlterationEffects;
+
+    interface DrawOptions extends CanvasLayer.DrawOptions {}
+
+    interface TearDownOptions extends CanvasLayer.DrawOptions {}
+  }
+}
+
+declare abstract class AnyCanvasBackgroundAlterationEffects extends CanvasBackgroundAlterationEffects {
+  constructor(arg0: never, ...args: never[]);
 }

--- a/src/foundry/client/pixi/layers/effects/coloration-effects.d.mts
+++ b/src/foundry/client/pixi/layers/effects/coloration-effects.d.mts
@@ -4,7 +4,10 @@ declare global {
   /**
    * A CanvasLayer for displaying coloration visual effects
    */
-  class CanvasColorationEffects extends CanvasLayer {
+  class CanvasColorationEffects<
+    DrawOptions extends CanvasColorationEffects.DrawOptions = CanvasColorationEffects.DrawOptions,
+    TearDownOptions extends CanvasColorationEffects.TearDownOptions = CanvasColorationEffects.TearDownOptions,
+  > extends CanvasLayer<DrawOptions, TearDownOptions> {
     /**
      * @defaultValue `true`
      */
@@ -20,8 +23,20 @@ declare global {
      */
     clear(): void;
 
-    protected override _draw(options?: Record<string, unknown>): Promise<void>;
+    protected override _draw(options?: DrawOptions): Promise<void>;
 
-    protected override _tearDown(options?: Record<string, unknown>): Promise<void>;
+    protected override _tearDown(options?: TearDownOptions): Promise<void>;
   }
+
+  namespace CanvasColorationEffects {
+    type AnyConstructor = typeof AnyCanvasColorationEffects;
+
+    interface DrawOptions extends CanvasLayer.DrawOptions {}
+
+    interface TearDownOptions extends CanvasLayer.TearDownOptions {}
+  }
+}
+
+declare abstract class AnyCanvasColorationEffects extends CanvasColorationEffects {
+  constructor(arg0: never, ...args: never[]);
 }

--- a/src/foundry/client/pixi/layers/effects/darkness-effects.d.mts
+++ b/src/foundry/client/pixi/layers/effects/darkness-effects.d.mts
@@ -1,10 +1,13 @@
-import type { AnyObject } from "../../../../../types/utils.d.mts";
+export {};
 
 declare global {
   /**
    * A layer of background alteration effects which change the appearance of the primary group render texture.
    */
-  class CanvasDarknessEffects extends CanvasLayer {
+  class CanvasDarknessEffects<
+    DrawOptions extends CanvasDarknessEffects.DrawOptions = CanvasDarknessEffects.DrawOptions,
+    TearDownOptions extends CanvasLayer.TearDownOptions = CanvasLayer.TearDownOptions,
+  > extends CanvasLayer<DrawOptions, TearDownOptions> {
     /**
      * @defaultValue `true`
      */
@@ -15,6 +18,16 @@ declare global {
      */
     clear(): void;
 
-    override _draw(options: AnyObject): Promise<void>;
+    override _draw(options: DrawOptions): Promise<void>;
   }
+
+  namespace CanvasDarknessEffects {
+    type AnyConstructor = typeof AnyCanvasDarknessEffects;
+
+    interface DrawOptions extends CanvasLayer.DrawOptions {}
+  }
+}
+
+declare abstract class AnyCanvasDarknessEffects extends CanvasDarknessEffects {
+  constructor(arg0: never, ...args: never[]);
 }

--- a/src/foundry/client/pixi/layers/effects/illumination-effects.d.mts
+++ b/src/foundry/client/pixi/layers/effects/illumination-effects.d.mts
@@ -11,7 +11,7 @@ declare global {
     /**
      * The filter used to mask visual effects on this layer
      */
-    filter: VisualEffectsMaskingFilter;
+    filter: VisualEffectsMaskingFilter | undefined;
 
     /**
      * The container holding the lights.
@@ -92,7 +92,7 @@ declare global {
     /**
      * @deprecated since v12, will be removed in v14
      */
-    background: PIXI.LegacyGraphics;
+    background: null;
 
     /**
      * @deprecated since v12, will be removed in v14

--- a/src/foundry/client/pixi/layers/effects/illumination-effects.d.mts
+++ b/src/foundry/client/pixi/layers/effects/illumination-effects.d.mts
@@ -1,12 +1,13 @@
 import type { NullishProps } from "../../../../../types/utils.d.mts";
 
-export {};
-
 declare global {
   /**
    * A CanvasLayer for displaying illumination visual effects
    */
-  class CanvasIlluminationEffects extends CanvasLayer {
+  class CanvasIlluminationEffects<
+    DrawOptions extends CanvasIlluminationEffects.DrawOptions = CanvasIlluminationEffects.DrawOptions,
+    TearDownOptions extends CanvasIlluminationEffects.TearDownOptions = CanvasIlluminationEffects.TearDownOptions,
+  > extends CanvasLayer<DrawOptions, TearDownOptions> {
     /**
      * The filter used to mask visual effects on this layer
      */
@@ -78,9 +79,10 @@ declare global {
 
     override render(renderer: PIXI.Renderer): void;
 
-    protected override _draw(options?: Record<string, unknown>): Promise<void>;
+    protected override _draw(options?: DrawOptions): Promise<void>;
 
-    protected override _tearDown(options?: Record<string, unknown>): Promise<void>;
+    protected override _tearDown(options?: TearDownOptions): Promise<void>;
+
     /**
      * @deprecated since v11, will be removed in v13
      * @remarks "CanvasIlluminationEffects#updateGlobalLight has been deprecated."
@@ -97,6 +99,14 @@ declare global {
      * @remarks `"CanvasIlluminationEffects#globalLight has been deprecated without replacement. Check the canvas.environment.globalLightSource.active instead."`
      */
     get globalLight(): boolean;
+  }
+
+  namespace CanvasIlluminationEffects {
+    type AnyConstructor = typeof AnyCanvasIlluminationEffects;
+
+    interface DrawOptions extends CanvasLayer.DrawOptions {}
+
+    interface TearDownOptions extends CanvasLayer.TearDownOptions {}
   }
 
   /**
@@ -126,4 +136,16 @@ declare global {
     /** @privateRemarks Including to protect duck typing due to overall similarities b/w DarknessLevelContainer and CachedContainer */
     #onChildChange(): void;
   }
+
+  namespace DarknessLevelContainer {
+    type AnyConstructor = typeof AnyCanvasIlluminationEffects;
+  }
+}
+
+declare abstract class AnyCanvasIlluminationEffects extends CanvasIlluminationEffects {
+  constructor(arg0: never, ...args: never[]);
+}
+
+declare abstract class AnyDarknessLevelContainer extends DarknessLevelContainer {
+  constructor(arg0: never, ...args: never[]);
 }

--- a/src/foundry/client/pixi/layers/effects/visibility.d.mts
+++ b/src/foundry/client/pixi/layers/effects/visibility.d.mts
@@ -6,7 +6,10 @@ declare global {
    * This layer uses an event-driven workflow to perform the minimal required calculation in response to changes.
    * @see {@link PointSource}
    */
-  class CanvasVisibility extends CanvasLayer {
+  class CanvasVisibility<
+    DrawOptions extends CanvasVisibility.DrawOptions = CanvasVisibility.DrawOptions,
+    TearDownOptions extends CanvasVisibility.TearDownOptions = CanvasVisibility.TearDownOptions,
+  > extends CanvasLayer<DrawOptions, TearDownOptions> {
     /**
      * The currently revealed vision.
      */
@@ -93,9 +96,9 @@ declare global {
      */
     initializeVisionMode(): void;
 
-    protected override _draw(options?: Record<string, unknown>): Promise<void>;
+    protected override _draw(options?: DrawOptions): Promise<void>;
 
-    protected override _tearDown(options?: Record<string, unknown>): Promise<void>;
+    protected override _tearDown(options?: TearDownOptions): Promise<void>;
 
     /**
      * Update the display of the sight layer.
@@ -173,7 +176,13 @@ declare global {
   }
 
   namespace CanvasVisibility {
+    type AnyConstructor = typeof AnyCanvasVisibility;
+
     type LightingVisibility = ValueOf<typeof VisionMode.LIGHTING_VISIBILITY>;
+
+    interface DrawOptions extends CanvasLayer.DrawOptions {}
+
+    interface TearDownOptions extends CanvasLayer.TearDownOptions {}
   }
 
   interface FogTextureConfiguration {
@@ -196,4 +205,8 @@ declare global {
     object: PlaceableObject | null;
     tests: CanvasVisibilityTest[];
   }
+}
+
+declare abstract class AnyCanvasVisibility extends CanvasVisibility {
+  constructor(arg0: never, ...args: never[]);
 }

--- a/src/foundry/client/pixi/layers/effects/visibility.d.mts
+++ b/src/foundry/client/pixi/layers/effects/visibility.d.mts
@@ -160,7 +160,7 @@ declare global {
      */
     _createVisibilityTestConfig(
       point: Canvas.Point,
-      /** @privateRemarks `tolerance` is assumed, unchecked, to be a number */
+      /** @privateRemarks Can't be NullishProps because `tolerance` is assumed, unchecked, to be a number */
       options?: InexactPartial<{
         /**
          * A numeric radial offset which allows for a non-exact match.

--- a/src/foundry/client/pixi/layers/effects/visibility.d.mts
+++ b/src/foundry/client/pixi/layers/effects/visibility.d.mts
@@ -86,7 +86,7 @@ declare global {
      *
      * @privateRemarks Foundry types this parameter as `FogTextureConfiguration`, and
      * unlike the other place they used this type seeming in error, only `rect`'s
-     * `x, y, width, height` properties are accesses, so I'm assuming they meant Rectangle
+     * `x, y, width, height` properties are accessed, so I'm assuming they meant Rectangle
      */
     set explorationRect(rect: Canvas.Rectangle);
 
@@ -135,8 +135,8 @@ declare global {
     testVisibility(
       point: Canvas.Point,
       /**
-       * @privateRemarks can't be NullishProps because `tolerance` gets passed directly to
-       * `_createVisibilityTestConfig` which assumes, unchecked, that it's a number
+       * @remarks Can't be NullishProps because `tolerance` gets passed directly to `_createVisibilityTestConfig`,
+       * where a default is provided only for `undefined` with `{ tolerance=2 }`, which must be numeric
        * */
       options?: InexactPartial<{
         /**
@@ -160,7 +160,7 @@ declare global {
      */
     _createVisibilityTestConfig(
       point: Canvas.Point,
-      /** @privateRemarks Can't be NullishProps because `tolerance` is assumed, unchecked, to be a number */
+      /** @remarks Can't be NullishProps because a default for `tolerance` is provided only for `undefined` with `{ tolerance=2 }`, which must be numeric */
       options?: InexactPartial<{
         /**
          * A numeric radial offset which allows for a non-exact match.

--- a/src/foundry/client/pixi/layers/effects/visibility.d.mts
+++ b/src/foundry/client/pixi/layers/effects/visibility.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial, ValueOf } from "../../../../../types/utils.d.mts";
+import type { EmptyObject, InexactPartial, ValueOf } from "../../../../../types/utils.d.mts";
 
 declare global {
   /**
@@ -13,17 +13,17 @@ declare global {
     /**
      * The currently revealed vision.
      */
-    vision: CanvasVisionMask.CanvasVisionContainer;
+    vision: CanvasVisionMask.CanvasVisionContainer | undefined;
 
     /**
      * The exploration container which tracks exploration progress.
      */
-    explored: PIXI.Container;
+    explored: PIXI.Container | undefined;
 
     /**
      * The optional visibility overlay sprite that should be drawn instead of the unexplored color in the fog of war.
      */
-    visibilityOverlay: PIXI.Sprite;
+    visibilityOverlay: PIXI.Sprite | undefined;
 
     /**
      * The active vision source data object
@@ -36,8 +36,8 @@ declare global {
      * ```
      */
     visionModeData: {
-      source: foundry.canvas.sources.PointVisionSource.Any | null;
-      activeLightingOptions: VisionMode["_source"]["lighting"];
+      source: foundry.canvas.sources.PointVisionSource.Any | null | undefined;
+      activeLightingOptions: VisionMode["_source"]["lighting"] | EmptyObject;
     };
 
     /**
@@ -74,17 +74,21 @@ declare global {
     /**
      * Does the currently viewed Scene support Token field of vision?
      */
-    get tokenVision(): boolean;
+    get tokenVision(): Scene.ConfiguredInstance["tokenVision"];
 
     /**
      * The configured options used for the saved fog-of-war texture.
      */
-    get textureConfiguration(): FogTextureConfiguration;
+    get textureConfiguration(): VisibilityTextureConfiguration | undefined;
 
     /**
      * Optional overrides for exploration sprite dimensions.
+     *
+     * @privateRemarks Foundry types this parameter as `FogTextureConfiguration`, and
+     * unlike the other place they used this type seeming in error, only `rect`'s
+     * `x, y, width, height` properties are accesses, so I'm assuming they meant Rectangle
      */
-    set explorationRect(rect: FogTextureConfiguration);
+    set explorationRect(rect: Canvas.Rectangle);
 
     /**
      * Initialize all Token vision sources which are present on this layer
@@ -130,6 +134,10 @@ declare global {
      */
     testVisibility(
       point: Canvas.Point,
+      /**
+       * @privateRemarks can't be NullishProps because `tolerance` gets passed directly to
+       * `_createVisibilityTestConfig` which assumes, unchecked, that it's a number
+       * */
       options?: InexactPartial<{
         /**
          * A numeric radial offset which allows for a non-exact match.
@@ -152,6 +160,7 @@ declare global {
      */
     _createVisibilityTestConfig(
       point: Canvas.Point,
+      /** @privateRemarks `tolerance` is assumed, unchecked, to be a number */
       options?: InexactPartial<{
         /**
          * A numeric radial offset which allows for a non-exact match.
@@ -185,7 +194,11 @@ declare global {
     interface TearDownOptions extends CanvasLayer.TearDownOptions {}
   }
 
-  interface FogTextureConfiguration {
+  /**
+   * @privateRemarks This is name foundry has for the return tyoe of `CanvasVisibility#configureVisibilityTexture`
+   * The FogTextureConfiguration references seem to be in error
+   */
+  interface VisibilityTextureConfiguration {
     resolution: number;
     width: number;
     height: number;

--- a/src/foundry/client/pixi/layers/effects/weather-effects.d.mts
+++ b/src/foundry/client/pixi/layers/effects/weather-effects.d.mts
@@ -1,10 +1,13 @@
-export {};
+import type { InexactPartial } from "../../../../../types/utils.d.mts";
 
 declare global {
   /**
    * A CanvasLayer for displaying visual effects like weather, transitions, flashes, or more
    */
-  class WeatherEffects extends FullCanvasObjectMixin(CanvasLayer) {
+  class WeatherEffects<
+    DrawOptions extends WeatherEffects.DrawOptions = WeatherEffects.DrawOptions,
+    TearDownOptions extends WeatherEffects.TearDownOptions = WeatherEffects.TearDownOptions,
+  > extends FullCanvasObjectMixin(CanvasLayer) {
     /**
      * @privateRemarks This is not overridden in foundry but reflects the real behavior.
      */
@@ -35,9 +38,9 @@ declare global {
     /**
      * @defaultValue `foundry.utils.mergeObject(super.layerOptions, { name: "effects" })`
      */
-    static override get layerOptions(): WeatherLayer.LayerOptions;
+    static override get layerOptions(): WeatherEffects.LayerOptions;
 
-    override options: WeatherLayer.LayerOptions;
+    override options: WeatherEffects.LayerOptions;
 
     /**
      * Array of weather effects linked to this weather container.
@@ -48,13 +51,13 @@ declare global {
      * A default configuration of the terrain mask that is automatically applied to any shader-based weather effects.
      * This configuration is automatically passed to WeatherShaderEffect#configureTerrainMask upon construction.
      */
-    terrainMaskConfig: WeatherLayer.WeatherTerrainMaskConfiguration;
+    terrainMaskConfig: WeatherEffects.WeatherTerrainMaskConfiguration;
 
     /**
      * A default configuration of the terrain mask that is automatically applied to any shader-based weather effects.
      * This configuration is automatically passed to WeatherShaderEffect#configureTerrainMask upon construction.
      */
-    occlusionMaskConfig: WeatherLayer.WeatherOcclusionMaskConfiguration;
+    occlusionMaskConfig: WeatherEffects.WeatherOcclusionMaskConfiguration;
 
     /**
      * The inverse occlusion mask filter bound to this container.
@@ -66,7 +69,7 @@ declare global {
      */
     get elevation(): number;
 
-    set elevation(value);
+    set elevation(value: number);
 
     /**
      * A key which resolves ties amongst objects at the same elevation of different layers.
@@ -82,24 +85,24 @@ declare global {
      */
     get sort(): number;
 
-    set sort(value);
+    set sort(value: number);
 
     /**
      * A key which resolves ties amongst objects at the same elevation within the same layer and same sort.
      */
     get zIndex(): number;
 
-    set zIndex(value);
+    set zIndex(value: number);
 
-    protected override _draw(options?: Record<string, unknown>): Promise<void>;
+    protected override _draw(options?: DrawOptions): Promise<void>;
 
-    protected override _tearDown(options?: Record<string, unknown>): Promise<void>;
+    protected override _tearDown(options?: TearDownOptions): Promise<void>;
 
     /**
      * Initialize the weather container from a weather config object.
      * @param weatherEffectsConfig - Weather config object (or null/undefined to clear the container).
      */
-    initializeEffects(weatherEffectsConfig?: WeatherLayer.WeatherEffectsConfig | null): void;
+    initializeEffects(weatherEffectsConfig?: WeatherEffects.WeatherEffectsConfig | null): void;
 
     /**
      * Clear the weather container.
@@ -113,7 +116,7 @@ declare global {
      */
     protected static configureOcclusionMask(
       context: PIXI.Shader,
-      config: WeatherLayer.WeatherOcclusionMaskConfiguration,
+      config?: InexactPartial<WeatherEffects.WeatherOcclusionMaskConfiguration>,
     ): void;
 
     /**
@@ -123,7 +126,7 @@ declare global {
      */
     protected static configureTerrainMask(
       context: PIXI.Shader,
-      config: WeatherLayer.WeatherTerrainMaskConfiguration,
+      config?: InexactPartial<WeatherEffects.WeatherTerrainMaskConfiguration>,
     ): void;
 
     /**
@@ -133,10 +136,16 @@ declare global {
     get weather(): this;
   }
 
-  namespace WeatherLayer {
+  namespace WeatherEffects {
+    type AnyConstructor = typeof AnyWeatherEffects;
+
     interface LayerOptions extends CanvasLayer.LayerOptions {
       name: "effects";
     }
+
+    interface DrawOptions extends CanvasLayer.DrawOptions {}
+
+    interface TearDownOptions extends CanvasLayer.TearDownOptions {}
 
     interface WeatherTerrainMaskConfiguration {
       /**
@@ -197,4 +206,8 @@ declare global {
       filter: PIXI.Filter;
     }
   }
+}
+
+declare abstract class AnyWeatherEffects extends WeatherEffects {
+  constructor(arg0: never, ...args: never[]);
 }

--- a/src/foundry/client/pixi/layers/effects/weather-effects.d.mts
+++ b/src/foundry/client/pixi/layers/effects/weather-effects.d.mts
@@ -50,14 +50,20 @@ declare global {
     /**
      * A default configuration of the terrain mask that is automatically applied to any shader-based weather effects.
      * This configuration is automatically passed to WeatherShaderEffect#configureTerrainMask upon construction.
+     *
+     * @privateRemarks This property is checked and conditionally passed in two places in this file,
+     * but never set as far as I can tell. It is not initialized to a value.
      */
-    terrainMaskConfig: WeatherEffects.WeatherTerrainMaskConfiguration;
+    terrainMaskConfig: WeatherEffects.WeatherTerrainMaskConfiguration | undefined;
 
     /**
      * A default configuration of the terrain mask that is automatically applied to any shader-based weather effects.
      * This configuration is automatically passed to WeatherShaderEffect#configureTerrainMask upon construction.
+     *
+     * @privateRemarks This property is passed to `WeatherEffects.configureOcclusionMask` in two places, but both times
+     * as `|| {enabled: true}`, and it is never set as far as I can tell.
      */
-    occlusionMaskConfig: WeatherEffects.WeatherOcclusionMaskConfiguration;
+    occlusionMaskConfig: WeatherEffects.WeatherOcclusionMaskConfiguration | undefined;
 
     /**
      * The inverse occlusion mask filter bound to this container.
@@ -66,6 +72,7 @@ declare global {
 
     /**
      * The elevation of this object.
+     * @throws The setter throws an error if passed NaN or a non-number
      */
     get elevation(): number;
 
@@ -74,6 +81,7 @@ declare global {
     /**
      * A key which resolves ties amongst objects at the same elevation of different layers.
      * @defaultValue `PrimaryCanvasGroup.SORT_LAYERS.WEATHER`
+     * @throws The setter throws an error if passed NaN or a non-number
      */
     get sortLayer(): number;
 
@@ -82,6 +90,7 @@ declare global {
     /**
      * A key which resolves ties amongst objects at the same elevation within the same layer.
      * @defaultValue `0`
+     * @throws The setter throws an error if passed NaN or a non-number
      */
     get sort(): number;
 
@@ -89,6 +98,7 @@ declare global {
 
     /**
      * A key which resolves ties amongst objects at the same elevation within the same layer and same sort.
+     * @throws The setter throws an error if passed NaN or a non-number
      */
     get zIndex(): number;
 
@@ -101,8 +111,10 @@ declare global {
     /**
      * Initialize the weather container from a weather config object.
      * @param weatherEffectsConfig - Weather config object (or null/undefined to clear the container).
+     *
+     * @privateRemarks Foundry has this typed as just `object`, but explicitly calls it with null and implicitly with undefined
      */
-    initializeEffects(weatherEffectsConfig?: WeatherEffects.WeatherEffectsConfig | null): void;
+    initializeEffects(weatherEffectsConfig?: WeatherEffects.WeatherEffectsConfig | null | undefined): void;
 
     /**
      * Clear the weather container.
@@ -116,6 +128,7 @@ declare global {
      */
     protected static configureOcclusionMask(
       context: PIXI.Shader,
+      /** @privateRemarks can't be NullishProps because `texture` is only checked for `!== undefined` */
       config?: InexactPartial<WeatherEffects.WeatherOcclusionMaskConfiguration>,
     ): void;
 
@@ -126,6 +139,7 @@ declare global {
      */
     protected static configureTerrainMask(
       context: PIXI.Shader,
+      /** @privateRemarks can't be NullishProps because `texture` is only checked for `!== undefined` */
       config?: InexactPartial<WeatherEffects.WeatherTerrainMaskConfiguration>,
     ): void;
 

--- a/src/foundry/client/pixi/layers/effects/weather-effects.d.mts
+++ b/src/foundry/client/pixi/layers/effects/weather-effects.d.mts
@@ -61,7 +61,7 @@ declare global {
      * This configuration is automatically passed to WeatherShaderEffect#configureTerrainMask upon construction.
      *
      * @privateRemarks This property is passed to `WeatherEffects.configureOcclusionMask` in two places, but both times
-     * as `|| {enabled: true}`, and it is never set as far as I can tell.
+     * as `this.occlusionMaskConfig || {enabled: true}`, and it is never set as far as I can tell.
      */
     occlusionMaskConfig: WeatherEffects.WeatherOcclusionMaskConfiguration | undefined;
 
@@ -72,7 +72,7 @@ declare global {
 
     /**
      * The elevation of this object.
-     * @throws The setter throws an error if passed NaN or a non-number
+     * @throws The setter throws an error if passed NaN
      */
     get elevation(): number;
 
@@ -81,7 +81,7 @@ declare global {
     /**
      * A key which resolves ties amongst objects at the same elevation of different layers.
      * @defaultValue `PrimaryCanvasGroup.SORT_LAYERS.WEATHER`
-     * @throws The setter throws an error if passed NaN or a non-number
+     * @throws The setter throws an error if passed NaN
      */
     get sortLayer(): number;
 
@@ -90,7 +90,7 @@ declare global {
     /**
      * A key which resolves ties amongst objects at the same elevation within the same layer.
      * @defaultValue `0`
-     * @throws The setter throws an error if passed NaN or a non-number
+     * @throws The setter throws an error if passed NaN
      */
     get sort(): number;
 
@@ -98,7 +98,7 @@ declare global {
 
     /**
      * A key which resolves ties amongst objects at the same elevation within the same layer and same sort.
-     * @throws The setter throws an error if passed NaN or a non-number
+     * @throws The setter throws an error if passed NaN
      */
     get zIndex(): number;
 
@@ -128,7 +128,7 @@ declare global {
      */
     protected static configureOcclusionMask(
       context: PIXI.Shader,
-      /** @privateRemarks can't be NullishProps because `texture` is only checked for `!== undefined` */
+      /** @remarks Can't be NullishProps because `texture` is only checked for `!== undefined` */
       config?: InexactPartial<WeatherEffects.WeatherOcclusionMaskConfiguration>,
     ): void;
 
@@ -139,7 +139,7 @@ declare global {
      */
     protected static configureTerrainMask(
       context: PIXI.Shader,
-      /** @privateRemarks can't be NullishProps because `texture` is only checked for `!== undefined` */
+      /** @remarks Can't be NullishProps because `texture` is only checked for `!== undefined` */
       config?: InexactPartial<WeatherEffects.WeatherTerrainMaskConfiguration>,
     ): void;
 

--- a/src/foundry/client/pixi/layers/effects/weather/particles/effect.d.mts
+++ b/src/foundry/client/pixi/layers/effects/weather/particles/effect.d.mts
@@ -28,10 +28,11 @@ declare global {
      * Subclasses can override this method for more advanced configurations.
      * @param options - Options provided to the ParticleEffect constructor which can be used to customize
      *                  configuration values for created emitters. (default: `{}`)
+     * @throws An error if `foundry.utils.isEmpty(options)`
      */
     getParticleEmitters(options: PIXI.particles.EmitterConfigV3): PIXI.particles.Emitter[];
 
-    override destroy(options?: boolean | PIXI.IDestroyOptions): void;
+    override destroy(options?: PIXI.DisplayObject.DestroyOptions): void;
 
     /**
      * Begin animation for the configured emitters.

--- a/src/foundry/client/pixi/layers/grid/highlight.d.mts
+++ b/src/foundry/client/pixi/layers/grid/highlight.d.mts
@@ -27,6 +27,7 @@ declare global {
 
     override clear(): this;
 
-    override destroy(...args: Parameters<PIXI.Graphics["destroy"]>): void;
+    /** @privateRemarks Foundry handles this by passing `(...args)` directly to super, but it only takes the one */
+    override destroy(options?: PIXI.DisplayObject.DestroyOptions): void;
   }
 }

--- a/src/foundry/client/pixi/layers/grid/layer.d.mts
+++ b/src/foundry/client/pixi/layers/grid/layer.d.mts
@@ -4,7 +4,6 @@ declare global {
   /**
    * A CanvasLayer responsible for drawing a square grid
    */
-  // @ts-expect-error see https://github.com/foundryvtt/foundryvtt/issues/11794
   class GridLayer<
     DrawOptions extends GridLayer.DrawOptions = GridLayer.DrawOptions,
     TearDownOptions extends CanvasLayer.TearDownOptions = CanvasLayer.TearDownOptions,
@@ -60,7 +59,7 @@ declare global {
      */
     initializeMesh(
       /**
-       * @privateRemarks Can't be NullishProps because ultimately `GridMesh#_initialize` does `!== undefined` checks
+       * @remarks Can't be NullishProps because ultimately `GridMesh#_initialize` does `!== undefined` checks
        */
       options?: InexactPartial<{
         /** The grid style */

--- a/src/foundry/client/pixi/layers/grid/layer.d.mts
+++ b/src/foundry/client/pixi/layers/grid/layer.d.mts
@@ -16,6 +16,12 @@ declare global {
     static get instance(): Canvas["grid"];
 
     /**
+     * The grid mesh.
+     * @defaultValue `undefined`
+     */
+    mesh: GridMesh | undefined;
+
+    /**
      * The Grid Highlight container
      * @defaultValue `undefined`
      */
@@ -46,15 +52,18 @@ declare global {
     /**
      * Creates the grid mesh.
      */
-    protected _drawMesh(): Promise<GridMesh>;
+    protected _drawMesh(): Promise<ReturnType<GridMesh["initialize"]>>;
 
     /**
      * Initialize the grid mesh appearance and configure the grid shader.
      */
     initializeMesh(
-      options?: NullishProps<{
+      /**
+       * @privateRemarks Can't be NullishProps because ultimately `GridMesh#_initialize` does `!== undefined` checks
+       */
+      options?: InexactPartial<{
         /** The grid style */
-        style: string; // keyof CONFIG["Canvas"]["gridStyles"]; TODO: Update as part of #2572
+        style: string; //TODO: Update as part of #2572 to keyof CONFIG["Canvas"]["gridStyles"];
 
         /** The grid thickness */
         thickness: number;
@@ -96,7 +105,7 @@ declare global {
      * @param name    - The name for the referenced highlight layer
      * @param options - Options for the grid position that should be highlighted
      */
-    highlightPosition(name: string, options?: GridLayer.HighlightPositionOptions): false | void;
+    highlightPosition(name: string, options: GridLayer.HighlightPositionOptions): void;
 
     /**
      * @deprecated since v12, will be removed in v14
@@ -160,7 +169,7 @@ declare global {
       x: number,
       y: number,
       interval?: number,
-      options?: InexactPartial<{
+      options?: NullishProps<{
         /**
          * The token
          */
@@ -248,7 +257,7 @@ declare global {
      * @deprecated since v12, will be removed in v14
      * @remarks Used by {@link foundry.grid.BaseGrid#measureDistances}
      */
-    type MeasureDistancesOptions = InexactPartial<{
+    type MeasureDistancesOptions = NullishProps<{
       /** Return the distance in grid increments rather than the co-ordinate distance. */
       gridSpaces?: boolean;
     }>;

--- a/src/foundry/client/pixi/layers/grid/layer.d.mts
+++ b/src/foundry/client/pixi/layers/grid/layer.d.mts
@@ -1,10 +1,14 @@
-import type { AnyObject, InexactPartial, NullishProps } from "../../../../../types/utils.d.mts";
+import type { InexactPartial, NullishProps } from "../../../../../types/utils.d.mts";
 
 declare global {
   /**
    * A CanvasLayer responsible for drawing a square grid
    */
-  class GridLayer extends CanvasLayer {
+  // @ts-expect-error see https://github.com/foundryvtt/foundryvtt/issues/11794
+  class GridLayer<
+    DrawOptions extends GridLayer.DrawOptions = GridLayer.DrawOptions,
+    TearDownOptions extends CanvasLayer.TearDownOptions = CanvasLayer.TearDownOptions,
+  > extends CanvasLayer<DrawOptions, TearDownOptions> {
     /**
      * @remarks Due to the grid rework in v12 this points to a BaseGrid subclass rather than a GridLayer instance
      * @privateRemarks This is not overridden in foundry but reflects the real behavior.
@@ -37,7 +41,7 @@ declare global {
      * Draw the grid
      * @param options - Override settings used in place of those saved to the Scene data
      */
-    _draw(options?: AnyObject): Promise<void>;
+    _draw(options?: DrawOptions): Promise<void>;
 
     /**
      * Creates the grid mesh.
@@ -182,6 +186,12 @@ declare global {
   }
 
   namespace GridLayer {
+    type AnyConstructor = typeof AnyGridLayer;
+
+    interface DrawOptions extends CanvasLayer.DrawOptions {}
+
+    interface TearDownOptions extends CanvasLayer.TearDownOptions {}
+
     interface LayerOptions extends CanvasLayer.LayerOptions {
       name: "grid";
     }
@@ -243,4 +253,8 @@ declare global {
       gridSpaces?: boolean;
     }>;
   }
+}
+
+declare abstract class AnyGridLayer extends GridLayer {
+  constructor(arg0: never, ...args: never[]);
 }

--- a/src/foundry/client/pixi/layers/grid/mesh.d.mts
+++ b/src/foundry/client/pixi/layers/grid/mesh.d.mts
@@ -38,6 +38,7 @@ declare global {
     /**
      * Initialize the data of this mesh given the (partial) data.
      * @param data - The (partial) data.
+     * @privateRemarks Can't be NullishProps because of `!== undefined` tests
      */
     protected _initialize(data: InexactPartial<GridMesh.Data>): void;
   }

--- a/src/foundry/client/pixi/layers/grid/mesh.d.mts
+++ b/src/foundry/client/pixi/layers/grid/mesh.d.mts
@@ -38,7 +38,7 @@ declare global {
     /**
      * Initialize the data of this mesh given the (partial) data.
      * @param data - The (partial) data.
-     * @privateRemarks Can't be NullishProps because of `!== undefined` tests
+     * @remarks Can't be NullishProps because of `!== undefined` tests
      */
     protected _initialize(data: InexactPartial<GridMesh.Data>): void;
   }

--- a/src/foundry/client/pixi/layers/masks/occlusion.d.mts
+++ b/src/foundry/client/pixi/layers/masks/occlusion.d.mts
@@ -78,7 +78,9 @@ declare global {
      * @param tokens - The set of currently controlled Token objects
      * @returns The PCO objects which should be currently occluded
      */
-    protected _identifyOccludedObjects(tokens: Token[]): Set<InstanceType<ReturnType<typeof PrimaryCanvasObjectMixin>>>;
+    protected _identifyOccludedObjects(
+      tokens: Token.ConfiguredInstance[],
+    ): Set<InstanceType<ReturnType<typeof PrimaryCanvasObjectMixin>>>;
 
     /**
      * @deprecated since v11, will be removed in v13

--- a/src/foundry/client/pixi/layers/masks/vision.d.mts
+++ b/src/foundry/client/pixi/layers/masks/vision.d.mts
@@ -26,15 +26,23 @@ declare global {
      */
     override clearColor: [r: number, g: number, b: number, a: number];
 
+    /**
+     * @defaultValue `false`
+     */
     override autoRender: boolean;
 
-    vision: CanvasVisionMask.CanvasVisionContainer;
+    /**
+     * The current vision Container.
+     * @defaultValue `undefined`
+     */
+    vision: CanvasVisionMask.CanvasVisionContainer | undefined;
 
     /**
      * The BlurFilter which applies to the vision mask texture.
      * This filter applies a NORMAL blend mode to the container.
+     * @defaultValue `undefined`
      */
-    blurFilter: AlphaBlurFilter;
+    blurFilter: AlphaBlurFilter | undefined;
 
     draw(): Promise<void>;
 
@@ -56,7 +64,7 @@ declare global {
      */
     get filter(): this["blurFilter"];
 
-    set filter(f);
+    set filter(f: AlphaBlurFilter);
   }
 
   namespace CanvasVisionMask {

--- a/src/foundry/client/pixi/layers/placeables/drawings.d.mts
+++ b/src/foundry/client/pixi/layers/placeables/drawings.d.mts
@@ -42,7 +42,7 @@ declare global {
 
     override get hud(): Exclude<Canvas["hud"], undefined>["drawing"];
 
-    override get hookName(): (typeof DrawingsLayer)["name"];
+    override get hookName(): string;
 
     override getSnappedPoint(point: Canvas.Point): Canvas.Point;
 
@@ -68,6 +68,9 @@ declare global {
 
     protected override _onClickLeft2(event: PIXI.FederatedEvent): void;
 
+    /**
+     * @throws A `DataModelValidationError` if document creation fails
+     */
     protected override _onDragLeftStart(event: PIXI.FederatedEvent): void;
 
     protected override _onDragLeftMove(event: PIXI.FederatedEvent): void;

--- a/src/foundry/client/pixi/layers/placeables/drawings.d.mts
+++ b/src/foundry/client/pixi/layers/placeables/drawings.d.mts
@@ -4,7 +4,10 @@ declare global {
   /**
    * The DrawingsLayer subclass of PlaceablesLayer.
    */
-  class DrawingsLayer extends PlaceablesLayer<"Drawing"> {
+  class DrawingsLayer<
+    DrawOptions extends DrawingsLayer.DrawOptions = DrawingsLayer.DrawOptions,
+    TearDownOptions extends CanvasLayer.TearDownOptions = CanvasLayer.TearDownOptions,
+  > extends PlaceablesLayer<"Drawing", DrawOptions, TearDownOptions> {
     /**
      * @privateRemarks This is not overridden in foundry but reflects the real behavior.
      */
@@ -20,10 +23,9 @@ declare global {
      * ```
      * mergeObject(super.layerOptions, {
      *   name: "drawings"
-     *   canDragCreate: true,
      *   controllableObjects: true,
      *   rotatableObjects: true,
-     *   zIndex: 20
+     *   zIndex: 500
      * })
      * ```
      */
@@ -36,21 +38,22 @@ declare global {
      */
     static DEFAULT_CONFIG_SETTING: "defaultDrawingConfig";
 
-    /**
-     * Use an adaptive precision depending on the size of the grid
-     */
-    get gridPrecision(): 0 | 8 | 16;
+    graphics: Collection<Drawing>;
 
     override get hud(): Exclude<Canvas["hud"], undefined>["drawing"];
 
     override get hookName(): (typeof DrawingsLayer)["name"];
+
+    override getSnappedPoint(point: Canvas.Point): Canvas.Point;
 
     /**
      * Render a configuration sheet to configure the default Drawing settings
      */
     configureDefault(): void;
 
-    override _deactivate(): this;
+    override _deactivate(): void;
+
+    override _draw(options?: DrawOptions): Promise<void>;
 
     /**
      * Get initial data for a new drawing.
@@ -63,30 +66,43 @@ declare global {
 
     protected override _onClickLeft(event: PIXI.FederatedEvent): void;
 
-    protected override _onClickLeft2(event: PIXI.FederatedEvent): void | Promise<void>;
+    protected override _onClickLeft2(event: PIXI.FederatedEvent): void;
 
-    protected override _onDragLeftStart(event: PIXI.FederatedEvent): ReturnType<Drawing["draw"]>;
+    protected override _onDragLeftStart(event: PIXI.FederatedEvent): void;
 
     protected override _onDragLeftMove(event: PIXI.FederatedEvent): void;
 
     /**
      * Handling of mouse-up events which conclude a new object creation after dragging
+     * @remarks Foundry notes this as \@private
      */
-    protected _onDragLeftDrop(event: PIXI.FederatedEvent): Promise<void>;
+    protected _onDragLeftDrop(event: PIXI.FederatedEvent): void;
 
     protected override _onDragLeftCancel(event: PointerEvent): void;
 
     protected override _onClickRight(event: PIXI.FederatedEvent): void;
+
+    /**
+     * Use an adaptive precision depending on the size of the grid
+     * @deprecated since v12 until v14
+     */
+    get gridPrecision(): 0 | 8 | 16;
   }
 
   namespace DrawingsLayer {
+    type AnyConstructor = typeof AnyDrawingsLayer;
+
+    interface DrawOptions extends CanvasLayer.DrawOptions {}
+
     interface LayerOptions extends PlaceablesLayer.LayerOptions<"Drawing"> {
       name: "drawings";
-      canDragCreate: true;
       controllableObjects: true;
       rotatableObjects: true;
-      elevationSorting: true;
-      zIndex: 20;
+      zIndex: 500;
     }
   }
+}
+
+declare abstract class AnyDrawingsLayer extends DrawingsLayer {
+  constructor(arg0: never, ...args: never[]);
 }

--- a/src/foundry/client/pixi/layers/placeables/lighting.d.mts
+++ b/src/foundry/client/pixi/layers/placeables/lighting.d.mts
@@ -4,7 +4,10 @@ export {};
  * The Lighting Layer which ambient light sources as part of the CanvasEffectsGroup.
  */
 declare global {
-  class LightingLayer extends PlaceablesLayer<"AmbientLight"> {
+  class LightingLayer<
+    DrawOptions extends LightingLayer.DrawOptions = LightingLayer.DrawOptions,
+    TearDownOptions extends LightingLayer.TearDownOptions = LightingLayer.TearDownOptions,
+  > extends PlaceablesLayer<"AmbientLight", DrawOptions, TearDownOptions> {
     /**
      * @privateRemarks This is not overridden in foundry but reflects the real behavior.
      */
@@ -23,7 +26,7 @@ declare global {
      * foundry.utils.mergeObject(super.layerOptions, {
      *  name: "lighting",
      *  rotatableObjects: true,
-     *  zIndex: 300
+     *  zIndex: 900
      * })
      * ```
      */
@@ -31,107 +34,49 @@ declare global {
 
     override get hookName(): string;
 
+    override _draw(options?: DrawOptions): Promise<void>;
+
+    override _tearDown(options?: TearDownOptions): Promise<void>;
+
+    /**
+     * Refresh the fields of all the ambient lights on this scene.
+     */
+    refreshFields(): void;
+
     override _activate(): void;
 
-    protected override _onDragLeftStart(event: PIXI.FederatedEvent): ReturnType<AmbientLight["draw"]>;
+    protected override _canDragLeftStart(user: User.ConfiguredInstance, event: PIXI.FederatedEvent): boolean;
 
-    protected override _onDragLeftMove(event: PIXI.FederatedEvent): Promise<void>;
+    protected override _onDragLeftStart(event: PIXI.FederatedEvent): void;
 
-    protected override _onDragLeftCancel(event: PointerEvent): Promise<void>;
+    protected override _onDragLeftMove(event: PIXI.FederatedEvent): void;
 
-    protected _onMouseWheel(event: WheelEvent): void;
+    protected override _onDragLeftCancel(event: PointerEvent): void;
+
+    protected _onMouseWheel(event: WheelEvent): Promise<AmbientLight>;
 
     /**
      * Actions to take when the darkness level of the Scene is changed
-     * @param darkness - The new darkness level
-     * @param prior    - The prior darkness level
+     * @param event - An event
      */
-    protected _onDarknessChange(darkness: number, prior: number): void;
-
-    /**
-     * @deprecated since v10, will be removed in v12
-     * @remarks "LightingLayer#background has been refactored to EffectsCanvasGroup#background"
-     */
-    get background(): EffectsCanvasGroup["background"];
-
-    /**
-     * @deprecated since v10, will be removed in v12
-     * @remarks "LightingLayer#illumination has been refactored to EffectsCanvasGroup#illumination"
-     */
-    get illumination(): EffectsCanvasGroup["illumination"];
-
-    /**
-     * @deprecated since v10, will be removed in v12
-     * @remarks "LightingLayer#channels has been refactored to EffectsCanvasGroup#lightingChannelColors"
-     * @remarks lightingChannelColors was removed in v11 without this deprecation being updated
-     */
-    get channels(): undefined;
-
-    /**
-     * @deprecated since v10, will be removed in v12
-     * @remarks "LightingLayer#coloration has been refactored to EffectsCanvasGroup#coloration"
-     */
-    get coloration(): EffectsCanvasGroup["coloration"];
-
-    /**
-     * @deprecated since v10, will be removed in v12
-     * @remarks "LightingLayer#darknessLevel has been refactored to Canvas#darknessLevel"
-     */
-    get darknessLevel(): Canvas["darknessLevel"];
-
-    /**
-     * @deprecated since v10, will be removed in v12
-     * @remarks "LightingLayer#globalLight has been refactored to CanvasIlluminationEffects#globalLight"
-     */
-    get globalLight(): CanvasIlluminationEffects["globalLight"];
-
-    /**
-     * @deprecated since v10, will be removed in v12
-     * @remarks "LightingLayer#sources has been refactored to EffectsCanvasGroup#lightSources"
-     */
-    get sources(): EffectsCanvasGroup["lightSources"];
-
-    /**
-     * @deprecated since v10, will be removed in v12
-     * @remarks "LightingLayer#version has been refactored to EffectsCanvasGroup#lightingVersion"
-     * @remarks lightingVersion was removed in v11 without this deprecation being updated
-     */
-    get version(): undefined;
-
-    /**
-     * @deprecated since v10, will be removed in v12
-     * @remarks "LightingLayer#activateAnimation has been refactored to EffectsCanvasGroup#activateAnimation"
-     */
-    activateAnimation(): void;
-
-    /**
-     * @deprecated since v10, will be removed in v12
-     * @remarks "LightingLayer#deactivateAnimation has been refactored to EffectsCanvasGroup#deactivateAnimation"
-     */
-    deactivateAnimation(): void;
-
-    /**
-     * @deprecated since v10, will be removed in v12
-     * @remarks "LightingLayer#animateDarkness has been refactored to EffectsCanvasGroup#animateDarkness"
-     */
-    animateDarkness: EffectsCanvasGroup["animateDarkness"];
-
-    /**
-     * @deprecated since v10, will be removed in v12
-     * @remarks "LightingLayer#initializeSources has been refactored to EffectsCanvasGroup#initializeLightSources"
-     */
-    initializeSources(): ReturnType<EffectsCanvasGroup["initializeLightSources"]>;
-
-    /**
-     * @deprecated since v10, will be removed in v12
-     * @remarks "LightingLayer#refresh has been refactored to EffectsCanvasGroup#refreshLighting"
-     */
-    refresh: EffectsCanvasGroup["refreshLighting"];
+    protected _onDarknessChange(event: PIXI.FederatedEvent): void;
   }
 
   namespace LightingLayer {
+    type AnyConstructor = typeof AnyLightingLayer;
+
+    interface DrawOptions extends PlaceablesLayer.DrawOptions {}
+
+    interface TearDownOptions extends PlaceablesLayer.TearDownOptions {}
+
     interface LayerOptions extends PlaceablesLayer.LayerOptions<"AmbientLight"> {
       name: "lighting";
+      rotatableObjects: true;
+      zIndex: 900;
     }
   }
+}
+
+declare abstract class AnyLightingLayer extends LightingLayer {
+  constructor(arg0: never, ...args: never[]);
 }

--- a/src/foundry/client/pixi/layers/placeables/lighting.d.mts
+++ b/src/foundry/client/pixi/layers/placeables/lighting.d.mts
@@ -53,7 +53,8 @@ declare global {
 
     protected override _onDragLeftCancel(event: PointerEvent): void;
 
-    protected _onMouseWheel(event: WheelEvent): Promise<AmbientLight>;
+    // @ts-expect-error Foundry is changing the return type here from Promise<PlaceableObject[]> to just Promise<AmbientLight>
+    protected _onMouseWheel(event: WheelEvent): ReturnType<AmbientLight.ConfiguredInstance["rotate"]>;
 
     /**
      * Actions to take when the darkness level of the Scene is changed

--- a/src/foundry/client/pixi/layers/placeables/notes.d.mts
+++ b/src/foundry/client/pixi/layers/placeables/notes.d.mts
@@ -1,7 +1,5 @@
 import type { InexactPartial } from "../../../../../types/utils.d.mts";
 
-export {};
-
 declare global {
   /**
    * The Notes Layer which contains Note canvas objects
@@ -65,6 +63,7 @@ declare global {
      */
     panToNote(
       note: Note,
+      /** @privateRemarks Can't be NullishProps because `duration` is passed to `canvas.animatePan` which assumes it is a number */
       options?: InexactPartial<{
         /**
          * The resulting zoom level.

--- a/src/foundry/client/pixi/layers/placeables/notes.d.mts
+++ b/src/foundry/client/pixi/layers/placeables/notes.d.mts
@@ -1,10 +1,15 @@
+import type { InexactPartial } from "../../../../../types/utils.d.mts";
+
 export {};
 
 declare global {
   /**
    * The Notes Layer which contains Note canvas objects
    */
-  class NotesLayer extends PlaceablesLayer<"Note"> {
+  class NotesLayer<
+    DrawOptions extends NotesLayer.DrawOptions = NotesLayer.DrawOptions,
+    TearDownOptions extends PlaceablesLayer.TearDownOptions = PlaceablesLayer.TearDownOptions,
+  > extends PlaceablesLayer<"Note", DrawOptions, TearDownOptions> {
     /**
      * @privateRemarks This is not overridden in foundry but reflects the real behavior.
      */
@@ -15,9 +20,7 @@ declare global {
      * ```
      * foundry.utils.mergeObject(super.layerOptions, {
      *  name: "notes",
-     *  canDragCreate: false,
-     *  sortActiveTop: true, // TODO this needs to be removed
-     *  zIndex: 200
+     *  zIndex: 800
      * })
      * ```
      * @remarks The TODO is foundry internal
@@ -38,7 +41,11 @@ declare global {
 
     override get hookName(): string;
 
+    override interactiveChildren: boolean;
+
     override _deactivate(): void;
+
+    override _draw(options?: DrawOptions): Promise<void>;
 
     /**
      * Register game settings used by the NotesLayer
@@ -58,7 +65,7 @@ declare global {
      */
     panToNote(
       note: Note,
-      options?: {
+      options?: InexactPartial<{
         /**
          * The resulting zoom level.
          * @defaultValue `1.5`
@@ -70,23 +77,25 @@ declare global {
          * @defaultValue `250`
          */
         duration: number;
-      },
+      }>,
     ): Promise<void>;
 
-    protected override _onClickLeft(event: PIXI.FederatedEvent): void;
+    protected override _onClickLeft(event: PIXI.FederatedEvent): Promise<Note | void>;
 
     /**
      * Handle JournalEntry document drop data
      */
-    protected _onDropData(event: DragEvent, data: NotesLayer.DropData): Promise<false | void>;
+    protected _onDropData(event: DragEvent, data: NotesLayer.DropData): Promise<false | Note>;
   }
 
   namespace NotesLayer {
+    type AnyConstructor = typeof AnyNotesLayer;
+
+    interface DrawOptions extends PlaceablesLayer.DrawOptions {}
+
     interface LayerOptions extends PlaceablesLayer.LayerOptions<"Note"> {
       name: "notes";
-      canDragCreate: false;
-      sortActiveTop: true;
-      zIndex: 60;
+      zIndex: 800;
     }
 
     interface DropData<DocType extends "JournalEntry" | "JournalEntryPage" = "JournalEntry" | "JournalEntryPage">
@@ -96,4 +105,8 @@ declare global {
       anchor: DocType extends "JournalEntryPage" ? { name: string } : undefined;
     }
   }
+}
+
+declare abstract class AnyNotesLayer extends NotesLayer {
+  constructor(arg0: never, ...args: never[]);
 }

--- a/src/foundry/client/pixi/layers/placeables/notes.d.mts
+++ b/src/foundry/client/pixi/layers/placeables/notes.d.mts
@@ -63,7 +63,7 @@ declare global {
      */
     panToNote(
       note: Note,
-      /** @privateRemarks Can't be NullishProps because `duration` is passed to `canvas.animatePan` which assumes it is a number */
+      /** @remarks Can't be NullishProps because `duration` is passed to `canvas.animatePan` which only provides a default for `undefined` with `{ duration=250 }`, and must be numeric */
       options?: InexactPartial<{
         /**
          * The resulting zoom level.

--- a/src/foundry/client/pixi/layers/placeables/notes.d.mts
+++ b/src/foundry/client/pixi/layers/placeables/notes.d.mts
@@ -21,7 +21,6 @@ declare global {
      *  zIndex: 800
      * })
      * ```
-     * @remarks The TODO is foundry internal
      */
     static override get layerOptions(): NotesLayer.LayerOptions;
 

--- a/src/foundry/client/pixi/layers/placeables/sounds.d.mts
+++ b/src/foundry/client/pixi/layers/placeables/sounds.d.mts
@@ -1,3 +1,4 @@
+import type { IntentionalPartial } from "../../../../../types/helperTypes.d.mts";
 import type { InexactPartial, NullishProps } from "../../../../../types/utils.d.mts";
 import type { AmbientSoundEffect } from "../../../../common/documents/_types.d.mts";
 
@@ -161,6 +162,7 @@ declare global {
       src: string,
       origin: Canvas.Point,
       radius: number,
+      /** @privateRemarks Can't be NullishProps because `volume` is assumed to be number */
       options?: InexactPartial<SoundsLayer.PlayAtPositionOptions>,
     ): Promise<foundry.audio.Sound | null>;
 
@@ -169,7 +171,7 @@ declare global {
      * @param args - Arguments passed to SoundsLayer#playAtPosition
      * @returns  A Promise which resolves once playback for the initiating client has completed
      */
-    emitAtPosition(...args: Parameters<SoundsLayer["playAtPosition"]>): Promise<void>;
+    emitAtPosition(...args: Parameters<this["playAtPosition"]>): ReturnType<this["playAtPosition"]>;
 
     /**
      * Handle mouse cursor movements which may cause ambient audio previews to occur
@@ -189,7 +191,10 @@ declare global {
      * @param event - The drag drop event
      * @param data  - The dropped transfer data.
      */
-    protected _onDropData(event: DragEvent, data: SoundsLayer.DropData): Promise<void>;
+    protected _onDropData(
+      event: DragEvent,
+      data: SoundsLayer.DropData,
+    ): Promise<ReturnType<PlaceablesLayer<"AmbientSound">["_createPreview"]> | false>;
   }
 
   namespace SoundsLayer {
@@ -234,8 +239,11 @@ declare global {
       baseEffect: AmbientSoundEffect;
       /** A muffled sound effect to apply to playback, a sound may only be muffled if it is not constrained by walls */
       muffledEffect: AmbientSoundEffect;
-      /** Additional data passed to the SoundSource constructor */
-      sourceData: InexactPartial<PointSourceData>;
+      /**
+       * Additional data passed to the SoundSource constructor
+       * @privateRemarks IntentionalPartial because this is spread into an object with existing keys
+       */
+      sourceData: IntentionalPartial<PointSourceData>;
       /** Additional options passed to Sound#play */
       playbackOptions: foundry.audio.Sound.PlaybackOptions;
     }

--- a/src/foundry/client/pixi/layers/placeables/sounds.d.mts
+++ b/src/foundry/client/pixi/layers/placeables/sounds.d.mts
@@ -162,7 +162,7 @@ declare global {
       src: string,
       origin: Canvas.Point,
       radius: number,
-      /** @privateRemarks Can't be NullishProps because `volume` is assumed to be number */
+      /** @remarks Can't be NullishProps because a default for `volume` is provided only for `undefined` with `{ volume=1 }`, which must be numeric */
       options?: InexactPartial<SoundsLayer.PlayAtPositionOptions>,
     ): Promise<foundry.audio.Sound | null>;
 
@@ -220,30 +220,37 @@ declare global {
        * @defaultValue `1.0`
        */
       volume: number;
+
       /**
        * Should volume be attenuated by distance?
        * @defaultValue `true`
        */
       easing: boolean;
+
       /**
        * Should the sound be constrained by walls?
        * @defaultValue `true`
        */
       walls: boolean;
+
       /**
        * Should the sound always be played for GM users regardless of actively controlled tokens?
        * @defaultValue `true`
        */
       gmAlways: boolean;
+
       /** A base sound effect to apply to playback */
       baseEffect: AmbientSoundEffect;
+
       /** A muffled sound effect to apply to playback, a sound may only be muffled if it is not constrained by walls */
       muffledEffect: AmbientSoundEffect;
+
       /**
        * Additional data passed to the SoundSource constructor
-       * @privateRemarks IntentionalPartial because this is spread into an object with existing keys
+       * @remarks IntentionalPartial because this is spread into an object with existing keys
        */
       sourceData: IntentionalPartial<PointSourceData>;
+
       /** Additional options passed to Sound#play */
       playbackOptions: foundry.audio.Sound.PlaybackOptions;
     }
@@ -253,30 +260,37 @@ declare global {
        * The Sound node which should be controlled for playback
        */
       sound: foundry.audio.Sound;
+
       /**
        * The SoundSource which defines the area of effect for the sound
        */
       source: foundry.canvas.sources.PointSoundSource;
+
       /**
        * An AmbientSound object responsible for the sound, or undefined
        */
       object: AmbientSound | undefined;
+
       /**
        * The coordinates of the closest listener or undefined if there is none
        */
       listener: Canvas.Point | undefined;
+
       /**
        * The minimum distance between a listener and the AmbientSound origin
        */
       distance: number;
+
       /**
        * Is the closest listener muffled
        */
       muffled: boolean;
+
       /**
        * Is playback constrained or muffled by walls?
        */
       walls: boolean;
+
       /**
        * The final volume at which the Sound should be played
        */
@@ -284,6 +298,7 @@ declare global {
     }
   }
 }
+
 /**
  * @privateRemarks This is the only place in v12 (and v13 as of 332) where this v11 type is still used
  */

--- a/src/foundry/client/pixi/layers/placeables/sounds.d.mts
+++ b/src/foundry/client/pixi/layers/placeables/sounds.d.mts
@@ -1,10 +1,14 @@
-export {};
+import type { InexactPartial, NullishProps } from "../../../../../types/utils.d.mts";
+import type { AmbientSoundEffect } from "../../../../common/documents/_types.d.mts";
 
 declare global {
   /**
    * This Canvas Layer provides a container for AmbientSound objects.
    */
-  class SoundsLayer extends PlaceablesLayer<"AmbientSound"> {
+  class SoundsLayer<
+    DrawOptions extends SoundsLayer.DrawOptions = SoundsLayer.DrawOptions,
+    TearDownOptions extends SoundsLayer.TearDownOptions = SoundsLayer.TearDownOptions,
+  > extends PlaceablesLayer<"AmbientSound", DrawOptions, TearDownOptions> {
     /**
      * @privateRemarks This is not overridden in foundry but reflects the real behavior.
      */
@@ -32,7 +36,7 @@ declare global {
      * ```
      * foundry.utils.mergeObject(super.layerOptions, {
      *  name: "sounds",
-     *  zIndex: 300
+     *  zIndex: 900
      * })
      * ```
      * */
@@ -43,9 +47,11 @@ declare global {
 
     override get hookName(): string;
 
-    override _activate(): void;
+    override _draw(options?: DrawOptions): Promise<void>;
 
-    override _tearDown(options?: Record<string, unknown>): Promise<void>;
+    override _tearDown(options?: TearDownOptions): Promise<void>;
+
+    override _activate(): void;
 
     /**
      * Initialize all AmbientSound sources which are present on this layer
@@ -58,7 +64,14 @@ declare global {
      * @param options - Additional options forwarded to AmbientSound synchronization
      *                  (defaultValue: `{}`)
      */
-    refresh(options?: { fade?: number }): number | void;
+    refresh(
+      options?: NullishProps<{
+        /**
+         * A duration in milliseconds to fade volume transition
+         */
+        fade: number;
+      }>,
+    ): number | void;
 
     /**
      * Preview ambient audio for a given mouse cursor position
@@ -72,38 +85,102 @@ declare global {
     stopAll(): void;
 
     /**
+     * Get an array of listener positions for Tokens which are able to hear environmental sound.
+     */
+    getListenerPositions(): Canvas.Point[];
+
+    /**
      * Sync the playing state and volume of all AmbientSound objects based on the position of listener points
      * @param listeners - Locations of listeners which have the capability to hear
      * @param options   - Additional options forwarded to AmbientSound synchronization
      *                    (defaultValue: `{}`)
      */
-    protected _syncPositions(listeners: Canvas.Point[], options?: { fade?: number }): void;
+    protected _syncPositions(
+      listeners: Canvas.Point[],
+      options?: NullishProps<{
+        /**
+         * A duration in milliseconds to fade volume transition
+         */
+        fade: number;
+      }>,
+    ): void;
 
     /**
-     * Define the easing function used to map radial distance to volume.
-     * Uses cosine easing which graduates from volume 1 at distance 0 to volume 0 at distance 1
-     * @returns The target volume level
+     * Configure playback by assigning the muffled state and final playback volume for the sound.
+     * This method should mutate the config object by assigning the volume and muffled properties.
+     * @param config - A playback configuration object
      */
-    protected _getEasingVolume(distance: number, radius: number): number;
+    protected _configurePlayback(config: SoundsLayer.AmbientSoundPlaybackConfig): void;
 
     /**
      * Actions to take when the darkness level of the Scene is changed
-     * @param darkness - The new darkness level
-     * @param prior    - The prior darkness level
+     * @param  event - The darkness-changing event
      */
-    protected _onDarknessChange(darkness: number, prior: number): void;
+    protected _onDarknessChange(event: PIXI.FederatedEvent): void;
+
+    /**
+     * Play a one-shot Sound originating from a predefined point on the canvas.
+     * The sound plays locally for the current client only.
+     * To play a sound for all connected clients use SoundsLayer#emitAtPosition.
+     * @param src     - The sound source path to play
+     * @param origin  - The canvas coordinates from which the sound originates
+     * @param radius  - The radius of effect in distance units
+     * @param options - Additional options which configure playback
+     * @returns  A Promise which resolves to the played Sound, or null
+     *
+     * @example Play the sound of a trap springing
+     * ```js
+     * const src = "modules/my-module/sounds/spring-trap.ogg";
+     * const origin = {x: 5200, y: 3700};  // The origin point for the sound
+     * const radius = 30;                  // Audible in a 30-foot radius
+     * await canvas.sounds.playAtPosition(src, origin, radius);
+     * ```
+     *
+     * @example A Token casts a spell
+     * ```js
+     * const src = "modules/my-module/sounds/spells-sprite.ogg";
+     * const origin = token.center;         // The origin point for the sound
+     * const radius = 60;                   // Audible in a 60-foot radius
+     * await canvas.sounds.playAtPosition(src, origin, radius, {
+     *   walls: false,                      // Not constrained by walls with a lowpass muffled effect
+     *   muffledEffect: {type: "lowpass", intensity: 6},
+     *   sourceData: {
+     *     angle: 120,                      // Sound emitted at a limited angle
+     *     rotation: 270                    // Configure the direction of sound emission
+     *   }
+     *   playbackOptions: {
+     *     loopStart: 12,                   // Audio sprite timing
+     *     loopEnd: 16,
+     *     fade: 300,                      // Fade-in 300ms
+     *     onended: () => console.log("Do something after the spell sound has played")
+     *   }
+     * });
+     * ```
+     */
+    playAtPosition(
+      src: string,
+      origin: Canvas.Point,
+      radius: number,
+      options?: InexactPartial<SoundsLayer.PlayAtPositionOptions>,
+    ): Promise<foundry.audio.Sound | null>;
+
+    /**
+     * Emit playback to other connected clients to occur at a specified position.
+     * @param args - Arguments passed to SoundsLayer#playAtPosition
+     * @returns  A Promise which resolves once playback for the initiating client has completed
+     */
+    emitAtPosition(...args: Parameters<SoundsLayer["playAtPosition"]>): Promise<void>;
 
     /**
      * Handle mouse cursor movements which may cause ambient audio previews to occur
-     * @param event - The initiating mouse move interaction event
      */
-    protected _onMouseMove(event: PIXI.FederatedEvent): void;
+    protected _onMouseMove(): void;
 
-    protected override _onDragLeftStart(event: PIXI.FederatedEvent): ReturnType<AmbientSound["draw"]>;
+    protected override _onDragLeftStart(event: PIXI.FederatedEvent): void;
 
     protected override _onDragLeftMove(event: PIXI.FederatedEvent): void;
 
-    protected override _onDragLeftDrop(event: PIXI.FederatedEvent): Promise<void>;
+    protected override _onDragLeftDrop(event: PIXI.FederatedEvent): void;
 
     protected override _onDragLeftCancel(event: PointerEvent): void;
 
@@ -116,14 +193,105 @@ declare global {
   }
 
   namespace SoundsLayer {
+    type AnyConstructor = typeof AnySoundsLayer;
+
+    interface DrawOptions extends PlaceablesLayer.DrawOptions {}
+
+    interface TearDownOptions extends PlaceablesLayer.TearDownOptions {}
+
     interface LayerOptions extends PlaceablesLayer.LayerOptions<"AmbientSound"> {
       name: "sounds";
-      zIndex: 300;
+      zIndex: 900;
     }
 
     interface DropData extends Canvas.DropPosition {
       type: "PlaylistSound";
       uuid: string;
     }
+
+    interface PlayAtPositionOptions {
+      /**
+       * The maximum volume at which the effect should be played
+       * @defaultValue `1.0`
+       */
+      volume: number;
+      /**
+       * Should volume be attenuated by distance?
+       * @defaultValue `true`
+       */
+      easing: boolean;
+      /**
+       * Should the sound be constrained by walls?
+       * @defaultValue `true`
+       */
+      walls: boolean;
+      /**
+       * Should the sound always be played for GM users regardless of actively controlled tokens?
+       * @defaultValue `true`
+       */
+      gmAlways: boolean;
+      /** A base sound effect to apply to playback */
+      baseEffect: AmbientSoundEffect;
+      /** A muffled sound effect to apply to playback, a sound may only be muffled if it is not constrained by walls */
+      muffledEffect: AmbientSoundEffect;
+      /** Additional data passed to the SoundSource constructor */
+      sourceData: InexactPartial<PointSourceData>;
+      /** Additional options passed to Sound#play */
+      playbackOptions: foundry.audio.Sound.PlaybackOptions;
+    }
+
+    interface AmbientSoundPlaybackConfig {
+      /**
+       * The Sound node which should be controlled for playback
+       */
+      sound: foundry.audio.Sound;
+      /**
+       * The SoundSource which defines the area of effect for the sound
+       */
+      source: foundry.canvas.sources.PointSoundSource;
+      /**
+       * An AmbientSound object responsible for the sound, or undefined
+       */
+      object: AmbientSound | undefined;
+      /**
+       * The coordinates of the closest listener or undefined if there is none
+       */
+      listener: Canvas.Point | undefined;
+      /**
+       * The minimum distance between a listener and the AmbientSound origin
+       */
+      distance: number;
+      /**
+       * Is the closest listener muffled
+       */
+      muffled: boolean;
+      /**
+       * Is playback constrained or muffled by walls?
+       */
+      walls: boolean;
+      /**
+       * The final volume at which the Sound should be played
+       */
+      volume: number;
+    }
   }
+}
+/**
+ * @privateRemarks This is the only place in v12 (and v13 as of 332) where this v11 type is still used
+ */
+interface PointSourceData {
+  x: number;
+  y: number;
+  elevation: number;
+  z: number | null;
+  radius: number;
+  externalRadius: number;
+  rotation: number;
+  angle: number;
+  walls: boolean;
+  disabled: boolean;
+}
+
+declare abstract class AnySoundsLayer extends SoundsLayer {
+  constructor(arg0: never, ...args: never[]);
 }

--- a/src/foundry/client/pixi/layers/placeables/templates.d.mts
+++ b/src/foundry/client/pixi/layers/placeables/templates.d.mts
@@ -5,7 +5,10 @@ export {};
  * @see {@link MeasuredTemplate}
  */
 declare global {
-  class TemplateLayer extends PlaceablesLayer<"MeasuredTemplate"> {
+  class TemplateLayer<
+    DrawOptions extends TemplateLayer.DrawOptions = TemplateLayer.DrawOptions,
+    TearDownOptions extends PlaceablesLayer.TearDownOptions = PlaceablesLayer.TearDownOptions,
+  > extends PlaceablesLayer<"MeasuredTemplate", DrawOptions, TearDownOptions> {
     /**
      * @privateRemarks This is not overridden in foundry but reflects the real behavior.
      */
@@ -21,10 +24,8 @@ declare global {
      * ```
      * mergeObject(super.layerOptions, {
      *   name: "templates",
-     *   canDragCreate: true,
      *   rotatableObjects: true,
-     *   sortActiveTop: true,
-     *   zIndex: 50
+     *   zIndex: 400
      * })
      * ```
      */
@@ -36,12 +37,14 @@ declare global {
 
     override _deactivate(): void;
 
+    override _draw(options?: DrawOptions): Promise<void>;
+
     /**
      * Register game settings used by the TemplatesLayer
      */
     static registerSettings(): void;
 
-    protected override _onDragLeftStart(event: PIXI.FederatedEvent): Promise<MeasuredTemplate>;
+    protected override _onDragLeftStart(event: PIXI.FederatedEvent): void;
 
     protected override _onDragLeftMove(event: PIXI.FederatedEvent): void;
 
@@ -49,12 +52,18 @@ declare global {
   }
 
   namespace TemplateLayer {
+    type AnyConstructor = typeof AnyTemplateLayer;
+
+    interface DrawOptions extends PlaceablesLayer.DrawOptions {}
+
     interface LayerOptions extends PlaceablesLayer.LayerOptions<"MeasuredTemplate"> {
       name: "templates";
-      canDragCreate: true;
       rotatableObjects: true;
-      sortActiveTop: true;
-      zIndex: 50;
+      zIndex: 400;
     }
   }
+}
+
+declare abstract class AnyTemplateLayer extends TemplateLayer {
+  constructor(arg0: never, ...args: never[]);
 }

--- a/src/foundry/client/pixi/layers/placeables/templates.d.mts
+++ b/src/foundry/client/pixi/layers/placeables/templates.d.mts
@@ -48,7 +48,10 @@ declare global {
 
     protected override _onDragLeftMove(event: PIXI.FederatedEvent): void;
 
-    protected override _onMouseWheel(event: WheelEvent): void | ReturnType<MeasuredTemplate["rotate"]>;
+    // @ts-expect-error Foundry is changing the return type here from Promise<PlaceableObject[]> to Promise<MeasuredTemplate>
+    protected override _onMouseWheel(
+      event: WheelEvent,
+    ): ReturnType<MeasuredTemplate.ConfiguredInstance["rotate"]> | void;
   }
 
   namespace TemplateLayer {

--- a/src/foundry/client/pixi/layers/placeables/tiles.d.mts
+++ b/src/foundry/client/pixi/layers/placeables/tiles.d.mts
@@ -37,28 +37,31 @@ declare global {
     /**
      * An array of Tile objects which are rendered within the objects container
      */
-    get tiles(): Tile[];
+    get tiles(): Tile.ConfiguredInstance[];
 
-    override controllableObjects(): Generator<Tile>;
+    override controllableObjects(): Generator<Tile.ConfiguredInstance>;
 
     override getSnappedPoint(point: Canvas.Point): Canvas.Point;
 
-    _tearDown(options?: TearDownOptions): ReturnType<PlaceablesLayer<"Tile">["_draw"]>;
+    protected override _tearDown(options?: TearDownOptions): Promise<void>;
 
-    protected _onDragLeftStart(event: PIXI.FederatedEvent): void;
+    protected override _onDragLeftStart(event: PIXI.FederatedEvent): void;
 
-    protected _onDragLeftMove(event: PIXI.FederatedEvent): void;
+    protected override _onDragLeftMove(event: PIXI.FederatedEvent): void;
 
-    protected _onDragLeftDrop(event: PIXI.FederatedEvent): void;
+    protected override _onDragLeftDrop(event: PIXI.FederatedEvent): void;
 
-    protected _onDragLeftCancel(event: PointerEvent): ReturnType<PlaceablesLayer<"Tile">["_onDragLeftCancel"]>;
+    protected override _onDragLeftCancel(event: PointerEvent): void;
 
     /**
      * Handle drop events for Tile data on the Tiles Layer
      * @param event - The concluding drag event
      * @param data  - The extracted Tile data
      */
-    protected _onDropData(event: DragEvent, data: DropData.Any): Promise<TileDocument | false | void>;
+    protected _onDropData(
+      event: DragEvent,
+      data: DropData.Any, //TODO: I don't think this is right. It wants, I think, a TileDocument source?
+    ): Promise<TileDocument.ConfiguredInstance | false | void>;
 
     /**
      * Prepare the data object when a new Tile is dropped onto the canvas
@@ -66,14 +69,18 @@ declare global {
      * @param data  - The extracted Tile data
      * @returns The prepared data to create
      */
-    _getDropData(event: DragEvent, data: TilesLayer.DropData): Promise<DropData.Any>;
+    _getDropData(
+      event: DragEvent,
+      //TODO: I don't think this is right. It wants, I think, a TileDocument source? and also returns one
+      data: TilesLayer.DropData,
+    ): Promise<DropData.Any>;
 
     /**
      * Get an array of overhead Tile objects which are roofs
      * @deprecated since v12 until v14
      * @remarks "TilesLayer#roofs has been deprecated without replacement."
      */
-    get roofs(): Tile[];
+    get roofs(): Tile.ConfiguredInstance[];
 
     /**
      * @deprecated since v11, will be removed in v13

--- a/src/foundry/client/pixi/layers/placeables/tiles.d.mts
+++ b/src/foundry/client/pixi/layers/placeables/tiles.d.mts
@@ -1,4 +1,4 @@
-import type { DropData } from "../../../data/abstract/client-document.d.mts";
+import type BaseTile from "../../../../common/documents/tile.d.mts";
 
 declare global {
   /**
@@ -60,7 +60,7 @@ declare global {
      */
     protected _onDropData(
       event: DragEvent,
-      data: DropData.Any, //TODO: I don't think this is right. It wants, I think, a TileDocument source?
+      data: BaseTile.ConstructorData,
     ): Promise<TileDocument.ConfiguredInstance | false | void>;
 
     /**
@@ -69,11 +69,7 @@ declare global {
      * @param data  - The extracted Tile data
      * @returns The prepared data to create
      */
-    _getDropData(
-      event: DragEvent,
-      //TODO: I don't think this is right. It wants, I think, a TileDocument source? and also returns one
-      data: TilesLayer.DropData,
-    ): Promise<DropData.Any>;
+    _getDropData(event: DragEvent, data: BaseTile.ConstructorData): Promise<BaseTile.ConstructorData>;
 
     /**
      * Get an array of overhead Tile objects which are roofs

--- a/src/foundry/client/pixi/layers/placeables/tokens.d.mts
+++ b/src/foundry/client/pixi/layers/placeables/tokens.d.mts
@@ -1,5 +1,5 @@
 import type { ArrayOverlaps } from "../../../../../types/helperTypes.d.mts";
-import type { InexactPartial, NullishProps } from "../../../../../types/utils.d.mts";
+import type { NullishProps } from "../../../../../types/utils.d.mts";
 import type Document from "../../../../common/abstract/document.d.mts";
 
 declare global {
@@ -13,8 +13,9 @@ declare global {
     /**
      * The current index position in the tab cycle
      * @defaultValue `null`
+     * @remarks Foundry marked \@private but accesses it from Canvas
      */
-    protected _tabIndex: number | null;
+    _tabIndex: number | null;
 
     /**
      * @privateRemarks This is not overridden in foundry but reflects the real behavior.
@@ -62,13 +63,13 @@ declare global {
 
     override getSnappedPoint(point: Canvas.Point): Canvas.Point;
 
-    override _draw(options?: DrawOptions): Promise<void>;
+    protected override _draw(options?: DrawOptions): Promise<void>;
 
-    override _tearDown(options?: TearDownOptions): Promise<void>;
+    protected override _tearDown(options?: TearDownOptions): Promise<void>;
 
-    override _activate(): void;
+    protected override _activate(): void;
 
-    override _deactivate(): void;
+    protected override _deactivate(): void;
 
     override _pasteObject(
       copy: Token.ConfiguredInstance,
@@ -86,7 +87,7 @@ declare global {
      * @param rectangle - The selection rectangle.
      * @param options - Additional options to configure targeting behaviour.
      */
-    targetObjects(rectangle: Canvas.Rectangle, options?: InexactPartial<PlaceableObject.ControlOptions>): number;
+    targetObjects(rectangle: Canvas.Rectangle, options?: NullishProps<PlaceableObject.ControlOptions>): number;
 
     /**
      * Cycle the controlled token by rotating through the list of Owned Tokens that are available within the Scene
@@ -94,7 +95,7 @@ declare global {
      * @param forwards - Which direction to cycle. A truthy value cycles forward, while a false value cycles backwards.
      * @param reset    - Restart the cycle order back at the beginning?
      */
-    cycleTokens(forwards: boolean, reset: boolean): Token | null;
+    cycleTokens(forwards: boolean, reset: boolean): Token.ConfiguredInstance | null;
 
     /**
      * Get the tab cycle order for tokens by sorting observable tokens based on their distance from top-left.
@@ -119,7 +120,7 @@ declare global {
 
     override storeHistory(
       type: PlaceablesLayer.HistoryEventType,
-      data: TokenDocument.ConfiguredInstance["_source"],
+      data: Document.ConfiguredSourceForName<"Token">[],
     ): void;
 
     /**
@@ -131,7 +132,7 @@ declare global {
     ): Promise<ReturnType<Notifications["warn"]> | false | TokenDocument.ConfiguredInstance>;
 
     //TODO: use configured ruler type once it exists
-    protected override _onClickLeft(event: PIXI.FederatedEvent): ReturnType<Ruler["_onClickLeft"]>; // ReturnType<CONFIG.Canvas["rulerClass"]["_onClickLeft"]>;
+    protected override _onClickLeft(event: PIXI.FederatedEvent): ReturnType<Ruler["_onClickLeft"]> | void; // ReturnType<CONFIG.Canvas["rulerClass"]["_onClickLeft"]>;
 
     protected override _onMouseWheel(event: WheelEvent): ReturnType<this["rotateMany"]>;
 

--- a/src/foundry/client/pixi/layers/placeables/tokens.d.mts
+++ b/src/foundry/client/pixi/layers/placeables/tokens.d.mts
@@ -1,3 +1,4 @@
+import type { ArrayOverlaps } from "../../../../../types/helperTypes.d.mts";
 import type { InexactPartial, NullishProps } from "../../../../../types/utils.d.mts";
 import type Document from "../../../../common/abstract/document.d.mts";
 
@@ -75,7 +76,10 @@ declare global {
       options?: NullishProps<{ hidden: boolean; snap: boolean }>,
     ): Document.ConfiguredSourceForName<"Token">;
 
-    protected override _getMovableObjects(ids: string[] | null, includeLocked: boolean): Token.ConfiguredInstance[];
+    protected override _getMovableObjects<T>(
+      ids?: ArrayOverlaps<T, string>,
+      includeLocked?: boolean,
+    ): Token.ConfiguredInstance[];
 
     /**
      * Target all Token instances which fall within a coordinate rectangle.

--- a/src/foundry/client/pixi/perception/fog.d.mts
+++ b/src/foundry/client/pixi/perception/fog.d.mts
@@ -35,7 +35,7 @@ declare global {
     /**
      * The configured options used for the saved fog-of-war texture.
      */
-    get textureConfiguration(): FogTextureConfiguration;
+    get textureConfiguration(): VisibilityTextureConfiguration;
 
     /**
      * Does the currently viewed Scene support Token field of vision?
@@ -50,7 +50,7 @@ declare global {
     /**
      * Create the exploration display object with or without a provided texture.
      */
-    protected _createExplorationObject(tex?: PIXI.Texture | PIXI.RenderTexture): DisplayObject
+    protected _createExplorationObject(tex?: PIXI.Texture | PIXI.RenderTexture): DisplayObject;
 
     /**
      * Initialize fog of war - resetting it when switching scenes or re-drawing the canvas

--- a/src/foundry/client/pixi/placeable.d.mts
+++ b/src/foundry/client/pixi/placeable.d.mts
@@ -593,6 +593,11 @@ declare global {
       releaseOthers?: boolean;
     }
 
+    /**
+     * @privateRemarks `PlaceableObject#_onDelete` is the only place in foundry code that calls `PlaceableObject#release` with any options at all,
+     * where it passes `{trigger: false}`. This is passed on to `PlaceableObject#_onRelease`, which does not check for any options, including trigger.
+     * `Drawing`, `Region`, and `Token` extend `_onRelease` and pass the options back to `super`, but do no further checks.
+     * */
     interface ReleaseOptions {
       trigger?: boolean;
     }

--- a/src/foundry/common/documents/_types.d.mts
+++ b/src/foundry/common/documents/_types.d.mts
@@ -73,7 +73,8 @@ export type AmbientLightData = BaseAmbientLight.Properties;
 
 export type AmbientSoundData = BaseAmbientSound.Properties;
 
-export type AmbientSoundEffect = unknown; // TODO: Add when BaseAmbientSound's schema is updated.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type AmbientSoundEffect = { type: string; intensity: number }; // TODO: Audit and maybe move when BaseAmbientSound's schema is updated.
 
 export type CardData = BaseCard.Properties;
 

--- a/src/foundry/common/documents/_types.d.mts
+++ b/src/foundry/common/documents/_types.d.mts
@@ -73,8 +73,10 @@ export type AmbientLightData = BaseAmbientLight.Properties;
 
 export type AmbientSoundData = BaseAmbientSound.Properties;
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-export type AmbientSoundEffect = { type: string; intensity: number }; // TODO: Audit and maybe move when BaseAmbientSound's schema is updated.
+export interface AmbientSoundEffect {
+  type: string;
+  intensity: number;
+} // TODO: Audit and maybe move when BaseAmbientSound's schema is updated.
 
 export type CardData = BaseCard.Properties;
 

--- a/src/types/augments/pixi.d.mts
+++ b/src/types/augments/pixi.d.mts
@@ -9,44 +9,12 @@ export * from "pixi.js";
  */
 export as namespace PIXI;
 
-declare abstract class AnyPIXIShader extends PIXI.Shader {
-  constructor(arg0: never, ...args: never[]);
-}
-
-declare abstract class AnyPIXIFilter extends PIXI.Filter {
-  constructor(arg0: never, ...args: never[]);
-}
-
-declare abstract class AnyPIXIBatchGeometry extends PIXI.BatchGeometry {
-  constructor(arg0: never, ...args: never[]);
-}
-
-declare abstract class AnyPIXIBatchRenderer extends PIXI.BatchRenderer {
-  constructor(arg0: never, ...args: never[]);
-}
-
-declare abstract class AnyDisplayObject extends PIXI.DisplayObject {
-  constructor(arg0: never, ...args: never[]);
-}
-
 declare global {
   namespace PIXI {
     export import smooth = graphicsSmooth;
     export import particles = pixiParticles;
 
     export class Graphics extends PIXI.smooth.SmoothGraphics {}
-
-    export import Shader = _PIXI.Shader;
-
-    namespace Shader {
-      type AnyConstructor = typeof AnyPIXIShader;
-    }
-
-    export import Filter = _PIXI.Filter;
-
-    namespace Filter {
-      type AnyConstructor = typeof AnyPIXIFilter;
-    }
 
     export import BatchGeometry = _PIXI.BatchGeometry;
 
@@ -60,10 +28,30 @@ declare global {
       type AnyConstructor = typeof AnyPIXIBatchRenderer;
     }
 
+    export import Container = _PIXI.Container;
+
+    namespace Container {
+      type AnyConstructor = typeof AnyPIXIContainer;
+    }
+
     export import DisplayObject = _PIXI.DisplayObject;
 
     namespace DisplayObject {
       type AnyConstructor = typeof AnyDisplayObject;
+
+      type DestroyOptions = _PIXI.IDestroyOptions | boolean;
+    }
+
+    export import Filter = _PIXI.Filter;
+
+    namespace Filter {
+      type AnyConstructor = typeof AnyPIXIFilter;
+    }
+
+    export import Shader = _PIXI.Shader;
+
+    namespace Shader {
+      type AnyConstructor = typeof AnyPIXIShader;
     }
   }
 }
@@ -84,4 +72,28 @@ declare module "pixi.js" {
      */
     PERCEPTION = 2,
   }
+}
+
+declare abstract class AnyPIXIBatchGeometry extends PIXI.BatchGeometry {
+  constructor(arg0: never, ...args: never[]);
+}
+
+declare abstract class AnyPIXIBatchRenderer extends PIXI.BatchRenderer {
+  constructor(arg0: never, ...args: never[]);
+}
+
+declare abstract class AnyPIXIContainer extends PIXI.Container {
+  constructor(arg0: never, ...args: never[]);
+}
+
+declare abstract class AnyDisplayObject extends PIXI.DisplayObject {
+  constructor(arg0: never, ...args: never[]);
+}
+
+declare abstract class AnyPIXIFilter extends PIXI.Filter {
+  constructor(arg0: never, ...args: never[]);
+}
+
+declare abstract class AnyPIXIShader extends PIXI.Shader {
+  constructor(arg0: never, ...args: never[]);
 }

--- a/src/types/helperTypes.d.mts
+++ b/src/types/helperTypes.d.mts
@@ -44,7 +44,7 @@ type _GetKey<T, K extends PropertyKey, D> = T extends { readonly [_ in K]?: infe
  * - Use `IntentionalPartial` when an explicit `undefined` is problematic but
  *   leaving off the property entirely is fine. This primarily occurs when
  *   patterns like `options = { ...defaultOptions, ...options }`,
- *   `Object.apply({}, defaultOptions, options)`,
+ *   `Object.assign({}, defaultOptions, options)`,
  *   `foundry.utils.mergeObject(defaultOptions, options)`, or so on.
  *
  *   Note that {@link foundry.utils.mergeObject | `foundry.utils.mergeObject`}

--- a/src/types/helperTypes.d.mts
+++ b/src/types/helperTypes.d.mts
@@ -66,7 +66,10 @@ export type IntentionalPartial<T> = Partial<T>;
 /**
  * This type is used to make a constraint where `T` must be statically known to overlap with `U`.
  */
-export type OverlapsWith<T, U> = [T & U] extends [never] ? U : T;
+export type OverlapsWith<T, U> = Extract<T, U> extends [never] ? U : T;
+
+export type ArrayOverlaps<T, Item> =
+  Extract<T, readonly unknown[]> extends readonly Item[] ? OverlapsWith<T, readonly Item[]> : readonly Item[];
 
 /**
  * Use this whenever a type is given that should match some constraint but is

--- a/src/types/utils.d.mts
+++ b/src/types/utils.d.mts
@@ -70,7 +70,7 @@ export type InexactPartial<T extends object, K extends AllKeysOf<T> = AllKeysOf<
  * - Use `IntentionalPartial` when an explicit `undefined` is problematic but
  *   leaving off the property entirely is fine. This primarily occurs when
  *   patterns like `options = { ...defaultOptions, ...options }`,
- *   `Object.apply({}, defaultOptions, options)`,
+ *   `Object.assign({}, defaultOptions, options)`,
  *   `foundry.utils.mergeObject(defaultOptions, options)`, or so on.
  *
  *   Note that {@link foundry.utils.mergeObject | `foundry.utils.mergeObject`}

--- a/src/types/utils.d.mts
+++ b/src/types/utils.d.mts
@@ -31,7 +31,7 @@ export type AllKeysOf<T extends object> = T extends unknown ? keyof T : never;
  * - Use `IntentionalPartial` when an explicit `undefined` is problematic but
  *   leaving off the property entirely is fine. This primarily occurs when
  *   patterns like `options = { ...defaultOptions, ...options }`,
- *   `Object.apply({}, defaultOptions, options)`,
+ *   `Object.assign({}, defaultOptions, options)`,
  *   `foundry.utils.mergeObject(defaultOptions, options)`, or so on.
  *
  *   Note that {@link foundry.utils.mergeObject | `foundry.utils.mergeObject`}

--- a/tests/foundry/client/pixi/layers/effects/weather-effects.test-d.ts
+++ b/tests/foundry/client/pixi/layers/effects/weather-effects.test-d.ts
@@ -1,7 +1,7 @@
 import { expectTypeOf } from "vitest";
 
 expectTypeOf(WeatherEffects.instance).toEqualTypeOf<EffectsCanvasGroup | undefined>();
-expectTypeOf(WeatherEffects.layerOptions).toEqualTypeOf<WeatherLayer.LayerOptions>();
+expectTypeOf(WeatherEffects.layerOptions).toEqualTypeOf<WeatherEffects.LayerOptions>();
 expectTypeOf(WeatherEffects.layerOptions.name).toEqualTypeOf<"effects">();
 
 const layer = new WeatherEffects();


### PR DESCRIPTION
- Added generic params for the as-yet-unused `DrawOptions` and `TearDownOptions`
- Audited use of `InexactPartial` and replaced with `NullishProps` where possible
- Bunch of other stuff I didn't document in a nice bullet-point-y way.
- Had to `//@ts-expect-error` in a couple places because Foundry Bad