### PR TITLE
AmbientLightConfig, AmbientSoundConfig, UserConfig implementations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,12 +44,12 @@
         "eslint-config-prettier": "^9.1.0",
         "eslint-import-resolver-typescript": "^3.6.1",
         "eslint-plugin-import": "^2.29.1",
-        "eslint-plugin-tsdoc": "^0.3.0",
+        "eslint-plugin-tsdoc": "^0.4.0",
         "husky": "^9.1.4",
         "is-ci": "^3.0.1",
         "lint-staged": "^15.2.10",
         "prettier": "^3.0.3",
-        "typescript": "~5.6",
+        "typescript": "~5.7",
         "vitest": "^2.1.4"
       },
       "peerDependencies": {
@@ -603,18 +603,20 @@
       "license": "MIT"
     },
     "node_modules/@microsoft/tsdoc": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.0.tgz",
-      "integrity": "sha512-HZpPoABogPvjeJOdzCOSJsXeL/SMCBgBZMVC3X3d7YYp2gf31MfxhUoYUNwf1ERPJOnQc0wkFn9trqI6ZEdZuA==",
-      "dev": true
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.1.tgz",
+      "integrity": "sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@microsoft/tsdoc-config": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.17.0.tgz",
-      "integrity": "sha512-v/EYRXnCAIHxOHW+Plb6OWuUoMotxTN0GLatnpOb1xq0KuTNw/WI3pamJx/UbsoJP5k9MCw1QxvvhPcF9pH3Zg==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.17.1.tgz",
+      "integrity": "sha512-UtjIFe0C6oYgTnad4q1QP4qXwLhe6tIpNTRStJ2RZEPIkqQPREAwE5spzVxsdn9UaEMUqhh0AqSx3X4nWAKXWw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@microsoft/tsdoc": "0.15.0",
+        "@microsoft/tsdoc": "0.15.1",
         "ajv": "~8.12.0",
         "jju": "~1.4.0",
         "resolve": "~1.22.2"
@@ -625,6 +627,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -640,7 +643,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -2605,24 +2609,6 @@
         "ms": "^2.1.1"
       }
     },
-    "node_modules/eslint-import-resolver-node/node_modules/resolve": {
-      "version": "1.22.8",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-core-module": "^2.13.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/eslint-import-resolver-typescript": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.6.1.tgz",
@@ -2767,13 +2753,14 @@
       }
     },
     "node_modules/eslint-plugin-tsdoc": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-tsdoc/-/eslint-plugin-tsdoc-0.3.0.tgz",
-      "integrity": "sha512-0MuFdBrrJVBjT/gyhkP2BqpD0np1NxNLfQ38xXDlSs/KVVpKI2A6vN7jx2Rve/CyUsvOsMGwp9KKrinv7q9g3A==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-tsdoc/-/eslint-plugin-tsdoc-0.4.0.tgz",
+      "integrity": "sha512-MT/8b4aKLdDClnS8mP3R/JNjg29i0Oyqd/0ym6NnQf+gfKbJJ4ZcSh2Bs1H0YiUMTBwww5JwXGTWot/RwyJ7aQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@microsoft/tsdoc": "0.15.0",
-        "@microsoft/tsdoc-config": "0.17.0"
+        "@microsoft/tsdoc": "0.15.1",
+        "@microsoft/tsdoc-config": "0.17.1"
       }
     },
     "node_modules/eslint-scope": {
@@ -3833,7 +3820,8 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
       "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -4962,6 +4950,7 @@
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4971,6 +4960,7 @@
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
       "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
@@ -5790,9 +5780,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/src/foundry/client-esm/applications/api/application.d.mts
+++ b/src/foundry/client-esm/applications/api/application.d.mts
@@ -301,7 +301,7 @@ declare namespace ApplicationV2 {
     disabled?: boolean | undefined;
   }
 
-  interface ChangeTabOptions {
+  interface ChangeTabOptions extends InexactPartial<{
     /**
      * An interaction event which caused the tab change, if any
      */
@@ -320,7 +320,7 @@ declare namespace ApplicationV2 {
      * @defaultValue `false`
      */
     updatePosition: boolean;
-  }
+  }> {}
 }
 
 /**
@@ -589,7 +589,7 @@ declare class ApplicationV2<
    * @remarks InexactPartial is used over NullishProps because event/navElement are not called with null as a possible value,
    *          and null interferes with the defaults of force/updatePosition
    */
-  changeTab(tab: string, group: string, options?: InexactPartial<ApplicationV2.ChangeTabOptions>): void;
+  changeTab(tab: string, group: string, options?: ApplicationV2.ChangeTabOptions): void;
 
   /**
    * Test whether this Application is allowed to be rendered.

--- a/src/foundry/client-esm/applications/api/application.d.mts
+++ b/src/foundry/client-esm/applications/api/application.d.mts
@@ -1,5 +1,11 @@
 import type { MustConform } from "../../../../types/helperTypes.d.mts";
-import type { AnyObject, DeepPartial, EmptyObject, InexactPartial, MaybePromise } from "../../../../types/utils.d.mts";
+import type {
+  AnyObject,
+  DeepPartial,
+  EmptyObject,
+  InexactPartial,
+  MaybePromise,
+} from "../../../../types/utils.d.mts";
 import type EventEmitterMixin from "../../../common/utils/event-emitter.d.mts";
 
 // TODO: Investigate use of DeepPartial vs Partial vs InexactPartial
@@ -294,6 +300,27 @@ declare namespace ApplicationV2 {
     /** @defaultValue `false` */
     disabled?: boolean | undefined;
   }
+
+  interface ChangeTabOptions {
+    /**
+     * An interaction event which caused the tab change, if any
+     */
+    event: Event;
+    /**
+     * An explicit navigation element being modified
+     */
+    navElement: HTMLElement;
+    /**
+     * Force changing the tab even if the new tab is already active
+     * @defaultValue `false`
+     */
+    force: boolean;
+    /**
+     * Update application position after changing the tab?
+     * @defaultValue `false`
+     */
+    updatePosition: boolean;
+  }
 }
 
 /**
@@ -559,31 +586,10 @@ declare class ApplicationV2<
    * @param tab     - The name of the tab which should become active
    * @param group   - The name of the tab group which defines the set of tabs
    * @param options - Additional options which affect tab navigation
+   * @remarks InexactPartial is used over NullishProps because event/navElement are not called with null as a possible value,
+   *          and null interferes with the defaults of force/updatePosition
    */
-  changeTab(
-    tab: string,
-    group: string,
-    options?: InexactPartial<{
-      /**
-       * An interaction event which caused the tab change, if any
-       */
-      event: Event;
-      /**
-       * An explicit navigation element being modified
-       */
-      navElement: HTMLElement;
-      /**
-       * Force changing the tab even if the new tab is already active
-       * @defaultValue `false`
-       */
-      force: boolean;
-      /**
-       * Update application position after changing the tab?
-       * @defaultValue `false`
-       */
-      updatePosition: boolean;
-    }>,
-  ): void;
+  changeTab(tab: string, group: string, options?: InexactPartial<ApplicationV2.ChangeTabOptions>): void;
 
   /**
    * Test whether this Application is allowed to be rendered.

--- a/src/foundry/client-esm/applications/sheets/ambient-light-config.d.mts
+++ b/src/foundry/client-esm/applications/sheets/ambient-light-config.d.mts
@@ -1,12 +1,14 @@
-import type { AnyObject, EmptyObject } from "../../../../types/utils.d.mts";
+import type { InterfaceToObject } from "../../../../types/helperTypes.d.mts";
+import type { AnyObject, DeepPartial, InexactPartial } from "../../../../types/utils.d.mts";
+import type ApplicationV2 from "../api/application.d.mts";
 import type DocumentSheetV2 from "../api/document-sheet.d.mts";
 import type HandlebarsApplicationMixin from "../api/handlebars-application.d.mts";
 
 /**
  * The AmbientLight configuration application.
  */
-export default class AmbientLightConfig<
-  RenderContext extends AnyObject = EmptyObject,
+declare class AmbientLightConfig<
+  RenderContext extends AnyObject = InterfaceToObject<AmbientLightConfig.RenderContext>,
   Configuration extends
     DocumentSheetV2.Configuration<AmbientLightDocument.ConfiguredInstance> = DocumentSheetV2.Configuration<AmbientLightDocument.ConfiguredInstance>,
   RenderOptions extends DocumentSheetV2.RenderOptions = DocumentSheetV2.RenderOptions,
@@ -15,4 +17,56 @@ export default class AmbientLightConfig<
   RenderContext,
   Configuration,
   RenderOptions
-> {}
+> {
+  static override DEFAULT_OPTIONS: DeepPartial<ApplicationV2.Configuration>;
+
+  static override PARTS: Record<string, HandlebarsApplicationMixin.HandlebarsTemplatePart>;
+
+  /**
+   * Maintain a copy of the original to show a real-time preview of changes.
+   */
+  preview: AmbientLightDocument.ConfiguredInstance | undefined;
+
+  override tabGroups: {
+    sheet: string;
+  }
+
+  protected override _preRender(context: DeepPartial<RenderContext>, options: DeepPartial<RenderOptions>): Promise<void>;
+
+  protected override _onRender(context: DeepPartial<RenderContext>, options: DeepPartial<RenderOptions>): Promise<void>;
+
+  protected override _onClose(options: DeepPartial<RenderOptions>): void;
+
+  protected override _prepareContext(options: DeepPartial<RenderOptions>): Promise<RenderContext>;
+
+  override changeTab(tab: string, group: string, options?: InexactPartial<ApplicationV2.ChangeTabOptions>): void;
+
+  override _onChangeForm(formConfig: ApplicationV2.FormConfiguration, event: Event): void;
+
+  /**
+   * Preview changes to the AmbientLight document as if they were true document updates.
+   * @param change - A change to preview
+   */
+  protected _previewChanges(change?: foundry.documents.BaseAmbientLight.UpdateData): void;
+
+  /**
+   * Restore the true data for the AmbientLight document when the form is submitted or closed.
+   */
+  protected _resetPreview(): void;
+}
+
+declare namespace AmbientLightConfig {
+  interface RenderContext {
+    light: AmbientLightDocument.ConfiguredInstance;
+    source: foundry.documents.BaseAmbientLight.Source;
+    fields: AmbientLightDocument["schema"]["fields"];
+    colorationTechniques: typeof AdaptiveLightingShader["SHADER_TECHNIQUES"];
+    gridUnits: string;
+    isDarkness: boolean;
+    lightAnimations: unknown; // TODO: Update after CONFIG updated
+    tabs: Record<string, ApplicationV2.Tab>;
+    buttons: ApplicationV2.FormFooterButton[];
+  }
+}
+
+export default AmbientLightConfig;

--- a/src/foundry/client-esm/applications/sheets/ambient-light-config.d.mts
+++ b/src/foundry/client-esm/applications/sheets/ambient-light-config.d.mts
@@ -1,5 +1,5 @@
 import type { InterfaceToObject } from "../../../../types/helperTypes.d.mts";
-import type { AnyObject, DeepPartial, InexactPartial } from "../../../../types/utils.d.mts";
+import type { AnyObject, DeepPartial } from "../../../../types/utils.d.mts";
 import type ApplicationV2 from "../api/application.d.mts";
 import type DocumentSheetV2 from "../api/document-sheet.d.mts";
 import type HandlebarsApplicationMixin from "../api/handlebars-application.d.mts";
@@ -39,7 +39,7 @@ declare class AmbientLightConfig<
 
   protected override _prepareContext(options: DeepPartial<RenderOptions>): Promise<RenderContext>;
 
-  override changeTab(tab: string, group: string, options?: InexactPartial<ApplicationV2.ChangeTabOptions>): void;
+  override changeTab(tab: string, group: string, options?: ApplicationV2.ChangeTabOptions): void;
 
   override _onChangeForm(formConfig: ApplicationV2.FormConfiguration, event: Event): void;
 
@@ -53,13 +53,18 @@ declare class AmbientLightConfig<
    * Restore the true data for the AmbientLight document when the form is submitted or closed.
    */
   protected _resetPreview(): void;
+
+  /**
+   * @privateRemarks Prevents duck typing
+   */
+  #private: true;
 }
 
 declare namespace AmbientLightConfig {
   interface RenderContext {
     light: AmbientLightDocument.ConfiguredInstance;
     source: foundry.documents.BaseAmbientLight.Source;
-    fields: AmbientLightDocument["schema"]["fields"];
+    fields: foundry.documents.BaseAmbientLight.Schema;
     colorationTechniques: typeof AdaptiveLightingShader["SHADER_TECHNIQUES"];
     gridUnits: string;
     isDarkness: boolean;

--- a/src/foundry/client-esm/applications/sheets/ambient-light-config.d.mts
+++ b/src/foundry/client-esm/applications/sheets/ambient-light-config.d.mts
@@ -18,7 +18,7 @@ declare class AmbientLightConfig<
   Configuration,
   RenderOptions
 > {
-  static override DEFAULT_OPTIONS: DeepPartial<ApplicationV2.Configuration>;
+  static override DEFAULT_OPTIONS: DocumentSheetV2.Configuration<AmbientLightDocument.ConfiguredInstance>;
 
   static override PARTS: Record<string, HandlebarsApplicationMixin.HandlebarsTemplatePart>;
 

--- a/src/foundry/client-esm/applications/sheets/ambient-light-config.d.mts
+++ b/src/foundry/client-esm/applications/sheets/ambient-light-config.d.mts
@@ -18,7 +18,7 @@ declare class AmbientLightConfig<
   Configuration,
   RenderOptions
 > {
-  static override DEFAULT_OPTIONS: DocumentSheetV2.Configuration<AmbientLightDocument.ConfiguredInstance>;
+  static override DEFAULT_OPTIONS: DeepPartial<DocumentSheetV2.Configuration<AmbientLightDocument.ConfiguredInstance>>;
 
   static override PARTS: Record<string, HandlebarsApplicationMixin.HandlebarsTemplatePart>;
 

--- a/src/foundry/client-esm/applications/sheets/ambient-sound-config.d.mts
+++ b/src/foundry/client-esm/applications/sheets/ambient-sound-config.d.mts
@@ -18,7 +18,7 @@ declare class AmbientSoundConfig<
   Configuration,
   RenderOptions
 > {
-  static override DEFAULT_OPTIONS: DocumentSheetV2.Configuration<AmbientSoundDocument.ConfiguredInstance>;
+  static override DEFAULT_OPTIONS: DeepPartial<DocumentSheetV2.Configuration<AmbientSoundDocument.ConfiguredInstance>>;
 
   static override PARTS: Record<string, HandlebarsApplicationMixin.HandlebarsTemplatePart>;
 

--- a/src/foundry/client-esm/applications/sheets/ambient-sound-config.d.mts
+++ b/src/foundry/client-esm/applications/sheets/ambient-sound-config.d.mts
@@ -1,12 +1,14 @@
-import type { AnyObject, EmptyObject } from "../../../../types/utils.d.mts";
+import type { InterfaceToObject } from "../../../../types/helperTypes.d.mts";
+import type { AnyObject, DeepPartial } from "../../../../types/utils.d.mts";
+import type ApplicationV2 from "../api/application.d.mts";
 import type DocumentSheetV2 from "../api/document-sheet.d.mts";
 import type HandlebarsApplicationMixin from "../api/handlebars-application.d.mts";
 
 /**
  * The AmbientSound configuration application.
  */
-export default class AmbientSoundConfig<
-  RenderContext extends AnyObject = EmptyObject,
+declare class AmbientSoundConfig<
+  RenderContext extends AnyObject = InterfaceToObject<AmbientSoundConfig.RenderContext>,
   Configuration extends
     DocumentSheetV2.Configuration<AmbientSoundDocument.ConfiguredInstance> = DocumentSheetV2.Configuration<AmbientSoundDocument.ConfiguredInstance>,
   RenderOptions extends DocumentSheetV2.RenderOptions = DocumentSheetV2.RenderOptions,
@@ -15,4 +17,31 @@ export default class AmbientSoundConfig<
   RenderContext,
   Configuration,
   RenderOptions
-> {}
+> {
+  static override DEFAULT_OPTIONS: DocumentSheetV2.Configuration<AmbientSoundDocument.ConfiguredInstance>;
+
+  static override PARTS: Record<string, HandlebarsApplicationMixin.HandlebarsTemplatePart>;
+
+  get title(): string;
+
+  protected override _prepareContext(options: DeepPartial<RenderOptions>): Promise<RenderContext>;
+
+  protected override _onRender(context: DeepPartial<RenderContext>, options: DeepPartial<RenderOptions>): Promise<void>;
+
+  protected override _onClose(options: DeepPartial<RenderOptions>): void;
+
+  override _onChangeForm(formConfig: ApplicationV2.FormConfiguration, event: Event): void;
+}
+
+declare namespace AmbientSoundConfig {
+  interface RenderContext {
+    sound: AmbientSoundDocument.ConfiguredInstance;
+    source: foundry.documents.BaseAmbientSound.Source;
+    fields: AmbientSoundDocument["schema"]["fields"];
+    gridUnits: string;
+    soundEffects: unknown; // TODO: Update after CONFIG updated
+    buttons: ApplicationV2.FormFooterButton[];
+  }
+}
+
+export default AmbientSoundConfig;

--- a/src/foundry/client-esm/applications/sheets/ambient-sound-config.d.mts
+++ b/src/foundry/client-esm/applications/sheets/ambient-sound-config.d.mts
@@ -31,13 +31,18 @@ declare class AmbientSoundConfig<
   protected override _onClose(options: DeepPartial<RenderOptions>): void;
 
   override _onChangeForm(formConfig: ApplicationV2.FormConfiguration, event: Event): void;
+
+  /**
+   * @privateRemarks Prevents duck typing
+   */
+  #private: true;
 }
 
 declare namespace AmbientSoundConfig {
   interface RenderContext {
     sound: AmbientSoundDocument.ConfiguredInstance;
     source: foundry.documents.BaseAmbientSound.Source;
-    fields: AmbientSoundDocument["schema"]["fields"];
+    fields: foundry.documents.BaseAmbientSound.Schema;
     gridUnits: string;
     soundEffects: unknown; // TODO: Update after CONFIG updated
     buttons: ApplicationV2.FormFooterButton[];

--- a/src/foundry/client-esm/applications/sheets/user-config.d.mts
+++ b/src/foundry/client-esm/applications/sheets/user-config.d.mts
@@ -1,12 +1,14 @@
-import type { AnyObject, EmptyObject } from "../../../../types/utils.d.mts";
+import type { InterfaceToObject } from "../../../../types/helperTypes.d.mts";
+import type { AnyObject, DeepPartial } from "../../../../types/utils.d.mts";
 import type DocumentSheetV2 from "../api/document-sheet.d.mts";
 import type HandlebarsApplicationMixin from "../api/handlebars-application.d.mts";
+import type { CustomFormGroup } from "../forms/fields.d.mts";
 
 /**
  * The User configuration application.
  */
-export default class UserConfig<
-  RenderContext extends AnyObject = EmptyObject,
+declare class UserConfig<
+  RenderContext extends AnyObject = InterfaceToObject<UserConfig.RenderContext>,
   Configuration extends
     DocumentSheetV2.Configuration<User.ConfiguredInstance> = DocumentSheetV2.Configuration<User.ConfiguredInstance>,
   RenderOptions extends DocumentSheetV2.RenderOptions = DocumentSheetV2.RenderOptions,
@@ -15,4 +17,23 @@ export default class UserConfig<
   RenderContext,
   Configuration,
   RenderOptions
-> {}
+> {
+  static override DEFAULT_OPTIONS: DocumentSheetV2.Configuration<User.ConfiguredInstance>;
+
+  static override PARTS: Record<string, HandlebarsApplicationMixin.HandlebarsTemplatePart>;
+
+  get title(): string;
+
+  protected override _prepareContext(options: DeepPartial<RenderOptions>): Promise<RenderContext>;
+}
+
+declare namespace UserConfig {
+  interface RenderContext {
+    user: User.ConfiguredInstance;
+    source: foundry.documents.BaseUser.Source;
+    fields: User["schema"]["fields"];
+    characterWidget: CustomFormGroup;
+  }
+}
+
+export default UserConfig;

--- a/src/foundry/client-esm/applications/sheets/user-config.d.mts
+++ b/src/foundry/client-esm/applications/sheets/user-config.d.mts
@@ -25,13 +25,18 @@ declare class UserConfig<
   get title(): string;
 
   protected override _prepareContext(options: DeepPartial<RenderOptions>): Promise<RenderContext>;
+
+  /**
+   * @privateRemarks Prevents duck typing
+   */
+  #private: true;
 }
 
 declare namespace UserConfig {
   interface RenderContext {
     user: User.ConfiguredInstance;
     source: foundry.documents.BaseUser.Source;
-    fields: User["schema"]["fields"];
+    fields: foundry.documents.BaseUser.Schema;
     characterWidget: CustomFormGroup;
   }
 }

--- a/tests/foundry/client/data/collections/users.test-d.ts
+++ b/tests/foundry/client/data/collections/users.test-d.ts
@@ -5,3 +5,6 @@ const users = new Users();
 expectTypeOf(users.get("", { strict: true })).toEqualTypeOf<Document.Stored<User>>();
 expectTypeOf(users.toJSON()).toEqualTypeOf<Document.Stored<User>["_source"][]>();
 expectTypeOf(users.directory).toEqualTypeOf<undefined | SidebarTab | null>();
+
+// Validating that the registerSheet API takes AppV2
+Users.registerSheet("core", foundry.applications.sheets.UserConfig);


### PR DESCRIPTION
Completes non-region work on #2612 

question; these classes have several private functions, primarily for their `actions` but also to help context prep. Should I include a `#private` property on the classes for duck typing purposes?