### PR TITLE
HandleEmptyObject deduped and broadened

### DIFF
--- a/src/foundry/client/config.d.mts
+++ b/src/foundry/client/config.d.mts
@@ -1,8 +1,8 @@
-import type { GetKey, HandleEmptyObject, InterfaceToObject } from "../../types/helperTypes.d.mts";
+import type { GetKey } from "../../types/helperTypes.d.mts";
 import type * as CONST from "../common/constants.d.mts";
 import type { DataModel, Document } from "../common/abstract/module.d.mts";
 import type PointLightSource from "../client-esm/canvas/sources/point-light-source.d.mts";
-import type { AnyObject, MaybePromise } from "../../types/utils.d.mts";
+import type { AnyObject, HandleEmptyObject, MaybePromise } from "../../types/utils.d.mts";
 
 declare global {
   namespace CONFIG {
@@ -2019,10 +2019,7 @@ declare global {
      * A mapping of status effect IDs which provide some additional mechanical integration.
      * @defaultValue `{ DEFEATED: "dead", INVISIBLE: "invisible", BLIND: "blind", BURROW: "burrow", HOVER: "hover", FLY: "fly" }`
      */
-    specialStatusEffects: HandleEmptyObject<
-      InterfaceToObject<CONFIG.SpecialStatusEffects>,
-      InterfaceToObject<CONFIG.DefaultSpecialStatusEffects>
-    >;
+    specialStatusEffects: HandleEmptyObject<CONFIG.SpecialStatusEffects, CONFIG.DefaultSpecialStatusEffects>;
 
     /**
      * A mapping of core audio effects used which can be replaced by systems or mods

--- a/src/types/helperTypes.d.mts
+++ b/src/types/helperTypes.d.mts
@@ -159,47 +159,6 @@ export type InterfaceToObject<T extends object> = {
 };
 
 /**
- * Replaces the type `{}` with `Record<string, never>` which is usually a better
- * representation of an empty object. The type `{}` actually allows any type be
- * assigned to it except for `null` and `undefined`.
- *
- * The theory behind this is that all non-nullish types allow
- * you to access any property on them without erroring. Primitive types like
- * `number` will not store the property but it still will not error to simply
- * try to get and set properties.
- *
- * The type `{}` can appear for example after operations like `Omit` if it
- * removes all properties rom an object, because an empty interface was given,
- * or so on.
- *
- * @example
- * ```ts
- * type ObjectArray<T extends Record<string, unknown>> = T[];
- *
- * // As you would hope a union can't be assigned. It errors with:
- * // "type 'string' is not assignable to type 'Record<string, unknown>'."
- * type UnionErrors = ObjectArray<string | { x: number }>;
- *
- * // However, this works.
- * type EmptyObjectArray = ObjectArray<{}>;
- *
- * // But it allows likely unsound behavior like this:
- * const emptyObject: EmptyObjectArray = [1, "foo", () => 3];
- *
- * // So it may be better to define `ObjectArray` like so:
- * type ObjectArray<T extends Record<string, unknown>> = HandleEmptyObject<T>[];
- *
- * // If it were, then this line would error appropriately!
- * const emptyObject: EmptyObjectArray = [1, "foo", () => 3];
- * ```
- */
-export type HandleEmptyObject<
-  T extends Record<string, unknown>,
-  D extends Record<string, unknown> = Record<string, never>,
-  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
-> = [{}] extends [T] ? D : T;
-
-/**
  * This is a helper type that allows you to ensure that a record conforms to a
  * certain shape. This is useful when you want to ensure that a record has all
  * keys of a certain type.

--- a/src/types/utils.d.mts
+++ b/src/types/utils.d.mts
@@ -248,6 +248,8 @@ export type GetDataReturnType<T extends object> = GetDataConfigOptions<T>[GetDat
  * removes all properties rom an object, because an empty interface was given,
  * or so on.
  *
+ * Type params extend `object` instead of `AnyObject` to allow interfaces
+ *
  * @example
  * ```ts
  * type ObjectArray<T extends Record<string, unknown>> = T[];
@@ -270,7 +272,7 @@ export type GetDataReturnType<T extends object> = GetDataConfigOptions<T>[GetDat
  * ```
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export type HandleEmptyObject<T extends AnyObject, D extends AnyObject = EmptyObject> = [{}] extends [T] ? D : T;
+export type HandleEmptyObject<T extends object, D extends AnyObject = object> = [{}] extends [T] ? D : T;
 
 /**
  * This type allows any plain objects. In other words it disallows functions


### PR DESCRIPTION
Removed duplicate type from `helperTypes`, broadened type params to `extends object` to allow for taking interfaces directly.