### PR TITLE
Touchup of `client/pixi/core/interaction/**` and associated side effects

### DIFF
--- a/src/foundry/client/data/abstract/world-collection.d.mts
+++ b/src/foundry/client/data/abstract/world-collection.d.mts
@@ -1,4 +1,4 @@
-import type { DeepPartial, InexactPartial } from "../../../../utils/index.d.mts";
+import type { DeepPartial, DropFirst, InexactPartial } from "../../../../utils/index.d.mts";
 import type Document from "../../../common/abstract/document.d.mts";
 import type { DirectoryCollectionMixin_DocumentCollection_Interface } from "./directory-collection-mixin.d.mts";
 
@@ -161,5 +161,3 @@ declare global {
     }
   }
 }
-
-type DropFirst<T extends Array<unknown>> = T extends [infer _1, ...infer V] ? V : T;

--- a/src/foundry/client/pixi/core/interaction/canvas-animation.d.mts
+++ b/src/foundry/client/pixi/core/interaction/canvas-animation.d.mts
@@ -1,102 +1,26 @@
-import type { ValueOf, PropertiesOfType } from "../../../../../utils/index.d.mts";
+import type { ValueOf, PropertiesOfType, Brand, InexactPartial } from "../../../../../utils/index.d.mts";
 
 declare global {
-  namespace CanvasAnimation {
-    type EasingFunction = CoreEasingFunctions | ((percent: number) => number);
-    type CoreEasingFunctions = PropertiesOfType<typeof CanvasAnimation, (percent: number) => number>;
-  }
-
-  interface CanvasAnimationAttribute {
-    /** The attribute name being animated */
-    attribute: string;
-
-    /** The object within which the attribute is stored */
-    parent: object;
-
-    /** The destination value of the attribute */
-    to: number;
-
-    /** An initial value of the attribute, otherwise parent[attribute] is used */
-    from?: number;
-
-    /** The computed delta between to and from */
-    delta?: number;
-
-    /** The amount of the total delta which has been animated */
-    done?: number;
-
-    /** Is this a color animation that applies to RGB channels */
-    color?: boolean;
-  }
-
-  interface CanvasAnimationOptions {
-    /** A DisplayObject which defines context to the PIXI.Ticker function */
-    context?: PIXI.DisplayObject;
-
-    /** A unique name which can be used to reference the in-progress animation */
-    name?: string | symbol;
-
-    /** A duration in milliseconds over which the animation should occur */
-    duration?: number;
-
-    /**
-     * A priority in PIXI.UPDATE_PRIORITY which defines when the animation
-     * should be evaluated related to others
-     */
-    priority?: number;
-
-    /**
-     * An easing function used to translate animation time or the string name
-     * of a static member of the CanvasAnimation class
-     */
-    easing?: CanvasAnimation.EasingFunction;
-
-    /** A callback function which fires after every frame */
-    ontick?: (dt: number, animation: CanvasAnimationData) => void;
-  }
-
-  interface CanvasAnimationData extends CanvasAnimationOptions {
-    /** The animation function being executed each frame */
-    fn: (dt: number) => void;
-
-    /** The current time of the animation, in milliseconds */
-    time: number;
-
-    /** The attributes being animated */
-    attributes: CanvasAnimationAttribute[];
-
-    /** The current state of the animation */
-    state: ValueOf<typeof CanvasAnimation.STATES>;
-
-    /** A Promise which resolves once the animation is complete */
-    promise: Promise<boolean>;
-
-    /** The resolution function, allowing animation to be ended early */
-    resolve: (value: boolean) => void;
-
-    /** The rejection function, allowing animation to be ended early */
-    reject: (err: Error) => void;
-  }
-
   /**
    * A helper class providing utility methods for PIXI Canvas animation
    */
   class CanvasAnimation {
+    /** @privateRemarks Returns a private class property that is a frozen object, so keys are readonly */
     static get STATES(): {
       /** An error occurred during waiting or running the animation. */
-      FAILED: -2;
+      readonly FAILED: -2 & CanvasAnimation.STATES;
 
       /** The animation was terminated before it could complete. */
-      TERMINATED: -1;
+      readonly TERMINATED: -1 & CanvasAnimation.STATES;
 
       /** Waiting for the wait promise before the animation is started. */
-      WAITING: 0;
+      readonly WAITING: 0 & CanvasAnimation.STATES;
 
       /** The animation has been started and is running. */
-      RUNNING: 1;
+      readonly RUNNING: 1 & CanvasAnimation.STATES;
 
       /** The animation was completed without errors and without being terminated. */
-      COMPLETED: 2;
+      readonly COMPLETED: 2 & CanvasAnimation.STATES;
     };
 
     /**
@@ -107,8 +31,9 @@ declare global {
     /**
      * Track an object of active animations by name, context, and function
      * This allows a currently playing animation to be referenced and terminated
+     * @privateRemarks Foundry does not account for the possibility of Symbol animation names and types the keys as simply `string`
      */
-    static animations: Record<string, CanvasAnimationData>;
+    static animations: Record<string | symbol, CanvasAnimationData>;
 
     /**
      * Apply an animation from the current value of some attribute to a new value
@@ -173,4 +98,108 @@ declare global {
      */
     static easeInCircle(pt: number): number;
   }
+
+  namespace CanvasAnimation {
+    interface Any extends AnyCanvasAnimation {}
+    type AnyConstructor = typeof AnyCanvasAnimation;
+
+    type EasingFunction = CoreEasingFunctions | ((percent: number) => number);
+    type CoreEasingFunctions = PropertiesOfType<typeof CanvasAnimation, (percent: number) => number>;
+
+    type STATES = Brand<number, "CanvasAnimation.STATES">;
+
+    /** @internal */
+    type _AnimationOptions = InexactPartial<{
+      /**
+       * A DisplayObject which defines context to the PIXI.Ticker function
+       * @defaultValue `canvas.stage`
+       * @remarks Can be `null`, because despite only having a signature-provided default,
+       * the (afaict, unexported) PIXI class `TickerListener`'s constructor (where this prop
+       * ends up) accepts `null` for context. This is likely never actually desireable, however.
+       */
+      context?: PIXI.DisplayObject | null;
+
+      /**
+       * A unique name which can be used to reference the in-progress animation
+       * @remarks This is only used if truthy, so `null` is allowed
+       */
+      name?: string | symbol | null;
+
+      /**
+       * A duration in milliseconds over which the animation should occur
+       * @defaultValue `1000`
+       * @remarks Can't be `null` because it only has a signature-provided default, and used as a divisor in `CanvasAnimation.#animateFrame`
+       */
+      duration?: number;
+
+      /**
+       * A priority in PIXI.UPDATE_PRIORITY which defines when the animation
+       * should be evaluated related to others
+       * @defaultValue `PIXI.UPDATE_PRIORITY`
+       * @remarks Has
+       */
+      priority?: PIXI.UPDATE_PRIORITY | null;
+    }>;
+  }
+
+  interface CanvasAnimationAttribute {
+    /** The attribute name being animated */
+    attribute: string;
+
+    /** The object within which the attribute is stored */
+    parent: object;
+
+    /** The destination value of the attribute */
+    to: number;
+
+    /** An initial value of the attribute, otherwise parent[attribute] is used */
+    from?: number;
+
+    /** The computed delta between to and from */
+    delta?: number;
+
+    /** The amount of the total delta which has been animated */
+    done?: number;
+
+    /** Is this a color animation that applies to RGB channels */
+    color?: boolean;
+  }
+
+  interface CanvasAnimationOptions extends CanvasAnimation._AnimationOptions {
+    /**
+     * An easing function used to translate animation time or the string name
+     * of a static member of the CanvasAnimation class
+     */
+    easing?: CanvasAnimation.EasingFunction;
+
+    /** A callback function which fires after every frame */
+    ontick?: (dt: number, animation: CanvasAnimationData) => void;
+  }
+
+  interface CanvasAnimationData extends CanvasAnimationOptions {
+    /** The animation function being executed each frame */
+    fn: (dt: number) => void;
+
+    /** The current time of the animation, in milliseconds */
+    time: number;
+
+    /** The attributes being animated */
+    attributes: CanvasAnimationAttribute[];
+
+    /** The current state of the animation */
+    state: ValueOf<typeof CanvasAnimation.STATES>;
+
+    /** A Promise which resolves once the animation is complete */
+    promise: Promise<boolean>;
+
+    /** The resolution function, allowing animation to be ended early */
+    resolve: (value: boolean) => void;
+
+    /** The rejection function, allowing animation to be ended early */
+    reject: (err: Error) => void;
+  }
+}
+
+declare abstract class AnyCanvasAnimation extends CanvasAnimation {
+  constructor(arg0: never, ...args: never[]);
 }

--- a/src/foundry/client/pixi/core/interaction/canvas-animation.d.mts
+++ b/src/foundry/client/pixi/core/interaction/canvas-animation.d.mts
@@ -1,4 +1,4 @@
-import type { PropertiesOfType, Brand, NullishProps } from "../../../../../utils/index.d.mts";
+import type { PropertiesOfType, Brand, NullishProps, AnyObject } from "../../../../../utils/index.d.mts";
 
 declare global {
   /**
@@ -6,22 +6,7 @@ declare global {
    */
   class CanvasAnimation {
     /** @privateRemarks Returns a private class property that is a frozen object, so keys are readonly */
-    static get STATES(): {
-      /** An error occurred during waiting or running the animation. */
-      readonly FAILED: -2 & CanvasAnimation.STATES;
-
-      /** The animation was terminated before it could complete. */
-      readonly TERMINATED: -1 & CanvasAnimation.STATES;
-
-      /** Waiting for the wait promise before the animation is started. */
-      readonly WAITING: 0 & CanvasAnimation.STATES;
-
-      /** The animation has been started and is running. */
-      readonly RUNNING: 1 & CanvasAnimation.STATES;
-
-      /** The animation was completed without errors and without being terminated. */
-      readonly COMPLETED: 2 & CanvasAnimation.STATES;
-    };
+    static get STATES(): CanvasAnimation.States;
 
     /**
      * The ticker used for animations.
@@ -34,7 +19,7 @@ declare global {
      * @privateRemarks Foundry does not account for the possibility of Symbol animation names and types the keys as simply `string`,
      * despite typing `CanvasAnimationOptions.name` as `string | symbol`
      */
-    static animations: Record<string | symbol, CanvasAnimationData>;
+    static animations: Record<PropertyKey, CanvasAnimationData>;
 
     /**
      * Apply an animation from the current value of some attribute to a new value
@@ -70,13 +55,13 @@ declare global {
      * @param name - The animation name to retrieve
      * @returns The animation data, or undefined
      */
-    static getAnimation(name: string | symbol): CanvasAnimationData | undefined;
+    static getAnimation(name: PropertyKey): CanvasAnimationData | undefined;
 
     /**
      * If an animation using a certain name already exists, terminate it
      * @param name - The animation name to terminate
      */
-    static terminateAnimation(name: string | symbol): void;
+    static terminateAnimation(name: PropertyKey): void;
 
     /**
      * Cosine based easing with smooth in-out.
@@ -109,6 +94,23 @@ declare global {
 
     type STATES = Brand<number, "CanvasAnimation.STATES">;
 
+    interface States {
+      /** An error occurred during waiting or running the animation. */
+      readonly FAILED: -2 & CanvasAnimation.STATES;
+
+      /** The animation was terminated before it could complete. */
+      readonly TERMINATED: -1 & CanvasAnimation.STATES;
+
+      /** Waiting for the wait promise before the animation is started. */
+      readonly WAITING: 0 & CanvasAnimation.STATES;
+
+      /** The animation has been started and is running. */
+      readonly RUNNING: 1 & CanvasAnimation.STATES;
+
+      /** The animation was completed without errors and without being terminated. */
+      readonly COMPLETED: 2 & CanvasAnimation.STATES;
+    }
+
     type OnTickFunction = (dt: number, animation: CanvasAnimationData) => void;
 
     /** @internal */
@@ -116,14 +118,14 @@ declare global {
       /**
        * A DisplayObject which defines context to the PIXI.Ticker function
        * @defaultValue `canvas.stage`
-       * @remarks `null` is allowed here because despite only having a signature-provided default,
+       * @remarks `null` is allowed here because despite only having a parameter default,
        * the (afaict, unexported) PIXI class `TickerListener`'s constructor (where this prop
        * ends up) accepts `null` for context. This is likely never actually desireable, however.
        */
       context: PIXI.DisplayObject;
 
       /** A unique name which can be used to reference the in-progress animation */
-      name: string | symbol;
+      name: PropertyKey;
 
       /**
        * A priority in PIXI.UPDATE_PRIORITY which defines when the animation
@@ -161,8 +163,7 @@ declare global {
     /**
      * A duration in milliseconds over which the animation should occur
      * @defaultValue `1000`
-     * @remarks Can't be `null` because it only has a signature-provided default, and used as a divisor in `CanvasAnimation.#animateFrame`
-     * @privateRemarks InexactPartial inlined so the rest of the interface can be NullishProps'd
+     * @remarks Can't be `null` because it only has a parameter default, and used as a divisor in `CanvasAnimation.#animateFrame`
      */
     duration?: number | undefined;
   }
@@ -172,7 +173,7 @@ declare global {
     attribute: string;
 
     /** The object within which the attribute is stored */
-    parent: object;
+    parent: AnyObject;
 
     /** The destination value of the attribute */
     to: number | Color;

--- a/src/foundry/client/pixi/core/interaction/canvas-animation.d.mts
+++ b/src/foundry/client/pixi/core/interaction/canvas-animation.d.mts
@@ -48,7 +48,7 @@ declare global {
      * CanvasAnimation.animate(attributes, {duration:500});
      * ```
      */
-    static animate(attributes: CanvasAnimationAttribute[], options?: CanvasAnimationOptions): Promise<boolean | void>;
+    static animate(attributes: CanvasAnimation.Attribute[], options?: CanvasAnimationOptions): Promise<boolean | void>;
 
     /**
      * Retrieve an animation currently in progress by its name
@@ -157,6 +157,17 @@ declare global {
        */
       from: number | Color;
     }>;
+
+    interface Attribute {
+      /** The attribute name being animated */
+      attribute: string;
+
+      /** The object within which the attribute is stored */
+      parent: AnyObject;
+
+      /** The destination value of the attribute */
+      to: number | Color;
+    }
   }
 
   interface CanvasAnimationOptions extends CanvasAnimation._AnimationOptions {
@@ -168,27 +179,18 @@ declare global {
     duration?: number | undefined;
   }
 
-  interface CanvasAnimationAttribute {
-    /** The attribute name being animated */
-    attribute: string;
-
-    /** The object within which the attribute is stored */
-    parent: AnyObject;
-
-    /** The destination value of the attribute */
-    to: number | Color;
-
+  interface CanvasAnimationAttribute extends CanvasAnimation.Attribute {
     /**
      * The computed delta between to and from
      * @remarks This key is always overwritten inside `.animate`, its passed value is irrelevant
      */
-    delta?: number;
+    delta: number;
 
     /**
      * The amount of the total delta which has been animated
      * @remarks This key is always overwritten inside `.animate`, its passed value is irrelevant
      */
-    done?: number;
+    done: number;
 
     /**
      * Is this a color animation that applies to RGB channels

--- a/src/foundry/client/pixi/core/interaction/control-icon.d.mts
+++ b/src/foundry/client/pixi/core/interaction/control-icon.d.mts
@@ -5,21 +5,12 @@ declare global {
    * A generic helper for drawing a standard Control Icon
    */
   class ControlIcon extends PIXI.Container {
-    constructor(args: {
-      texture: string;
-
-      /** @defaultValue `40` */
-      size?: number;
-
-      /** @defaultValue `0xFF5500` */
-      borderColor?: number;
-
-      /** @defaultValue `null` */
-      tint?: number | null;
-
-      /** @defaultValue `number` */
-      elevation: number;
-    });
+    /**
+     * @privateRemarks
+     * - Despite being an `={}` param, `options` is required (specifically its `texture` property)
+     * - Foundry adds a `...args` rest param after `options` and calls `super(...args)`, but `new PIXI.Container()` takes no arguments
+     */
+    constructor(options: ControlIcon.Options);
 
     iconSrc: string;
 
@@ -42,24 +33,23 @@ declare global {
     /**
      * @defaultValue `false`
      */
-    interactiveChildren: boolean;
+    override interactiveChildren: boolean;
 
-    hitArea: PIXI.Rectangle;
+    override hitArea: PIXI.Rectangle;
+
+    override cursor: string;
 
     bg: PIXI.Graphics;
 
     icon: PIXI.Sprite;
 
-    /**
-     * @defaultValue
-     * The `visible` property is true.
-     */
     border: PIXI.Graphics;
 
     tooltip: PreciseText;
 
     /**
      * The elevation of the ControlIcon, which is displayed in its tooltip text.
+     * @throws If a set is attempted with anything but a finite number
      */
     get elevation(): number;
 
@@ -77,13 +67,66 @@ declare global {
   }
 
   namespace ControlIcon {
-    type _RefreshOptions = InexactPartial<{
-      visible: boolean;
-      iconColor: number;
+    interface Any extends AnyControlIcon {}
+    type AnyConstructor = typeof AnyControlIcon;
+
+    /** @internal */
+    type _Options = InexactPartial<{
+      /**
+       * @defaultValue `40`
+       * @remarks Can't be `null` as it only has a signature-provided default
+       * @privateRemarks It *could* be `null`, as in all the places its used in math, coercing it to `0` does not
+       * produce errors, but it pollutes the `this.size` type unnecessarily and is obviously not intended.
+       */
+      size: number;
+
+      /**
+       * @defaultValue `0xFF5500`
+       * @remarks Can't be `null` as that's not a valid value for the `PIXI.Color` constructor,
+       * and it only has a signature-provided default
+       * @privateRemarks I'm pretty sure this could be any `PIXI.ColorSource` not just an RGB integer,
+       * but not sure enough to change the type
+       */
       borderColor: number;
+
+      /**
+       * @defaultValue `null`
+       * @remarks The default value of `null` is equivalent to `0xFFFFFF`, or effectively no tint
+       */
+      tint: number | null;
+
+      /**
+       * @defaultValue `number`
+       * @remarks Can't be null as the `ControlIcon#elevation` setter throws if passed anything but a finite number,
+       * and it only has a signature-provided default
+       */
+      elevation: number;
+    }>;
+
+    interface Options extends _Options {
+      /** A source string for the icon's texture */
+      texture: string;
+    }
+
+    /** @internal */
+    type _RefreshOptions = InexactPartial<{
+      /** @remarks Can't be `null` because of an explicit `!== undefined` check */
+      visible: boolean;
+
+      /** @remarks Can't be `null` because of an explicit `!== undefined` check */
+      iconColor: number;
+
+      /** @remarks Can't be `null` because of an explicit `!== undefined` check */
+      borderColor: number;
+
+      /** @remarks Can't be `null` because of an explicit `!== undefined` check */
       borderVisible: boolean;
     }>;
 
     interface RefreshOptions extends _RefreshOptions {}
   }
+}
+
+declare abstract class AnyControlIcon extends ControlIcon {
+  constructor(arg0: never, ...args: never[]);
 }

--- a/src/foundry/client/pixi/core/interaction/control-icon.d.mts
+++ b/src/foundry/client/pixi/core/interaction/control-icon.d.mts
@@ -74,9 +74,7 @@ declare global {
     type _Options = InexactPartial<{
       /**
        * @defaultValue `40`
-       * @remarks Can't be `null` as it only has a parameter default
-       * @privateRemarks It *could* be `null`, as in all the places its used in math, coercing it to `0` does not
-       * produce errors, but it pollutes the `this.size` type unnecessarily and is obviously not intended.
+       * @remarks Can't be `null` as it only has a parameter default, and `null` coerced to `0` is a nonsensical size value
        */
       size: number;
 
@@ -84,8 +82,6 @@ declare global {
        * @defaultValue `0xFF5500`
        * @remarks Can't be `null` as that's not a valid value for the `PIXI.Color` constructor,
        * and it only has a parameter default
-       * @privateRemarks This could probably be any `PIXI.ColorSource` not just an RGB integer,
-       * but proving this would be difficult, and all Foundry uses are numbers
        */
       borderColor: number;
 

--- a/src/foundry/client/pixi/core/interaction/control-icon.d.mts
+++ b/src/foundry/client/pixi/core/interaction/control-icon.d.mts
@@ -6,7 +6,7 @@ declare global {
    */
   class ControlIcon extends PIXI.Container {
     /**
-     * @privateRemarks
+     * @remarks
      * - Despite being an `={}` param, `options` is required (specifically its `texture` property)
      * - Foundry adds a `...args` rest param after `options` and calls `super(...args)`, but `new PIXI.Container()` takes no arguments
      */
@@ -74,7 +74,7 @@ declare global {
     type _Options = InexactPartial<{
       /**
        * @defaultValue `40`
-       * @remarks Can't be `null` as it only has a signature-provided default
+       * @remarks Can't be `null` as it only has a parameter default
        * @privateRemarks It *could* be `null`, as in all the places its used in math, coercing it to `0` does not
        * produce errors, but it pollutes the `this.size` type unnecessarily and is obviously not intended.
        */
@@ -83,9 +83,9 @@ declare global {
       /**
        * @defaultValue `0xFF5500`
        * @remarks Can't be `null` as that's not a valid value for the `PIXI.Color` constructor,
-       * and it only has a signature-provided default
-       * @privateRemarks I'm pretty sure this could be any `PIXI.ColorSource` not just an RGB integer,
-       * but not sure enough to change the type
+       * and it only has a parameter default
+       * @privateRemarks This could probably be any `PIXI.ColorSource` not just an RGB integer,
+       * but proving this would be difficult, and all Foundry uses are numbers
        */
       borderColor: number;
 
@@ -98,7 +98,7 @@ declare global {
       /**
        * @defaultValue `number`
        * @remarks Can't be null as the `ControlIcon#elevation` setter throws if passed anything but a finite number,
-       * and it only has a signature-provided default
+       * and it only has a parameter default
        */
       elevation: number;
     }>;

--- a/src/foundry/client/pixi/core/interaction/mouse-handler.d.mts
+++ b/src/foundry/client/pixi/core/interaction/mouse-handler.d.mts
@@ -136,14 +136,7 @@ declare global {
      * 4: DRAG - the object is being dragged
      * 5: DROP - the object is being dropped
      */
-    static INTERACTION_STATES: {
-      NONE: 0 & MouseInteractionManager.INTERACTION_STATES;
-      HOVER: 1 & MouseInteractionManager.INTERACTION_STATES;
-      CLICKED: 2 & MouseInteractionManager.INTERACTION_STATES;
-      GRABBED: 3 & MouseInteractionManager.INTERACTION_STATES;
-      DRAG: 4 & MouseInteractionManager.INTERACTION_STATES;
-      DROP: 5 & MouseInteractionManager.INTERACTION_STATES;
-    };
+    static INTERACTION_STATES: MouseInteractionManager.InteractionStates;
 
     /**
      * The maximum number of milliseconds between two clicks to be considered a double-click.
@@ -217,19 +210,7 @@ declare global {
     /**
      * A reference to the possible interaction states which can be observed
      */
-    get handlerOutcomes(): {
-      /** -2: SKIPPED - the handler has been skipped by previous logic */
-      SKIPPED: -2 & MouseInteractionManager.HANDLER_OUTCOMES;
-
-      /** -1: DISALLOWED - the handler has dissallowed further process */
-      DISALLOWED: -1 & MouseInteractionManager.HANDLER_OUTCOMES;
-
-      /** 1: REFUSED - the handler callback has been processed and is refusing further process */
-      REFUSED: 1 & MouseInteractionManager.HANDLER_OUTCOMES;
-
-      /** 2: ACCEPTED - the handler callback has been processed and is accepting further process */
-      ACCEPTED: 2 & MouseInteractionManager.HANDLER_OUTCOMES;
-    };
+    get handlerOutcomes(): MouseInteractionManager.HandlerOutcomes;
     /**
      * A public method to handle directly an event into this manager, according to its type.
      * Note: drag events are not handled.
@@ -246,31 +227,40 @@ declare global {
     /**
      * Reset the mouse manager.
      */
-    reset(
-      options?: NullishProps<{
-        /**
-         * Reset the interaction data?
-         * @defaultValue `true`
-         */
-        interactionData: boolean;
-
-        /**
-         * Reset the state?
-         * @defaultValue `true`
-         */
-        state: boolean;
-      }>,
-    ): void;
+    reset(options?: MouseInteractionManager.ResetOptions): void;
   }
 
   namespace MouseInteractionManager {
     interface Any extends AnyMouseInteractionManager {}
     type AnyConstructor = typeof AnyMouseInteractionManager;
 
-    /** @privateRemarks The private class property is `#HANDLER_OUTCOME` singular, but the getter is `handlerOutcomes`, so I went with plural */
+    /** @privateRemarks The private class property is `#HANDLER_OUTCOME` singular, but the getter is `handlerOutcomes`, so the brand uses the plural*/
     type HANDLER_OUTCOMES = Brand<number, "MouseInteractionManager.HANDLER_OUTCOMES">;
 
+    interface HandlerOutcomes {
+      /** -2: SKIPPED - the handler has been skipped by previous logic */
+      SKIPPED: -2 & MouseInteractionManager.HANDLER_OUTCOMES;
+
+      /** -1: DISALLOWED - the handler has dissallowed further process */
+      DISALLOWED: -1 & MouseInteractionManager.HANDLER_OUTCOMES;
+
+      /** 1: REFUSED - the handler callback has been processed and is refusing further process */
+      REFUSED: 1 & MouseInteractionManager.HANDLER_OUTCOMES;
+
+      /** 2: ACCEPTED - the handler callback has been processed and is accepting further process */
+      ACCEPTED: 2 & MouseInteractionManager.HANDLER_OUTCOMES;
+    }
+
     type INTERACTION_STATES = Brand<number, "MouseInteractionManager.INTERACTION_STATES">;
+
+    interface InteractionStates {
+      NONE: 0 & MouseInteractionManager.INTERACTION_STATES;
+      HOVER: 1 & MouseInteractionManager.INTERACTION_STATES;
+      CLICKED: 2 & MouseInteractionManager.INTERACTION_STATES;
+      GRABBED: 3 & MouseInteractionManager.INTERACTION_STATES;
+      DRAG: 4 & MouseInteractionManager.INTERACTION_STATES;
+      DROP: 5 & MouseInteractionManager.INTERACTION_STATES;
+    }
 
     /**
      * @remarks The list of actions provided by foundry, minus `dragXCancel`, `unclickX`, and `longPress`, which do not check permissions
@@ -342,6 +332,23 @@ declare global {
      * Interaction options which configure handling workflows
      */
     interface Options extends _Options {}
+
+    /** @internal */
+    type _ResetOptions = NullishProps<{
+      /**
+       * Reset the interaction data?
+       * @defaultValue `true`
+       */
+      interactionData: boolean;
+
+      /**
+       * Reset the state?
+       * @defaultValue `true`
+       */
+      state: boolean;
+    }>;
+
+    interface ResetOptions extends _ResetOptions {}
   }
 }
 

--- a/src/foundry/client/pixi/core/interaction/mouse-handler.d.mts
+++ b/src/foundry/client/pixi/core/interaction/mouse-handler.d.mts
@@ -36,7 +36,7 @@ declare global {
    *  action: dragLeftCancel
    *  action: dragRightCancel
    */
-  class MouseInteractionManager<Object extends PIXI.Container = PIXI.Container> {
+  class MouseInteractionManager<ObjectFor extends PIXI.Container = PIXI.Container> {
     /**
      * @param permissions - (default: `{}`)
      * @param callbacks   - (default: `{}`)
@@ -44,14 +44,14 @@ declare global {
      * @remarks Foundry does not provide type information for the constructor, everything here is inferred from usage
      */
     constructor(
-      object: Object,
+      object: ObjectFor,
       layer: PIXI.Container,
       permissions?: MouseInteractionManager.Permissions,
       callbacks?: MouseInteractionManager.Callbacks,
       options?: MouseInteractionManager.Options,
     );
 
-    object: Object;
+    object: ObjectFor;
 
     layer: PIXI.Container;
 
@@ -80,12 +80,7 @@ declare global {
      * Bound handlers which can be added and removed
      * @defaultValue `{}`
      */
-    //TODO
-    interactionData: {
-      origin?: PIXI.Point;
-      destination?: PIXI.Point;
-      object?: Record<string, unknown>;
-    } & Partial<Record<string, unknown>>;
+    interactionData: MouseInteractionManager.InteractionData<ObjectFor>;
 
     /**
      * The drag handling time
@@ -349,6 +344,12 @@ declare global {
     }>;
 
     interface ResetOptions extends _ResetOptions {}
+
+    interface InteractionData<T> {
+      origin?: PIXI.Point;
+      destination?: PIXI.Point;
+      object?: T;
+    }
   }
 }
 

--- a/src/foundry/client/pixi/core/interaction/mouse-handler.d.mts
+++ b/src/foundry/client/pixi/core/interaction/mouse-handler.d.mts
@@ -214,7 +214,9 @@ declare global {
     callback<Action extends keyof Callbacks>(
       action: Action,
       event: Event | PIXI.FederatedEvent,
-      ...args: DropFirst<Parameters<Callbacks[Action]>>
+      ...args: this["callbacks"][Action] extends MouseInteractionManager.CallbackFunction
+        ? DropFirst<Parameters<this["callbacks"][Action]>>
+        : never[]
     ): boolean;
 
     /**

--- a/src/foundry/client/pixi/core/interaction/ping.d.mts
+++ b/src/foundry/client/pixi/core/interaction/ping.d.mts
@@ -15,7 +15,8 @@ declare global {
 
     _color: Color;
 
-    override destroy(options?: PIXI.IDestroyOptions | boolean): void;
+    /** @remarks `Ping#destroy`'s parameter must be an object if passed, as the body does `options.children = true` */
+    override destroy(options?: PIXI.IDestroyOptions): void;
 
     /**
      * Start the ping animation.
@@ -42,23 +43,28 @@ declare global {
       /**
        * The duration of the animation in milliseconds.
        * @defaultValue `900`
-       * @remarks Can't be `null` or `undefined` because `options` is `mergeObject`ed with an object with this key
+       * @remarks Can't be `null` because `options` is `mergeObject`ed with an object with this key,
+       * and the result is passed on to `CanvasAnimation.animate` in its options
        */
-      duration: number;
+      duration: number | undefined;
 
       /**
        * The size of the ping graphic.
        * @defaultValue `128`
-       * @remarks Can't be `null` or `undefined` because `options` is `mergeObject`ed with an object with this key
+       * @remarks Can't be `null` or `undefined` because `options` is `mergeObject`ed with an object with this key.
+       * This value is not used in the base `Ping` class, but is used by subclasses to define radius and padding in
+       * ways where `undefined` produces `NaN` and values of `0` (ie, cast `null`) are nonsensical
        */
       size: number;
 
       /**
        * The color of the ping graphic.
        * @defaultValue `#ff6400`
-       * @remarks Can't be `null` or `undefined` because `options` is `mergeObject`ed with an object with this key
+       * @remarks Can't be `null` or `undefined` because `options` is `mergeObject`ed with an object with this key,
+       * and passing either to `Color.from` produces a `Color(NaN)`, which may cause breakage in subclasses or when
+       * passed to PIXI methods
        */
-      color: string;
+      color: Color.Source;
 
       /**
        * The name for the ping animation to pass to {@link CanvasAnimation.animate}.

--- a/src/foundry/client/pixi/core/interaction/ping.d.mts
+++ b/src/foundry/client/pixi/core/interaction/ping.d.mts
@@ -1,4 +1,4 @@
-import type { IntentionalPartial } from "../../../../../utils/index.d.mts";
+import type { InexactPartial } from "../../../../../utils/index.d.mts";
 
 declare global {
   /**
@@ -21,7 +21,7 @@ declare global {
     /**
      * Start the ping animation.
      * @returns Returns true if the animation ran to completion, false otherwise.
-     * @privateRemarks This calls `CanvasAnimation.animate` with an empty array for the first argument,
+     * @privateRemarks This calls `CanvasAnimation.animate` with an empty attribute array for the first argument,
      * meaning no chance of early return, so no `| void` in the return type
      */
     animate(): Promise<boolean>;
@@ -39,7 +39,7 @@ declare global {
     type AnyConstructor = typeof AnyPing;
 
     /** @internal */
-    type _Options = IntentionalPartial<{
+    type _Options = InexactPartial<{
       /**
        * The duration of the animation in milliseconds.
        * @defaultValue `900`
@@ -69,7 +69,7 @@ declare global {
       /**
        * The name for the ping animation to pass to {@link CanvasAnimation.animate}.
        */
-      name?: string | undefined | null;
+      name?: PropertyKey | undefined | null;
     }>;
   }
 

--- a/src/foundry/client/pixi/core/interaction/ping.d.mts
+++ b/src/foundry/client/pixi/core/interaction/ping.d.mts
@@ -1,31 +1,6 @@
-import type { IDestroyOptions } from "pixi.js";
+import type { IntentionalPartial } from "../../../../../utils/index.d.mts";
 
 declare global {
-  interface PingOptions {
-    /**
-     * The duration of the animation in milliseconds.
-     * @defaultValue `900`
-     */
-    duration?: number;
-
-    /**
-     * The size of the ping graphic.
-     * @defaultValue `128`
-     */
-    size?: number;
-
-    /**
-     * The color of the ping graphic.
-     * @defaultValue `#ff6400`
-     */
-    color?: string;
-
-    /**
-     * The name for the ping animation to pass to {@link CanvasAnimation.animate}.
-     */
-    name?: string;
-  }
-
   /**
    * A class to manage a user ping on the canvas.
    */
@@ -38,13 +13,15 @@ declare global {
 
     options: PingOptions;
 
-    _color: Color | number;
+    _color: Color;
 
-    destroy(options?: IDestroyOptions | boolean): void;
+    override destroy(options?: PIXI.IDestroyOptions | boolean): void;
 
     /**
      * Start the ping animation.
      * @returns Returns true if the animation ran to completion, false otherwise.
+     * @privateRemarks This calls `CanvasAnimation.animate` with an empty array for the first argument,
+     * meaning no chance of early return, so no `| void` in the return type
      */
     animate(): Promise<boolean>;
 
@@ -55,4 +32,44 @@ declare global {
      */
     protected _animateFrame(dt: number, animation: CanvasAnimationData): void;
   }
+
+  namespace Ping {
+    interface Any extends AnyPing {}
+    type AnyConstructor = typeof AnyPing;
+
+    /** @internal */
+    type _Options = IntentionalPartial<{
+      /**
+       * The duration of the animation in milliseconds.
+       * @defaultValue `900`
+       * @remarks Can't be `null` or `undefined` because `options` is `mergeObject`ed with an object with this key
+       */
+      duration: number;
+
+      /**
+       * The size of the ping graphic.
+       * @defaultValue `128`
+       * @remarks Can't be `null` or `undefined` because `options` is `mergeObject`ed with an object with this key
+       */
+      size: number;
+
+      /**
+       * The color of the ping graphic.
+       * @defaultValue `#ff6400`
+       * @remarks Can't be `null` or `undefined` because `options` is `mergeObject`ed with an object with this key
+       */
+      color: string;
+
+      /**
+       * The name for the ping animation to pass to {@link CanvasAnimation.animate}.
+       */
+      name?: string | undefined | null;
+    }>;
+  }
+
+  interface PingOptions extends Ping._Options {}
+}
+
+declare abstract class AnyPing extends Ping {
+  constructor(arg0: never, ...args: never[]);
 }

--- a/src/foundry/client/pixi/core/interaction/pings/chevron.d.mts
+++ b/src/foundry/client/pixi/core/interaction/pings/chevron.d.mts
@@ -41,11 +41,19 @@ declare global {
      */
     _t34: number;
 
+    /** @remarks Doesn't exist before the first `#_createRings()` call, usually via `#animate()` */
+    _inner?: PIXI.Graphics;
+
+    /** @remarks Doesn't exist before the first `#_createRings()` call, usually via `#animate()` */
+    _outer?: PIXI.Graphics;
+
     /**
      * The path to the chevron texture.
-     * @internal
+     * @remarks Unusually for Foundry, this is referred to by `ChevronPing.`, not `this.constructor.`, in
+     * `#_loadChevron()`, which must therefore be overridden to use a different value in a subclass
+     * @privateRemarks Foundry marked `@private`.
      */
-    protected static _CHEVRON_PATH: "icons/pings/chevron.webp";
+    static _CHEVRON_PATH: string;
 
     override animate(): Promise<boolean>;
 
@@ -54,20 +62,20 @@ declare global {
     /**
      * Draw the outer and inner rings.
      * @param a - The alpha.
-     * @internal
+     * @privateRemarks Foundry marked `@private`
      */
-    protected _drawRings(a: number): void;
+    _drawRings(a: number): void;
 
     /**
      * Load the chevron texture.
-     * @internal
+     * @privateRemarks Foundry marked `@private`
      */
-    protected _loadChevron(): Promise<PIXI.Sprite>;
+    _loadChevron(): Promise<PIXI.Sprite>;
 
     /**
      * Draw the two rings that are used as part of the ping animation.
-     * @internal
+     * @privateRemarks Foundry marked `@private`
      */
-    protected _createRings(): PIXI.Graphics[];
+    _createRings(): [PIXI.Graphics, PIXI.Graphics];
   }
 }

--- a/src/foundry/client/pixi/core/interaction/resize-handle.d.mts
+++ b/src/foundry/client/pixi/core/interaction/resize-handle.d.mts
@@ -26,14 +26,7 @@ declare global {
       current: Canvas.Rectangle,
       origin: Canvas.Rectangle,
       destination: Canvas.Rectangle,
-      options?: NullishProps<{
-        /**
-         * Constrain the aspect ratio
-         * @defaultValue `null`
-         * @remarks If truthy, will enforce the passed ratio, landscape if `width >= height`, portrait otherwise
-         */
-        aspectRatio: number;
-      }>,
+      options?: ResizeHandle.UpdateDimensionsOptions,
     ): Canvas.Rectangle;
 
     activateListeners(): void;
@@ -61,16 +54,26 @@ declare global {
     interface Any extends AnyResizeHandle {}
     type AnyConstructor = typeof AnyResizeHandle;
 
-    /** @remarks Undocumented, inferred from usage */
     type Offsets = [widthOffset: number, heightOffset: number];
 
     /** @internal */
     type _Handlers = NullishProps<{
-      /** @remarks Undocumented, inferred from usage */
-      canDrag: (...args: never[]) => boolean | null | void;
+      canDrag: () => boolean | null | void;
     }>;
 
     interface Handlers extends _Handlers {}
+
+    /** @internal */
+    type _UpdateDimensionsOptions = NullishProps<{
+      /**
+       * Constrain the aspect ratio
+       * @defaultValue `null`
+       * @remarks If truthy, will enforce the passed ratio, landscape if `width >= height`, portrait otherwise
+       */
+      aspectRatio: number;
+    }>;
+
+    interface UpdateDimensionsOptions extends _UpdateDimensionsOptions {}
   }
 }
 

--- a/src/foundry/client/pixi/core/interaction/resize-handle.d.mts
+++ b/src/foundry/client/pixi/core/interaction/resize-handle.d.mts
@@ -1,15 +1,15 @@
-export {};
+import type { NullishProps } from "../../../../../utils/index.d.mts";
 
 declare global {
   class ResizeHandle extends PIXI.Graphics {
     /**
      * @param handlers - (default: `{}`)
      */
-    constructor(offset: ResizeHandle["offset"], handlers?: ResizeHandle["handlers"]);
+    constructor(offset: ResizeHandle.Offsets, handlers?: ResizeHandle.Handlers);
 
-    offset: [widthOffset: number, heightOffset: number];
+    offset: ResizeHandle.Offsets;
 
-    handlers: { canDrag?: boolean };
+    handlers: ResizeHandle.Handlers;
 
     /**
      * Track whether the handle is being actively used for a drag workflow
@@ -26,7 +26,14 @@ declare global {
       current: Canvas.Rectangle,
       origin: Canvas.Rectangle,
       destination: Canvas.Rectangle,
-      { aspectRatio }?: { aspectRatio?: number | null },
+      options?: NullishProps<{
+        /**
+         * Constrain the aspect ratio
+         * @defaultValue `null`
+         * @remarks If truthy, will enforce the passed ratio, landscape if `width >= height`, portrait otherwise
+         */
+        aspectRatio: number;
+      }>,
     ): Canvas.Rectangle;
 
     activateListeners(): void;
@@ -49,4 +56,24 @@ declare global {
      */
     protected _onMouseDown(event: PIXI.FederatedEvent): void;
   }
+
+  namespace ResizeHandle {
+    interface Any extends AnyResizeHandle {}
+    type AnyConstructor = typeof AnyResizeHandle;
+
+    /** @remarks Undocumented, inferred from usage */
+    type Offsets = [widthOffset: number, heightOffset: number];
+
+    /** @internal */
+    type _Handlers = NullishProps<{
+      /** @remarks Undocumented, inferred from usage */
+      canDrag: (...args: never[]) => boolean | null | void;
+    }>;
+
+    interface Handlers extends _Handlers {}
+  }
+}
+
+declare abstract class AnyResizeHandle extends ResizeHandle {
+  constructor(arg0: never, ...args: never[]);
 }

--- a/src/foundry/client/pixi/core/interaction/targets.d.mts
+++ b/src/foundry/client/pixi/core/interaction/targets.d.mts
@@ -14,8 +14,8 @@ declare global {
    * A subclass of Set which manages the Token ids which the User has targeted.
    * @see User#targets
    */
-  class UserTargets extends Set<TokenDocument.ObjectInstance> {
-    constructor(user: UserTargets["user"]);
+  class UserTargets extends Set<Token.ConfiguredInstance> {
+    constructor(user: User.ConfiguredInstance);
 
     user: User.ConfiguredInstance;
 
@@ -27,13 +27,22 @@ declare global {
     /**
      * @remarks Returns void, but Set<T>.add returns boolean
      */
-    override add(token: TokenDocument.ObjectInstance): void;
+    override add(token: Token.ConfiguredInstance): void;
 
     override clear(): void;
 
     /**
      * @remarks Returns void, but Set<T>.delete returns boolean
      */
-    override delete(token: TokenDocument.ObjectInstance): void;
+    override delete(token: Token.ConfiguredInstance): void;
   }
+
+  namespace UserTargets {
+    interface Any extends AnyUserTargets {}
+    type AnyConstructor = typeof AnyUserTargets;
+  }
+}
+
+declare abstract class AnyUserTargets extends UserTargets {
+  constructor(arg0: never, ...args: never[]);
 }

--- a/src/types/augments/pixi.d.mts
+++ b/src/types/augments/pixi.d.mts
@@ -920,6 +920,15 @@ declare global {
 
       /** Lowest priority used for {@link PIXI.BasePrepare} utility. */
       UTILITY: 50 & UPDATE_PRIORITY;
+
+      /** @remarks Foundry addition, defined as `HIGH - 2` */
+      OBJECTS: 23 & UPDATE_PRIORITY;
+
+      /** @remarks Foundry addition, defined as `NORMAL + 3` */
+      PRIMARY: 3 & UPDATE_PRIORITY;
+
+      /** @remarks Foundry addition, defined as `NORMAL + 2` */
+      PERCEPTION: 2 & UPDATE_PRIORITY;
     };
 
     type WRAP_MODES = Brand<number, "PIXI.WRAP_MODES">;
@@ -1022,16 +1031,42 @@ declare module "@pixi/events" {
 declare module "pixi.js" {
   export import LegacyGraphics = _PIXI.Graphics;
 
+  export enum BLEND_MODES {
+    /**
+     * A custom blend mode equation which chooses the maximum color from each channel within the stack.
+     * @remarks Foundry addition, value is technically dynamic as it's the last PIXI entry at the time + 1, but effectively static
+     */
+    MAX_COLOR = 30,
+
+    /**
+     * A custom blend mode equation which chooses the minimum color from each channel within the stack.
+     * @remarks Foundry addition, value is technically dynamic as it's the last PIXI entry at the time + 1, but effectively static
+     */
+    MIN_COLOR = 31,
+
+    /**
+     * A custom blend mode equation which chooses the minimum color for color channels and min alpha from alpha channel.
+     * @remarks Foundry addition, value is technically dynamic as it's the last PIXI entry at the time + 1, but effectively static
+     */
+    MIN_ALL = 32,
+  }
+
   export enum UPDATE_PRIORITY {
     /**
      * @remarks Foundry defined custom ticker priority
-     * Handled in Canvas##activateTicker
+     * Handled in Canvas##activateTicker, defined as `HIGH - 2`
      */
     OBJECTS = 23,
 
     /**
      * @remarks Foundry defined custom ticker priority
-     * Handled in Canvas##activateTicker
+     * Handled in Canvas##activateTicker, defined as `NORMAL + 3`
+     */
+    PRIMARY = 3,
+
+    /**
+     * @remarks Foundry defined custom ticker priority
+     * Handled in Canvas##activateTicker, defined as `NORMAL + 2`
      */
     PERCEPTION = 2,
   }

--- a/src/types/augments/pixi.d.mts
+++ b/src/types/augments/pixi.d.mts
@@ -904,6 +904,7 @@ declare global {
      * Represents the update priorities used by internal PIXI classes when registered with
      * the {@link PIXI.Ticker} object. Higher priority items are updated first and lower
      * priority items, such as render, should go later.
+     * @remarks Includes Foundry's additions of `OBJECTS`, `PRIMARY`, and `PERCEPTION`
      */
     const UPDATE_PRIORITY: {
       /** Highest priority used for interaction events in {@link PIXI.EventSystem} */

--- a/src/utils/index.d.mts
+++ b/src/utils/index.d.mts
@@ -1021,3 +1021,8 @@ type _MustBeValidUuid<
       ? OriginalUuid
       : InvalidUuid<OriginalUuid>
     : `${Type}.${string}` | `${string}.${string}.${Type}.${string}`;
+
+/**
+ * Drop the first element of an array
+ */
+type DropFirst<T extends AnyArray> = T extends [infer _1, ...infer V] ? V : T;

--- a/src/utils/index.d.mts
+++ b/src/utils/index.d.mts
@@ -1023,6 +1023,6 @@ type _MustBeValidUuid<
     : `${Type}.${string}` | `${string}.${string}.${Type}.${string}`;
 
 /**
- * Drop the first element of an array
+ * Drops the first element of an array
  */
 type DropFirst<T extends AnyArray> = T extends [infer _1, ...infer V] ? V : T;

--- a/tests/foundry/client/pixi/board.test-d.ts
+++ b/tests/foundry/client/pixi/board.test-d.ts
@@ -1,8 +1,8 @@
-import { assertType, expectTypeOf } from "vitest";
+import { expectTypeOf } from "vitest";
 
 const myCanvas = new Canvas();
-assertType<Record<string, CONFIG.Canvas.LayerDefinition<CanvasLayer.AnyConstructor>>>(Canvas.layers);
-expectTypeOf(myCanvas.draw(new Scene({ name: "My Scene" }))).toEqualTypeOf<Promise<Canvas>>();
+declare const someScene: Scene.ConfiguredInstance;
+expectTypeOf(myCanvas.draw(someScene)).toEqualTypeOf<Promise<Canvas>>();
 
 expectTypeOf(myCanvas.getLayerByEmbeddedName("AmbientLight")).toEqualTypeOf<LightingLayer | null>();
 expectTypeOf(myCanvas.getLayerByEmbeddedName("AmbientSound")).toEqualTypeOf<SoundsLayer | null>();
@@ -14,18 +14,18 @@ expectTypeOf(myCanvas.getLayerByEmbeddedName("Token")).toEqualTypeOf<TokenLayer 
 expectTypeOf(myCanvas.getLayerByEmbeddedName("Wall")).toEqualTypeOf<WallsLayer | null>();
 expectTypeOf(myCanvas.getLayerByEmbeddedName("any-string")).toEqualTypeOf<null>();
 
-expectTypeOf(myCanvas.animatePan({})).toEqualTypeOf<Promise<boolean>>();
+expectTypeOf(myCanvas.animatePan({})).toEqualTypeOf<Promise<boolean | void>>();
 expectTypeOf(
   myCanvas.animatePan({ x: 100, y: 100, scale: 1, duration: 250, easing: (pt: number) => pt }),
-).toEqualTypeOf<Promise<boolean>>();
+).toEqualTypeOf<Promise<boolean | void>>();
 expectTypeOf(myCanvas.animatePan({ x: 500, y: 500, scale: 10, speed: 6, easing: "easeInCircle" })).toEqualTypeOf<
-  Promise<boolean>
+  Promise<boolean | void>
 >();
 
-expectTypeOf(myCanvas.recenter()).toEqualTypeOf<Promise<boolean>>();
-expectTypeOf(myCanvas.recenter({})).toEqualTypeOf<Promise<boolean>>();
-expectTypeOf(myCanvas.recenter({ x: null, y: null, scale: null })).toEqualTypeOf<Promise<boolean>>();
-expectTypeOf(myCanvas.recenter({ x: 100, y: 100, scale: 1 })).toEqualTypeOf<Promise<boolean>>();
+expectTypeOf(myCanvas.recenter()).toEqualTypeOf<Promise<boolean | void>>();
+expectTypeOf(myCanvas.recenter({})).toEqualTypeOf<Promise<boolean | void>>();
+expectTypeOf(myCanvas.recenter({ x: null, y: null, scale: null })).toEqualTypeOf<Promise<boolean | void>>();
+expectTypeOf(myCanvas.recenter({ x: 100, y: 100, scale: 1 })).toEqualTypeOf<Promise<boolean | void>>();
 
 myCanvas.pendingRenderFlags.OBJECTS.add(myCanvas.perception);
 

--- a/tests/foundry/client/pixi/core/interaction/canvas-animation.test-d.ts
+++ b/tests/foundry/client/pixi/core/interaction/canvas-animation.test-d.ts
@@ -1,3 +1,24 @@
 import { expectTypeOf } from "vitest";
 
+declare function someEasing(pt: number): number;
+declare const somePromise: Promise<unknown>;
 expectTypeOf(CanvasAnimation.easeOutCircle(3)).toEqualTypeOf<number>();
+expectTypeOf(
+  CanvasAnimation.animate(
+    [
+      {
+        parent: { darkness: 0 },
+        attribute: "darkness",
+        to: 0.8,
+      },
+    ],
+    {
+      duration: 2000,
+      priority: 27 as PIXI.UPDATE_PRIORITY,
+      easing: someEasing,
+      name: "darknessShift",
+      wait: somePromise,
+    },
+  ),
+).toEqualTypeOf<Promise<boolean | void>>();
+expectTypeOf(CanvasAnimation.getAnimation("darknessShift")).toEqualTypeOf<CanvasAnimationData | undefined>;

--- a/tests/foundry/client/pixi/core/interaction/control-icon.test-d.ts
+++ b/tests/foundry/client/pixi/core/interaction/control-icon.test-d.ts
@@ -1,5 +1,19 @@
 import { expectTypeOf } from "vitest";
 
-const myControlIcon = new ControlIcon({ texture: "foobar" });
+const myControlIcon = new ControlIcon({
+  texture: "foobar",
+  borderColor: 0x00ff00,
+  elevation: 20,
+  size: 64,
+  tint: 0x373964,
+});
 
-expectTypeOf(myControlIcon.border.visible).toEqualTypeOf<boolean>();
+expectTypeOf(myControlIcon.draw()).toEqualTypeOf<Promise<ControlIcon>>();
+expectTypeOf(
+  myControlIcon.refresh({
+    visible: true,
+    iconColor: 0xdeadea,
+    borderColor: 0xff0000,
+    borderVisible: true,
+  }),
+).toEqualTypeOf<ControlIcon>();

--- a/tests/foundry/client/pixi/core/interaction/mouse-handler.test-d.ts
+++ b/tests/foundry/client/pixi/core/interaction/mouse-handler.test-d.ts
@@ -1,12 +1,30 @@
 import { expectTypeOf } from "vitest";
-import type { ValueOf } from "fvtt-types/utils";
 
-() => {
-  const myCanvas = new Canvas();
+expectTypeOf(MouseInteractionManager.INTERACTION_STATES).toMatchTypeOf<
+  Record<string, number & MouseInteractionManager.INTERACTION_STATES>
+>();
 
-  if (!myCanvas.stage) return;
+declare const someEvent: PIXI.FederatedEvent;
 
-  const myMouseHandler = new MouseInteractionManager(myCanvas.stage, myCanvas.stage);
-
-  expectTypeOf(myMouseHandler.state).toEqualTypeOf<ValueOf<(typeof MouseInteractionManager)["INTERACTION_STATES"]>>();
+const permissions = {
+  dragLeftStart: (_user: User.ConfiguredInstance, _e: Event | PIXI.FederatedEvent) => true,
+  dragLeftDrop: (user: User.ConfiguredInstance, _e: Event | PIXI.FederatedEvent) => user.id?.includes("F") ?? false,
+  dragRightStart: false,
 };
+
+const callbacks = {
+  dragLeftStart: (_e: Event | PIXI.FederatedEvent, otherArg: number) => {
+    return otherArg > 4;
+  },
+  dragLeftDrop: (_e: Event | PIXI.FederatedEvent, otherArg: string) => {
+    return otherArg.includes("hello, world");
+  },
+};
+
+const myMouseHandler = new MouseInteractionManager(new PIXI.Container(), new PIXI.Container(), permissions, callbacks, {
+  target: null,
+});
+
+expectTypeOf(myMouseHandler.callback("dragLeftStart", someEvent, 8)).toEqualTypeOf<boolean>;
+expectTypeOf(myMouseHandler.callback("dragLeftDrop", someEvent, "bob"));
+expectTypeOf(myMouseHandler.state).toEqualTypeOf<MouseInteractionManager.INTERACTION_STATES>();

--- a/tests/foundry/client/pixi/core/interaction/mouse-handler.test-d.ts
+++ b/tests/foundry/client/pixi/core/interaction/mouse-handler.test-d.ts
@@ -1,8 +1,8 @@
 import { expectTypeOf } from "vitest";
 
-expectTypeOf(MouseInteractionManager.INTERACTION_STATES).toMatchTypeOf<
-  Record<string, number & MouseInteractionManager.INTERACTION_STATES>
->();
+expectTypeOf(
+  MouseInteractionManager.INTERACTION_STATES.CLICKED,
+).toMatchTypeOf<MouseInteractionManager.INTERACTION_STATES>();
 
 declare const someEvent: PIXI.FederatedEvent;
 declare const someRegion: Region.ConfiguredInstance;
@@ -25,9 +25,7 @@ const myMouseHandler = new MouseInteractionManager(someRegion, new PIXI.Containe
   target: null,
 });
 
-expectTypeOf(myMouseHandler.handlerOutcomes).toMatchTypeOf<
-  Record<string, number & MouseInteractionManager.HANDLER_OUTCOMES>
->();
+expectTypeOf(myMouseHandler.handlerOutcomes.ACCEPTED).toMatchTypeOf<MouseInteractionManager.HANDLER_OUTCOMES>();
 
 // Unfortunately the parameters beyond the event are not being typechecked due to complexities in the way manager callbacks are registered
 expectTypeOf(myMouseHandler.callback("hoverIn", someEvent, { hoverOutOthers: true })).toEqualTypeOf<boolean>;

--- a/tests/foundry/client/pixi/core/interaction/mouse-handler.test-d.ts
+++ b/tests/foundry/client/pixi/core/interaction/mouse-handler.test-d.ts
@@ -5,26 +5,33 @@ expectTypeOf(MouseInteractionManager.INTERACTION_STATES).toMatchTypeOf<
 >();
 
 declare const someEvent: PIXI.FederatedEvent;
+declare const someRegion: Region.ConfiguredInstance;
 
 const permissions = {
   dragLeftStart: (_user: User.ConfiguredInstance, _e: Event | PIXI.FederatedEvent) => true,
-  dragLeftDrop: (user: User.ConfiguredInstance, _e: Event | PIXI.FederatedEvent) => user.id?.includes("F") ?? false,
   dragRightStart: false,
 };
 
 const callbacks = {
-  dragLeftStart: (_e: Event | PIXI.FederatedEvent, otherArg: number) => {
-    return otherArg > 4;
+  hoverIn: (_e: Event | PIXI.FederatedEvent, options: PlaceableObject.HoverInOptions) => {
+    if (options.hoverOutOthers) console.log("stuff");
   },
-  dragLeftDrop: (_e: Event | PIXI.FederatedEvent, otherArg: string) => {
-    return otherArg.includes("hello, world");
+  longPress: (_e: Event | PIXI.FederatedEvent, origin: PIXI.Point) => {
+    return origin.x > 500;
   },
 };
 
-const myMouseHandler = new MouseInteractionManager(new PIXI.Container(), new PIXI.Container(), permissions, callbacks, {
+const myMouseHandler = new MouseInteractionManager(someRegion, new PIXI.Container(), permissions, callbacks, {
   target: null,
 });
 
-expectTypeOf(myMouseHandler.callback("dragLeftStart", someEvent, 8)).toEqualTypeOf<boolean>;
-expectTypeOf(myMouseHandler.callback("dragLeftDrop", someEvent, "bob"));
+expectTypeOf(myMouseHandler.handlerOutcomes).toMatchTypeOf<
+  Record<string, number & MouseInteractionManager.HANDLER_OUTCOMES>
+>();
+
+// Unfortunately the parameters beyond the event are not being typechecked due to complexities in the way manager callbacks are registered
+expectTypeOf(myMouseHandler.callback("hoverIn", someEvent, { hoverOutOthers: true })).toEqualTypeOf<boolean>;
+expectTypeOf(myMouseHandler.callback("longPress", someEvent, new PIXI.Point(1000, 1000)));
+
 expectTypeOf(myMouseHandler.state).toEqualTypeOf<MouseInteractionManager.INTERACTION_STATES>();
+expectTypeOf(myMouseHandler.reset({ interactionData: true, state: false })).toEqualTypeOf<void>();

--- a/tests/foundry/client/pixi/core/interaction/ping.test-d.ts
+++ b/tests/foundry/client/pixi/core/interaction/ping.test-d.ts
@@ -1,7 +1,7 @@
 import { expectTypeOf } from "vitest";
 
 const myPoint = new PIXI.Point(2, 2);
-
 const myPing = new Ping(myPoint);
 
 expectTypeOf(myPing.animate()).toEqualTypeOf<Promise<boolean>>();
+expectTypeOf(myPing._color).toEqualTypeOf<Color>();

--- a/tests/foundry/client/pixi/core/interaction/pings/chevron.test-d.ts
+++ b/tests/foundry/client/pixi/core/interaction/pings/chevron.test-d.ts
@@ -2,6 +2,12 @@ import { expectTypeOf } from "vitest";
 
 const myPoint = new PIXI.Point(2, 2);
 
-const myPing = new ChevronPing(myPoint);
+const myChevronPing = new ChevronPing(myPoint, {
+  name: undefined,
+  color: Color.fromHSL([0.5, 0.3, 0.92]),
+  duration: 500,
+  size: 48,
+});
 
-expectTypeOf(myPing.animate()).toEqualTypeOf<Promise<boolean>>();
+expectTypeOf(myChevronPing.animate()).toEqualTypeOf<Promise<boolean>>();
+expectTypeOf(myChevronPing._loadChevron()).toEqualTypeOf<Promise<PIXI.Sprite>>();

--- a/tests/foundry/client/pixi/core/interaction/pings/pulse.test-d.ts
+++ b/tests/foundry/client/pixi/core/interaction/pings/pulse.test-d.ts
@@ -2,6 +2,39 @@ import { expectTypeOf } from "vitest";
 
 const myPoint = new PIXI.Point(2, 2);
 
-const myPing = new PulsePing(myPoint);
+const myPulsePing = new PulsePing(myPoint, {
+  color: "#FF00FF",
+  color2: "#00FFFF",
+  duration: 4000,
+  rings: 5,
+  size: 256,
+  name: null,
+});
 
-expectTypeOf(myPing.animate()).toEqualTypeOf<Promise<boolean>>();
+expectTypeOf(myPulsePing.animate()).toEqualTypeOf<Promise<boolean>>();
+
+const myArrowPing = new ArrowPing(myPoint, {
+  color: [0.2, 0.5, 0.6],
+  color2: [0.3, 0, 0.2],
+  name: "myArrowPing",
+  rings: 2,
+  rotation: Math.PI / 2,
+  duration: 2000,
+  size: 128,
+});
+
+expectTypeOf(myArrowPing.animate()).toEqualTypeOf<Promise<boolean>>();
+
+declare const someColor: Color;
+declare const someSymbol: unique symbol;
+
+const myAlertPing = new AlertPing(myPoint, {
+  color: undefined,
+  color2: someColor,
+  rings: 15,
+  name: someSymbol,
+  duration: 250,
+  size: 512,
+});
+
+expectTypeOf(myAlertPing.animate()).toEqualTypeOf<Promise<boolean>>();

--- a/tests/foundry/client/pixi/core/interaction/resize-handle.test-d.ts
+++ b/tests/foundry/client/pixi/core/interaction/resize-handle.test-d.ts
@@ -1,5 +1,10 @@
 import { expectTypeOf } from "vitest";
 
-const myResizeHandler = new ResizeHandle([2, 3]);
+declare const someRect: Canvas.Rectangle;
 
-expectTypeOf(myResizeHandler.visible).toEqualTypeOf<boolean>();
+const myResizeHandle = new ResizeHandle([2, 3], { canDrag: () => true });
+
+expectTypeOf(myResizeHandle.offset).toEqualTypeOf<[number, number]>();
+expectTypeOf(
+  myResizeHandle.updateDimensions(someRect, someRect, someRect, { aspectRatio: 2 }),
+).toEqualTypeOf<Canvas.Rectangle>();

--- a/tests/foundry/client/pixi/core/interaction/targets.test-d.ts
+++ b/tests/foundry/client/pixi/core/interaction/targets.test-d.ts
@@ -1,10 +1,10 @@
 import { expectTypeOf } from "vitest";
 
-declare const user: User;
-declare const token: Token;
+declare const user: User.ConfiguredInstance;
+declare const token: Token.ConfiguredInstance;
 
 const targets = new UserTargets(user);
-expectTypeOf(targets.user).toEqualTypeOf<User>();
+expectTypeOf(targets.user).toEqualTypeOf<User.ConfiguredInstance>();
 expectTypeOf(targets.ids).toEqualTypeOf<string[]>();
 expectTypeOf(targets.add(token)).toEqualTypeOf<void>();
 expectTypeOf(targets.clear()).toEqualTypeOf<void>();


### PR DESCRIPTION
Touched up everything in the title folder except RenderFlags, as that has had recent attention and what I can decode of it looks accuate