### PR TITLE
cleaned up relative references to utils

### DIFF
--- a/src/foundry/client-esm/applications/api/dialog.d.mts
+++ b/src/foundry/client-esm/applications/api/dialog.d.mts
@@ -1,4 +1,4 @@
-import type { AnyFunction, DeepPartial, EmptyObject, MaybePromise } from "../../../../utils/index.d.mts";
+import type { AnyFunction, DeepPartial, EmptyObject, MaybePromise } from "fvtt-types/utils";
 import type ApplicationV2 from "./application.d.mts";
 
 /**

--- a/src/foundry/client-esm/applications/api/document-sheet.d.mts
+++ b/src/foundry/client-esm/applications/api/document-sheet.d.mts
@@ -1,4 +1,4 @@
-import type { AnyObject, DeepPartial, EmptyObject, SimpleMerge } from "../../../../utils/index.d.mts";
+import type { AnyObject, DeepPartial, EmptyObject, SimpleMerge } from "fvtt-types/utils";
 import type ApplicationV2 from "./application.d.mts";
 
 declare namespace DocumentSheetV2 {

--- a/src/foundry/client-esm/applications/api/handlebars-application.d.mts
+++ b/src/foundry/client-esm/applications/api/handlebars-application.d.mts
@@ -1,4 +1,4 @@
-import type { DeepPartial, Mixin } from "../../../../utils/index.d.mts";
+import type { DeepPartial, Mixin } from "fvtt-types/utils";
 import type ApplicationV2 from "./application.d.mts";
 
 /**

--- a/src/foundry/client-esm/applications/apps/compendium-art-config.d.mts
+++ b/src/foundry/client-esm/applications/apps/compendium-art-config.d.mts
@@ -1,4 +1,4 @@
-import type { ConformRecord, InterfaceToObject, MustConform, DeepPartial } from "../../../../utils/index.d.mts";
+import type { ConformRecord, InterfaceToObject, MustConform, DeepPartial } from "fvtt-types/utils";
 import type { CompendiumArtDescriptor } from "../../helpers/_types.d.mts";
 import type ApplicationV2 from "../api/application.d.mts";
 import type HandlebarsApplicationMixin from "../api/handlebars-application.d.mts";

--- a/src/foundry/client-esm/applications/apps/permission-config.d.mts
+++ b/src/foundry/client-esm/applications/apps/permission-config.d.mts
@@ -1,4 +1,4 @@
-import type { ConformRecord, InterfaceToObject, MustConform, DeepPartial } from "../../../../utils/index.d.mts";
+import type { ConformRecord, InterfaceToObject, MustConform, DeepPartial } from "fvtt-types/utils";
 import type { UserPermission } from "../../../common/constants.d.mts";
 import type { CONST } from "../../client.d.mts";
 import type ApplicationV2 from "../api/application.d.mts";

--- a/src/foundry/client-esm/applications/dice/roll-resolver.d.mts
+++ b/src/foundry/client-esm/applications/dice/roll-resolver.d.mts
@@ -1,4 +1,4 @@
-import type { AnyObject, DeepPartial, EmptyObject, InexactPartial } from "../../../../utils/index.d.mts";
+import type { AnyObject, DeepPartial, EmptyObject, InexactPartial } from "fvtt-types/utils";
 import type ApplicationV2 from "../api/application.d.mts";
 import type HandlebarsApplicationMixin from "../api/handlebars-application.d.mts";
 

--- a/src/foundry/client-esm/applications/forms/fields.d.mts
+++ b/src/foundry/client-esm/applications/forms/fields.d.mts
@@ -1,4 +1,4 @@
-import type { NullishProps } from "../../../../utils/index.d.mts";
+import type { NullishProps } from "fvtt-types/utils";
 
 export type CustomFormGroup = (
   field: foundry.data.fields.DataField,

--- a/src/foundry/client-esm/applications/sheets/actor-sheet.d.mts
+++ b/src/foundry/client-esm/applications/sheets/actor-sheet.d.mts
@@ -1,4 +1,4 @@
-import type { AnyObject, EmptyObject } from "../../../../utils/index.d.mts";
+import type { AnyObject, EmptyObject } from "fvtt-types/utils";
 import type ApplicationV2 from "../api/application.d.mts";
 import type DocumentSheetV2 from "../api/document-sheet.d.mts";
 

--- a/src/foundry/client-esm/applications/sheets/ambient-light-config.d.mts
+++ b/src/foundry/client-esm/applications/sheets/ambient-light-config.d.mts
@@ -1,4 +1,4 @@
-import type { InterfaceToObject, AnyObject, DeepPartial } from "../../../../utils/index.d.mts";
+import type { InterfaceToObject, AnyObject, DeepPartial } from "fvtt-types/utils";
 import type ApplicationV2 from "../api/application.d.mts";
 import type DocumentSheetV2 from "../api/document-sheet.d.mts";
 import type HandlebarsApplicationMixin from "../api/handlebars-application.d.mts";

--- a/src/foundry/client-esm/applications/sheets/ambient-sound-config.d.mts
+++ b/src/foundry/client-esm/applications/sheets/ambient-sound-config.d.mts
@@ -1,4 +1,4 @@
-import type { InterfaceToObject, AnyObject, DeepPartial } from "../../../../utils/index.d.mts";
+import type { InterfaceToObject, AnyObject, DeepPartial } from "fvtt-types/utils";
 import type ApplicationV2 from "../api/application.d.mts";
 import type DocumentSheetV2 from "../api/document-sheet.d.mts";
 import type HandlebarsApplicationMixin from "../api/handlebars-application.d.mts";

--- a/src/foundry/client-esm/applications/sheets/item-sheet.d.mts
+++ b/src/foundry/client-esm/applications/sheets/item-sheet.d.mts
@@ -1,4 +1,4 @@
-import type { AnyObject, EmptyObject } from "../../../../utils/index.d.mts";
+import type { AnyObject, EmptyObject } from "fvtt-types/utils";
 import type DocumentSheetV2 from "../api/document-sheet.d.mts";
 
 /**

--- a/src/foundry/client-esm/applications/sheets/region-behavior-config.d.mts
+++ b/src/foundry/client-esm/applications/sheets/region-behavior-config.d.mts
@@ -1,4 +1,4 @@
-import type { AnyObject, DeepPartial, EmptyObject } from "../../../../utils/index.d.mts";
+import type { AnyObject, DeepPartial, EmptyObject } from "fvtt-types/utils";
 import type { FormFooterButton, FormNode } from "../_types.d.mts";
 import type DocumentSheetV2 from "../api/document-sheet.d.mts";
 import type HandlebarsApplicationMixin from "../api/handlebars-application.d.mts";

--- a/src/foundry/client-esm/applications/sheets/region-config.d.mts
+++ b/src/foundry/client-esm/applications/sheets/region-config.d.mts
@@ -1,4 +1,4 @@
-import type { AnyObject, DeepPartial, EmptyObject } from "../../../../utils/index.d.mts";
+import type { AnyObject, DeepPartial, EmptyObject } from "fvtt-types/utils";
 import type DocumentSheetV2 from "../api/document-sheet.d.mts";
 import type HandlebarsApplicationMixin from "../api/handlebars-application.d.mts";
 

--- a/src/foundry/client-esm/applications/sheets/user-config.d.mts
+++ b/src/foundry/client-esm/applications/sheets/user-config.d.mts
@@ -1,4 +1,4 @@
-import type { InterfaceToObject, AnyObject, DeepPartial } from "../../../../utils/index.d.mts";
+import type { InterfaceToObject, AnyObject, DeepPartial } from "fvtt-types/utils";
 import type DocumentSheetV2 from "../api/document-sheet.d.mts";
 import type HandlebarsApplicationMixin from "../api/handlebars-application.d.mts";
 import type { CustomFormGroup } from "../forms/fields.d.mts";

--- a/src/foundry/client-esm/applications/ui/region-legend.d.mts
+++ b/src/foundry/client-esm/applications/ui/region-legend.d.mts
@@ -1,4 +1,4 @@
-import type { AnyObject, DeepPartial, EmptyObject } from "../../../../utils/index.d.mts";
+import type { AnyObject, DeepPartial, EmptyObject } from "fvtt-types/utils";
 import type ApplicationV2 from "../api/application.d.mts";
 import type HandlebarsApplicationMixin from "../api/handlebars-application.d.mts";
 

--- a/src/foundry/client-esm/audio/biquad.d.mts
+++ b/src/foundry/client-esm/audio/biquad.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial } from "../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 
 /**
  * A sound effect which applies a biquad filter.

--- a/src/foundry/client-esm/audio/convolver.d.mts
+++ b/src/foundry/client-esm/audio/convolver.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial } from "../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 
 declare namespace ConvolverEffect {}
 

--- a/src/foundry/client-esm/audio/helper.d.mts
+++ b/src/foundry/client-esm/audio/helper.d.mts
@@ -1,6 +1,6 @@
 import type Sound from "./sound.d.mts";
 import type AudioBufferCache from "./cache.d.mts";
-import type { InexactPartial } from "../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 
 /**
  * A helper class to provide common functionality for working with the Web Audio API.

--- a/src/foundry/client-esm/audio/sound.d.mts
+++ b/src/foundry/client-esm/audio/sound.d.mts
@@ -1,4 +1,4 @@
-import type { AnyObject, InexactPartial, ValueOf } from "../../../utils/index.d.mts";
+import type { AnyObject, InexactPartial, ValueOf } from "fvtt-types/utils";
 import type EventEmitterMixin from "../../common/utils/event-emitter.d.mts";
 
 declare namespace Sound {

--- a/src/foundry/client-esm/canvas/edges/edge.d.mts
+++ b/src/foundry/client-esm/canvas/edges/edge.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial } from "../../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 import type { WallThresholdData } from "../../../common/documents/_types.d.mts";
 
 /**

--- a/src/foundry/client-esm/canvas/smaa/smaa.d.mts
+++ b/src/foundry/client-esm/canvas/smaa/smaa.d.mts
@@ -1,6 +1,6 @@
 import type { CLEAR_MODES, FilterState, FilterSystem, RenderTexture } from "pixi.js";
 
-import type { InexactPartial } from "../../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 
 declare class SMAAFilter extends PIXI.Filter {
   /**

--- a/src/foundry/client-esm/canvas/sources/base-effect-source.d.mts
+++ b/src/foundry/client-esm/canvas/sources/base-effect-source.d.mts
@@ -1,4 +1,4 @@
-import type { NullishProps, IntentionalPartial } from "../../../../utils/index.d.mts";
+import type { NullishProps, IntentionalPartial } from "fvtt-types/utils";
 
 /**
  * TODO - Re-document after ESM refactor.

--- a/src/foundry/client-esm/canvas/sources/base-light-source.d.mts
+++ b/src/foundry/client-esm/canvas/sources/base-light-source.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial, IntentionalPartial } from "../../../../utils/index.d.mts";
+import type { InexactPartial, IntentionalPartial } from "fvtt-types/utils";
 import type RenderedEffectSource from "./rendered-effect-source.d.mts";
 
 /**

--- a/src/foundry/client-esm/canvas/sources/point-darkness-source.d.mts
+++ b/src/foundry/client-esm/canvas/sources/point-darkness-source.d.mts
@@ -1,4 +1,4 @@
-import type { IntentionalPartial } from "../../../../utils/index.d.mts";
+import type { IntentionalPartial } from "fvtt-types/utils";
 import type BaseLightSource from "./base-light-source.d.mts";
 import type PointEffectSourceMixin from "./point-effect-source.d.mts";
 import type RenderedEffectSource from "./rendered-effect-source.d.mts";

--- a/src/foundry/client-esm/canvas/sources/point-effect-source.d.mts
+++ b/src/foundry/client-esm/canvas/sources/point-effect-source.d.mts
@@ -1,4 +1,4 @@
-import type { Mixin, IntentionalPartial } from "../../../../utils/index.d.mts";
+import type { Mixin, IntentionalPartial } from "fvtt-types/utils";
 import type BaseEffectSource from "./base-effect-source.d.mts";
 
 declare class PointEffectSource {

--- a/src/foundry/client-esm/canvas/sources/point-light-source.d.mts
+++ b/src/foundry/client-esm/canvas/sources/point-light-source.d.mts
@@ -1,4 +1,4 @@
-import type { IntentionalPartial } from "../../../../utils/index.d.mts";
+import type { IntentionalPartial } from "fvtt-types/utils";
 import type BaseLightSource from "./base-light-source.d.mts";
 import type PointEffectSourceMixin from "./point-effect-source.d.mts";
 

--- a/src/foundry/client-esm/canvas/sources/point-sound-source.d.mts
+++ b/src/foundry/client-esm/canvas/sources/point-sound-source.d.mts
@@ -1,4 +1,4 @@
-import type { NullishProps } from "../../../../utils/index.d.mts";
+import type { NullishProps } from "fvtt-types/utils";
 import type BaseEffectSource from "./base-effect-source.d.mts";
 import type PointEffectSourceMixin from "./point-effect-source.d.mts";
 

--- a/src/foundry/client-esm/canvas/sources/point-vision-source.d.mts
+++ b/src/foundry/client-esm/canvas/sources/point-vision-source.d.mts
@@ -1,6 +1,6 @@
 import type RenderedEffectSource from "./rendered-effect-source.d.mts";
 import type PointEffectSourceMixin from "./point-effect-source.d.mts";
-import type { IntentionalPartial } from "../../../../utils/index.d.mts";
+import type { IntentionalPartial } from "fvtt-types/utils";
 
 /**
  * A specialized subclass of RenderedEffectSource which represents a source of point-based vision.

--- a/src/foundry/client-esm/canvas/sources/rendered-effect-source.d.mts
+++ b/src/foundry/client-esm/canvas/sources/rendered-effect-source.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial, IntentionalPartial } from "../../../../utils/index.d.mts";
+import type { InexactPartial, IntentionalPartial } from "fvtt-types/utils";
 import type BaseEffectSource from "./base-effect-source.d.mts";
 
 /**

--- a/src/foundry/client-esm/canvas/tokens/ring-data.d.mts
+++ b/src/foundry/client-esm/canvas/tokens/ring-data.d.mts
@@ -1,6 +1,6 @@
 import type DataModel from "../../../common/abstract/data.d.mts";
 import type { DataField, DataSchema } from "../../../common/data/fields.d.mts";
-import type { AnyConstructor, SimpleMerge } from "../../../../utils/index.d.mts";
+import type { AnyConstructor, SimpleMerge } from "fvtt-types/utils";
 import type TokenRing from "./ring.d.mts";
 
 import fields = foundry.data.fields;

--- a/src/foundry/client-esm/data/client-backend.d.mts
+++ b/src/foundry/client-esm/data/client-backend.d.mts
@@ -1,4 +1,4 @@
-import type { FixedInstanceType, LoggingLevels } from "../../../utils/index.d.mts";
+import type { FixedInstanceType, LoggingLevels } from "fvtt-types/utils";
 import type Document from "../../common/abstract/document.d.mts";
 import type {
   DatabaseGetOperation,

--- a/src/foundry/client-esm/data/region-behaviors/adjust-darkness-level.d.mts
+++ b/src/foundry/client-esm/data/region-behaviors/adjust-darkness-level.d.mts
@@ -1,5 +1,5 @@
 import type RegionBehaviorType from "./base.d.mts";
-import type { Brand } from "../../../../utils/index.d.mts";
+import type { Brand } from "fvtt-types/utils";
 import fields = foundry.data.fields;
 import type { InvertObject } from "../../../common/utils/helpers.d.mts";
 

--- a/src/foundry/client-esm/data/region-behaviors/base.d.mts
+++ b/src/foundry/client-esm/data/region-behaviors/base.d.mts
@@ -1,5 +1,5 @@
 import type TypeDataModel from "../../../common/abstract/type-data.d.mts";
-import type { AnyObject, EmptyObject } from "../../../../utils/index.d.mts";
+import type { AnyObject, EmptyObject } from "fvtt-types/utils";
 
 import fields = foundry.data.fields;
 

--- a/src/foundry/client-esm/data/region-behaviors/display-scrolling-text.d.mts
+++ b/src/foundry/client-esm/data/region-behaviors/display-scrolling-text.d.mts
@@ -1,5 +1,5 @@
 import type RegionBehaviorType from "./base.d.mts";
-import type { Brand } from "../../../../utils/index.d.mts";
+import type { Brand } from "fvtt-types/utils";
 import fields = foundry.data.fields;
 import type { InvertObject } from "../../../common/utils/helpers.d.mts";
 

--- a/src/foundry/client-esm/dice/roll.d.mts
+++ b/src/foundry/client-esm/dice/roll.d.mts
@@ -1,4 +1,4 @@
-import type { AnyObject, EmptyObject, InexactPartial, FixedInstanceType } from "../../../utils/index.d.mts";
+import type { AnyObject, EmptyObject, InexactPartial, FixedInstanceType } from "fvtt-types/utils";
 
 import type { RollParseNode } from "./_types.d.mts";
 import type DiceTerm from "./terms/dice.d.mts";

--- a/src/foundry/client-esm/dice/terms/coin.d.mts
+++ b/src/foundry/client-esm/dice/terms/coin.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial } from "../../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 import type DiceTerm from "./dice.d.mts";
 
 /**

--- a/src/foundry/client-esm/dice/terms/dice.d.mts
+++ b/src/foundry/client-esm/dice/terms/dice.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial, FixedInstanceType } from "../../../../utils/index.d.mts";
+import type { InexactPartial, FixedInstanceType } from "fvtt-types/utils";
 import type { DiceRollParseNode } from "../_types.d.mts";
 
 import type RollTerm from "./term.d.mts";

--- a/src/foundry/client-esm/dice/terms/die.d.mts
+++ b/src/foundry/client-esm/dice/terms/die.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial } from "../../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 
 import type DiceTerm from "./dice.d.mts";
 

--- a/src/foundry/client-esm/dice/terms/fate.d.mts
+++ b/src/foundry/client-esm/dice/terms/fate.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial } from "../../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 
 import type DiceTerm from "./dice.d.mts";
 import type Die from "./die.d.mts";

--- a/src/foundry/client-esm/dice/terms/function.d.mts
+++ b/src/foundry/client-esm/dice/terms/function.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial, FixedInstanceType } from "../../../../utils/index.d.mts";
+import type { InexactPartial, FixedInstanceType } from "fvtt-types/utils";
 import type { FunctionRollParseNode } from "../_types.d.mts";
 
 import type RollTerm from "./term.d.mts";

--- a/src/foundry/client-esm/dice/terms/numeric.d.mts
+++ b/src/foundry/client-esm/dice/terms/numeric.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial } from "../../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 import type RollTerm from "./term.d.mts";
 
 /**

--- a/src/foundry/client-esm/dice/terms/operator.d.mts
+++ b/src/foundry/client-esm/dice/terms/operator.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial } from "../../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 
 import type RollTerm from "./term.d.mts";
 

--- a/src/foundry/client-esm/dice/terms/parenthetical.d.mts
+++ b/src/foundry/client-esm/dice/terms/parenthetical.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial } from "../../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 import type { ParentheticalRollParseNode } from "../_types.d.mts";
 
 import type RollTerm from "./term.d.mts";

--- a/src/foundry/client-esm/dice/terms/pool.d.mts
+++ b/src/foundry/client-esm/dice/terms/pool.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial, FixedInstanceType } from "../../../../utils/index.d.mts";
+import type { InexactPartial, FixedInstanceType } from "fvtt-types/utils";
 import type { PoolRollParseNode } from "../_types.d.mts";
 
 import type RollTerm from "./term.d.mts";

--- a/src/foundry/client-esm/dice/terms/string.d.mts
+++ b/src/foundry/client-esm/dice/terms/string.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial } from "../../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 import type RollTerm from "./term.d.mts";
 
 /**

--- a/src/foundry/client-esm/dice/terms/term.d.mts
+++ b/src/foundry/client-esm/dice/terms/term.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial, FixedInstanceType } from "../../../../utils/index.d.mts";
+import type { InexactPartial, FixedInstanceType } from "fvtt-types/utils";
 import type { RollParseNode } from "../_types.mts";
 
 import type RollResolver from "../../applications/dice/roll-resolver.d.mts";

--- a/src/foundry/client/apps/app.d.mts
+++ b/src/foundry/client/apps/app.d.mts
@@ -1,4 +1,4 @@
-import type { MaybePromise, ValueOf } from "../../../utils/index.d.mts";
+import type { MaybePromise, ValueOf } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/apps/av/av-config.d.mts
+++ b/src/foundry/client/apps/av/av-config.d.mts
@@ -1,4 +1,4 @@
-import type { GetDataReturnType, MaybePromise } from "../../../../utils/index.d.mts";
+import type { GetDataReturnType, MaybePromise } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/apps/av/cameras.d.mts
+++ b/src/foundry/client/apps/av/cameras.d.mts
@@ -1,4 +1,4 @@
-import type { GetDataReturnType, MaybePromise } from "../../../../utils/index.d.mts";
+import type { GetDataReturnType, MaybePromise } from "fvtt-types/utils";
 import type Document from "../../../common/abstract/document.d.mts";
 
 declare global {

--- a/src/foundry/client/apps/dice/dice-config.d.mts
+++ b/src/foundry/client/apps/dice/dice-config.d.mts
@@ -1,4 +1,4 @@
-import type { MaybePromise, GetDataReturnType, EmptyObject } from "../../../../utils/index.d.mts";
+import type { MaybePromise, GetDataReturnType, EmptyObject } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/apps/form.d.mts
+++ b/src/foundry/client/apps/form.d.mts
@@ -1,6 +1,6 @@
 import type { EditorView } from "prosemirror-view";
 import type { Editor } from "tinymce";
-import type { AnyObject, GetDataReturnType, InexactPartial, MaybePromise } from "../../../utils/index.d.mts";
+import type { AnyObject, GetDataReturnType, InexactPartial, MaybePromise } from "fvtt-types/utils";
 import type { ProseMirrorKeyMaps, ProseMirrorMenu } from "../../common/prosemirror/_module.d.mts";
 import type Document from "../../common/abstract/document.d.mts";
 

--- a/src/foundry/client/apps/forms/actor.d.mts
+++ b/src/foundry/client/apps/forms/actor.d.mts
@@ -1,4 +1,4 @@
-import type { GetDataReturnType, MaybePromise } from "../../../../utils/index.d.mts";
+import type { GetDataReturnType, MaybePromise } from "fvtt-types/utils";
 import type Document from "../../../common/abstract/document.d.mts";
 
 declare global {

--- a/src/foundry/client/apps/forms/adventure-exporter.d.mts
+++ b/src/foundry/client/apps/forms/adventure-exporter.d.mts
@@ -1,6 +1,6 @@
 import type { EditorView } from "prosemirror-view";
 import type { Editor } from "tinymce";
-import type { GetDataReturnType } from "../../../../utils/index.d.mts";
+import type { GetDataReturnType } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/apps/forms/adventure-importer.d.mts
+++ b/src/foundry/client/apps/forms/adventure-importer.d.mts
@@ -1,4 +1,4 @@
-import type { GetDataReturnType } from "../../../../utils/index.d.mts";
+import type { GetDataReturnType } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/apps/forms/base-sheet.d.mts
+++ b/src/foundry/client/apps/forms/base-sheet.d.mts
@@ -1,6 +1,6 @@
 import type { EditorView } from "prosemirror-view";
 import type { Editor } from "tinymce";
-import type { GetDataReturnType } from "../../../../utils/index.d.mts";
+import type { GetDataReturnType } from "fvtt-types/utils";
 
 declare global {
   class BaseSheet<Options extends BaseSheet.Options = BaseSheet.Options> extends DocumentSheet<

--- a/src/foundry/client/apps/forms/card-config.d.mts
+++ b/src/foundry/client/apps/forms/card-config.d.mts
@@ -1,4 +1,4 @@
-import type { GetDataReturnType, MaybePromise } from "../../../../utils/index.d.mts";
+import type { GetDataReturnType, MaybePromise } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/apps/forms/cards-config.d.mts
+++ b/src/foundry/client/apps/forms/cards-config.d.mts
@@ -1,4 +1,4 @@
-import type { GetDataReturnType, MaybePromise } from "../../../../utils/index.d.mts";
+import type { GetDataReturnType, MaybePromise } from "fvtt-types/utils";
 import type Document from "../../../common/abstract/document.d.mts";
 
 declare global {

--- a/src/foundry/client/apps/forms/combat-config.d.mts
+++ b/src/foundry/client/apps/forms/combat-config.d.mts
@@ -1,4 +1,4 @@
-import type { GetDataReturnType, MaybePromise } from "../../../../utils/index.d.mts";
+import type { GetDataReturnType, MaybePromise } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/apps/forms/effect-config.d.mts
+++ b/src/foundry/client/apps/forms/effect-config.d.mts
@@ -1,4 +1,4 @@
-import type { GetDataReturnType, MaybePromise, SimpleMerge, ValueOf } from "../../../../utils/index.d.mts";
+import type { GetDataReturnType, MaybePromise, SimpleMerge, ValueOf } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/apps/forms/folder-config.d.mts
+++ b/src/foundry/client/apps/forms/folder-config.d.mts
@@ -1,4 +1,4 @@
-import type { GetDataReturnType, MaybePromise, ValueOf } from "../../../../utils/index.d.mts";
+import type { GetDataReturnType, MaybePromise, ValueOf } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/apps/forms/fonts.d.mts
+++ b/src/foundry/client/apps/forms/fonts.d.mts
@@ -1,4 +1,4 @@
-import type { GetDataReturnType, MaybePromise } from "../../../../utils/index.d.mts";
+import type { GetDataReturnType, MaybePromise } from "fvtt-types/utils";
 
 declare global {
   class FontConfig<Options extends FontConfig.Options = FontConfig.Options> extends FormApplication<

--- a/src/foundry/client/apps/forms/grid-config.d.mts
+++ b/src/foundry/client/apps/forms/grid-config.d.mts
@@ -1,4 +1,4 @@
-import type { InterfaceToObject, AnyObject, GetDataReturnType, MaybePromise } from "../../../../utils/index.d.mts";
+import type { InterfaceToObject, AnyObject, GetDataReturnType, MaybePromise } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/apps/forms/image-popout.d.mts
+++ b/src/foundry/client/apps/forms/image-popout.d.mts
@@ -1,4 +1,4 @@
-import type { MaybePromise } from "../../../../utils/index.d.mts";
+import type { MaybePromise } from "fvtt-types/utils";
 
 declare global {
   interface ImagePopoutOptions extends FormApplicationOptions {

--- a/src/foundry/client/apps/forms/item.d.mts
+++ b/src/foundry/client/apps/forms/item.d.mts
@@ -1,4 +1,4 @@
-import type { GetDataReturnType, MaybePromise } from "../../../../utils/index.d.mts";
+import type { GetDataReturnType, MaybePromise } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/apps/forms/journal-page-sheet.d.mts
+++ b/src/foundry/client/apps/forms/journal-page-sheet.d.mts
@@ -1,6 +1,6 @@
 import type { Editor } from "tinymce";
 import type { EditorView } from "prosemirror-view";
-import type { GetDataReturnType, InexactPartial, MaybePromise } from "../../../../utils/index.d.mts";
+import type { GetDataReturnType, InexactPartial, MaybePromise } from "fvtt-types/utils";
 import type Showdown from "showdown";
 
 declare global {

--- a/src/foundry/client/apps/forms/journal-sheet.d.mts
+++ b/src/foundry/client/apps/forms/journal-sheet.d.mts
@@ -1,4 +1,4 @@
-import type { MaybePromise, InexactPartial } from "../../../../utils/index.d.mts";
+import type { MaybePromise, InexactPartial } from "fvtt-types/utils";
 
 declare global {
   interface JournalSheetOptions extends DocumentSheetOptions<JournalEntry.ConfiguredInstance> {

--- a/src/foundry/client/apps/forms/macro-config.d.mts
+++ b/src/foundry/client/apps/forms/macro-config.d.mts
@@ -1,4 +1,4 @@
-import type { GetDataReturnType, MaybePromise, ValueOf } from "../../../../utils/index.d.mts";
+import type { GetDataReturnType, MaybePromise, ValueOf } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/apps/forms/measure-template.d.mts
+++ b/src/foundry/client/apps/forms/measure-template.d.mts
@@ -1,4 +1,4 @@
-import type { GetDataReturnType, MaybePromise, ValueOf } from "../../../../utils/index.d.mts";
+import type { GetDataReturnType, MaybePromise, ValueOf } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/apps/forms/ownership.d.mts
+++ b/src/foundry/client/apps/forms/ownership.d.mts
@@ -1,4 +1,4 @@
-import type { GetDataReturnType, MaybePromise } from "../../../../utils/index.d.mts";
+import type { GetDataReturnType, MaybePromise } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/apps/forms/playlist-config.d.mts
+++ b/src/foundry/client/apps/forms/playlist-config.d.mts
@@ -1,4 +1,4 @@
-import type { GetDataReturnType, MaybePromise, ValueOf } from "../../../../utils/index.d.mts";
+import type { GetDataReturnType, MaybePromise, ValueOf } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/apps/forms/playlist-sound-config.d.mts
+++ b/src/foundry/client/apps/forms/playlist-sound-config.d.mts
@@ -1,4 +1,4 @@
-import type { GetDataReturnType, MaybePromise } from "../../../../utils/index.d.mts";
+import type { GetDataReturnType, MaybePromise } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/apps/forms/roll-table-config.d.mts
+++ b/src/foundry/client/apps/forms/roll-table-config.d.mts
@@ -1,4 +1,4 @@
-import type { MaybePromise } from "../../../../utils/index.d.mts";
+import type { MaybePromise } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/apps/forms/scene-config.d.mts
+++ b/src/foundry/client/apps/forms/scene-config.d.mts
@@ -1,4 +1,4 @@
-import type { MaybePromise } from "../../../../utils/index.d.mts";
+import type { MaybePromise } from "fvtt-types/utils";
 import type Document from "../../../common/abstract/document.d.mts";
 
 declare global {

--- a/src/foundry/client/apps/forms/sheet-config.d.mts
+++ b/src/foundry/client/apps/forms/sheet-config.d.mts
@@ -1,4 +1,4 @@
-import type { GetDataReturnType, MaybePromise } from "../../../../utils/index.d.mts";
+import type { GetDataReturnType, MaybePromise } from "fvtt-types/utils";
 import type DocumentSheetV2 from "../../../client-esm/applications/api/document-sheet.d.mts";
 import type { Document } from "../../../common/abstract/module.d.mts";
 

--- a/src/foundry/client/apps/forms/user-config.d.mts
+++ b/src/foundry/client/apps/forms/user-config.d.mts
@@ -1,4 +1,4 @@
-import type { GetDataReturnType, MaybePromise } from "../../../../utils/index.d.mts";
+import type { GetDataReturnType, MaybePromise } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/apps/hud/container.d.mts
+++ b/src/foundry/client/apps/hud/container.d.mts
@@ -1,4 +1,4 @@
-import type { MaybePromise } from "../../../../utils/index.d.mts";
+import type { MaybePromise } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/apps/hud/hotbar.d.mts
+++ b/src/foundry/client/apps/hud/hotbar.d.mts
@@ -1,4 +1,4 @@
-import type { GetDataReturnType, MaybePromise } from "../../../../utils/index.d.mts";
+import type { GetDataReturnType, MaybePromise } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/apps/hud/hud.d.mts
+++ b/src/foundry/client/apps/hud/hud.d.mts
@@ -1,4 +1,4 @@
-import type { MaybePromise } from "../../../../utils/index.d.mts";
+import type { MaybePromise } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/apps/hud/menu.d.mts
+++ b/src/foundry/client/apps/hud/menu.d.mts
@@ -1,4 +1,4 @@
-import type { MaybePromise } from "../../../../utils/index.d.mts";
+import type { MaybePromise } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/apps/hud/navigation.d.mts
+++ b/src/foundry/client/apps/hud/navigation.d.mts
@@ -1,4 +1,4 @@
-import type { GetDataReturnType, MaybePromise } from "../../../../utils/index.d.mts";
+import type { GetDataReturnType, MaybePromise } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/apps/hud/pause.d.mts
+++ b/src/foundry/client/apps/hud/pause.d.mts
@@ -1,4 +1,4 @@
-import type { GetDataReturnType, MaybePromise } from "../../../../utils/index.d.mts";
+import type { GetDataReturnType, MaybePromise } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/apps/hud/players.d.mts
+++ b/src/foundry/client/apps/hud/players.d.mts
@@ -1,4 +1,4 @@
-import type { GetDataReturnType, MaybePromise } from "../../../../utils/index.d.mts";
+import type { GetDataReturnType, MaybePromise } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/apps/i18n.d.mts
+++ b/src/foundry/client/apps/i18n.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial } from "../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/apps/placeables/drawing-config.d.mts
+++ b/src/foundry/client/apps/placeables/drawing-config.d.mts
@@ -1,4 +1,4 @@
-import type { MaybePromise } from "../../../../utils/index.d.mts";
+import type { MaybePromise } from "fvtt-types/utils";
 
 declare global {
   interface DrawingConfigOptions extends FormApplicationOptions {

--- a/src/foundry/client/apps/placeables/drawing-hud.d.mts
+++ b/src/foundry/client/apps/placeables/drawing-hud.d.mts
@@ -1,4 +1,4 @@
-import type { MaybePromise } from "../../../../utils/index.d.mts";
+import type { MaybePromise } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/apps/placeables/light-config.d.mts
+++ b/src/foundry/client/apps/placeables/light-config.d.mts
@@ -1,4 +1,4 @@
-import type { InterfaceToObject, AnyObject, DeepPartial, MaybePromise } from "../../../../utils/index.d.mts";
+import type { InterfaceToObject, AnyObject, DeepPartial, MaybePromise } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/apps/placeables/note-config.d.mts
+++ b/src/foundry/client/apps/placeables/note-config.d.mts
@@ -1,4 +1,4 @@
-import type { MaybePromise } from "../../../../utils/index.d.mts";
+import type { MaybePromise } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/apps/placeables/sound-config.d.mts
+++ b/src/foundry/client/apps/placeables/sound-config.d.mts
@@ -1,4 +1,4 @@
-import type { MaybePromise } from "../../../../utils/index.d.mts";
+import type { MaybePromise } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/apps/placeables/tile-config.d.mts
+++ b/src/foundry/client/apps/placeables/tile-config.d.mts
@@ -1,4 +1,4 @@
-import type { MaybePromise } from "../../../../utils/index.d.mts";
+import type { MaybePromise } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/apps/placeables/tile-hud.d.mts
+++ b/src/foundry/client/apps/placeables/tile-hud.d.mts
@@ -1,4 +1,4 @@
-import type { MaybePromise } from "../../../../utils/index.d.mts";
+import type { MaybePromise } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/apps/placeables/token-config.d.mts
+++ b/src/foundry/client/apps/placeables/token-config.d.mts
@@ -1,4 +1,4 @@
-import type { InterfaceToObject, AnyObject } from "../../../../utils/index.d.mts";
+import type { InterfaceToObject, AnyObject } from "fvtt-types/utils";
 import type StringTerm from "../../../client-esm/dice/terms/string.d.mts";
 
 declare global {

--- a/src/foundry/client/apps/placeables/token-hud.d.mts
+++ b/src/foundry/client/apps/placeables/token-hud.d.mts
@@ -1,4 +1,4 @@
-import type { MaybePromise } from "../../../../utils/index.d.mts";
+import type { MaybePromise } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/apps/placeables/wall-config.d.mts
+++ b/src/foundry/client/apps/placeables/wall-config.d.mts
@@ -1,4 +1,4 @@
-import type { MaybePromise } from "../../../../utils/index.d.mts";
+import type { MaybePromise } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/apps/sidebar/apps/keybindings-config.d.mts
+++ b/src/foundry/client/apps/sidebar/apps/keybindings-config.d.mts
@@ -1,4 +1,4 @@
-import type { MaybePromise } from "../../../../../utils/index.d.mts";
+import type { MaybePromise } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/apps/sidebar/apps/module-management.d.mts
+++ b/src/foundry/client/apps/sidebar/apps/module-management.d.mts
@@ -1,4 +1,4 @@
-import type { MaybePromise } from "../../../../../utils/index.d.mts";
+import type { MaybePromise } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/apps/sidebar/apps/support-details.d.mts
+++ b/src/foundry/client/apps/sidebar/apps/support-details.d.mts
@@ -1,4 +1,4 @@
-import type { MaybePromise } from "../../../../../utils/index.d.mts";
+import type { MaybePromise } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/apps/sidebar/apps/tours-management.d.mts
+++ b/src/foundry/client/apps/sidebar/apps/tours-management.d.mts
@@ -1,4 +1,4 @@
-import type { MaybePromise } from "../../../../../utils/index.d.mts";
+import type { MaybePromise } from "fvtt-types/utils";
 
 declare global {
   /** A management app for configuring which Tours are available or have been completed. */

--- a/src/foundry/client/apps/sidebar/apps/world-config.d.mts
+++ b/src/foundry/client/apps/sidebar/apps/world-config.d.mts
@@ -1,4 +1,4 @@
-import type { MaybePromise } from "../../../../../utils/index.d.mts";
+import type { MaybePromise } from "fvtt-types/utils";
 
 declare global {
   interface WorldConfigOptions extends FormApplicationOptions {

--- a/src/foundry/client/apps/sidebar/directory-tab-mixin.d.mts
+++ b/src/foundry/client/apps/sidebar/directory-tab-mixin.d.mts
@@ -1,4 +1,4 @@
-import type { Mixin } from "../../../../utils/index.d.mts";
+import type { Mixin } from "fvtt-types/utils";
 
 declare class DirectoryApplication {
   /** @privateRemarks All mixin classses should accept anything for its constructor. */

--- a/src/foundry/client/apps/sidebar/package-configuration.d.mts
+++ b/src/foundry/client/apps/sidebar/package-configuration.d.mts
@@ -1,4 +1,4 @@
-import type { MaybePromise } from "../../../../utils/index.d.mts";
+import type { MaybePromise } from "fvtt-types/utils";
 
 declare global {
   /** An application for configuring data across all installed and active packages. */

--- a/src/foundry/client/apps/sidebar/sidebar.d.mts
+++ b/src/foundry/client/apps/sidebar/sidebar.d.mts
@@ -1,4 +1,4 @@
-import type { MaybePromise } from "../../../../utils/index.d.mts";
+import type { MaybePromise } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/av/client.d.mts
+++ b/src/foundry/client/av/client.d.mts
@@ -1,4 +1,4 @@
-import type { DeepPartial } from "../../../utils/index.d.mts";
+import type { DeepPartial } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/av/clients/simplepeer.d.mts
+++ b/src/foundry/client/av/clients/simplepeer.d.mts
@@ -1,4 +1,4 @@
-import type { DeepPartial } from "../../../../utils/index.d.mts";
+import type { DeepPartial } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/av/master.d.mts
+++ b/src/foundry/client/av/master.d.mts
@@ -1,4 +1,4 @@
-import type { DeepPartial, FixedInstanceType } from "../../../utils/index.d.mts";
+import type { DeepPartial, FixedInstanceType } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/av/settings.d.mts
+++ b/src/foundry/client/av/settings.d.mts
@@ -1,4 +1,4 @@
-import type { GetKey, ValueOf } from "../../../utils/index.d.mts";
+import type { GetKey, ValueOf } from "fvtt-types/utils";
 
 declare global {
   interface AVSettingsData {

--- a/src/foundry/client/config.d.mts
+++ b/src/foundry/client/config.d.mts
@@ -1,6 +1,6 @@
 import type * as CONST from "../common/constants.d.mts";
 import type { DataModel, Document } from "../common/abstract/module.d.mts";
-import type { GetKey, AnyObject, HandleEmptyObject, MaybePromise } from "../../utils/index.d.mts";
+import type { GetKey, AnyObject, HandleEmptyObject, MaybePromise } from "fvtt-types/utils";
 import type BaseLightSource from "../client-esm/canvas/sources/base-light-source.d.mts";
 
 declare global {

--- a/src/foundry/client/core/hooks.d.mts
+++ b/src/foundry/client/core/hooks.d.mts
@@ -1,4 +1,4 @@
-import type { AnyFunction } from "../../../utils/index.d.mts";
+import type { AnyFunction } from "fvtt-types/utils";
 
 export {};
 

--- a/src/foundry/client/core/image.d.mts
+++ b/src/foundry/client/core/image.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial, NullishProps } from "../../../utils/index.d.mts";
+import type { InexactPartial, NullishProps } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/core/keybindings.d.mts
+++ b/src/foundry/client/core/keybindings.d.mts
@@ -1,4 +1,4 @@
-import type { ValueOf } from "../../../utils/index.d.mts";
+import type { ValueOf } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/core/packages.d.mts
+++ b/src/foundry/client/core/packages.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial, Mixin } from "../../../utils/index.d.mts";
+import type { InexactPartial, Mixin } from "fvtt-types/utils";
 import type { CONST } from "../../client-esm/client.d.mts";
 import type BasePackage from "../../common/packages/base-package.d.mts";
 

--- a/src/foundry/client/core/settings.d.mts
+++ b/src/foundry/client/core/settings.d.mts
@@ -1,4 +1,4 @@
-import type { AnyArray, AnyObject, InexactPartial, FixedInstanceType } from "../../../utils/index.d.mts";
+import type { AnyArray, AnyObject, InexactPartial, FixedInstanceType } from "fvtt-types/utils";
 import type ApplicationV2 from "../../client-esm/applications/api/application.d.mts";
 import type { CustomFormInput } from "../../client-esm/applications/forms/fields.d.mts";
 import type DataModel from "../../common/abstract/data.d.mts";

--- a/src/foundry/client/core/socket.d.mts
+++ b/src/foundry/client/core/socket.d.mts
@@ -1,4 +1,4 @@
-import type { AnyObject } from "../../../utils/index.d.mts";
+import type { AnyObject } from "fvtt-types/utils";
 import type { DatabaseOperationMap, DocumentSocketRequest } from "../../common/abstract/_types.d.mts";
 
 declare global {

--- a/src/foundry/client/core/sorting.d.mts
+++ b/src/foundry/client/core/sorting.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial } from "../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/core/tooltip.d.mts
+++ b/src/foundry/client/core/tooltip.d.mts
@@ -1,4 +1,4 @@
-import type { ValueOf } from "../../../utils/index.d.mts";
+import type { ValueOf } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/core/tour.d.mts
+++ b/src/foundry/client/core/tour.d.mts
@@ -1,4 +1,4 @@
-import type { ValueOf } from "../../../utils/index.d.mts";
+import type { ValueOf } from "fvtt-types/utils";
 
 export { Tour };
 

--- a/src/foundry/client/core/utils.d.mts
+++ b/src/foundry/client/core/utils.d.mts
@@ -1,4 +1,4 @@
-import type { AnyObject, MustBeValidUuid } from "../../../utils/index.d.mts";
+import type { AnyObject, MustBeValidUuid } from "fvtt-types/utils";
 import type Document from "../../common/abstract/document.d.mts";
 
 declare const __Unset: unique symbol;

--- a/src/foundry/client/core/workers.d.mts
+++ b/src/foundry/client/core/workers.d.mts
@@ -1,4 +1,4 @@
-import type { ValueOf } from "../../../utils/index.d.mts";
+import type { ValueOf } from "fvtt-types/utils";
 
 // TODO: smarter types for named functions
 declare global {

--- a/src/foundry/client/data/abstract/canvas-document.d.mts
+++ b/src/foundry/client/data/abstract/canvas-document.d.mts
@@ -1,4 +1,4 @@
-import type { FixedInstanceType, Mixin } from "../../../../utils/index.d.mts";
+import type { FixedInstanceType, Mixin } from "fvtt-types/utils";
 import type Document from "../../../common/abstract/document.d.mts";
 import type { InternalClientDocument } from "./client-document.d.mts";
 

--- a/src/foundry/client/data/abstract/client-document.d.mts
+++ b/src/foundry/client/data/abstract/client-document.d.mts
@@ -1,4 +1,4 @@
-import type { DeepPartial, InexactPartial, Mixin, FixedInstanceType } from "../../../../utils/index.d.mts";
+import type { DeepPartial, InexactPartial, Mixin, FixedInstanceType } from "fvtt-types/utils";
 import type { DatabaseCreateOperation } from "../../../common/abstract/_types.d.mts";
 import type DataModel from "../../../common/abstract/data.d.mts";
 import type Document from "../../../common/abstract/document.d.mts";

--- a/src/foundry/client/data/abstract/directory-collection-mixin.d.mts
+++ b/src/foundry/client/data/abstract/directory-collection-mixin.d.mts
@@ -1,4 +1,4 @@
-import type { Mixin } from "../../../../utils/index.d.mts";
+import type { Mixin } from "fvtt-types/utils";
 import type Document from "../../../common/abstract/document.d.mts";
 
 type DirectoryCollectionMixin_DocumentCollection_Static = DirectoryCollection<DirectoryCollection.DirectoryTypes> &

--- a/src/foundry/client/data/abstract/document-collection.d.mts
+++ b/src/foundry/client/data/abstract/document-collection.d.mts
@@ -1,4 +1,4 @@
-import type { AnyObject, DeepPartial, InexactPartial, FixedInstanceType } from "../../../../utils/index.d.mts";
+import type { AnyObject, DeepPartial, InexactPartial, FixedInstanceType } from "fvtt-types/utils";
 import type { DatabaseAction, DatabaseOperationMap } from "../../../common/abstract/_types.d.mts";
 import type Document from "../../../common/abstract/document.d.mts";
 

--- a/src/foundry/client/data/abstract/world-collection.d.mts
+++ b/src/foundry/client/data/abstract/world-collection.d.mts
@@ -1,4 +1,4 @@
-import type { DeepPartial, DropFirst, InexactPartial } from "../../../../utils/index.d.mts";
+import type { DeepPartial, DropFirst, InexactPartial } from "fvtt-types/utils";
 import type Document from "../../../common/abstract/document.d.mts";
 import type { DirectoryCollectionMixin_DocumentCollection_Interface } from "./directory-collection-mixin.d.mts";
 

--- a/src/foundry/client/data/collections/actors.d.mts
+++ b/src/foundry/client/data/collections/actors.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial } from "../../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/data/collections/compendium-collection.d.mts
+++ b/src/foundry/client/data/collections/compendium-collection.d.mts
@@ -1,4 +1,4 @@
-import type { DeepPartial, EmptyObject, InexactPartial } from "../../../../utils/index.d.mts";
+import type { DeepPartial, EmptyObject, InexactPartial } from "fvtt-types/utils";
 import type Document from "../../../common/abstract/document.d.mts";
 import type { DirectoryCollectionMixin_DocumentCollection_Interface } from "../abstract/directory-collection-mixin.d.mts";
 

--- a/src/foundry/client/data/collections/journal.d.mts
+++ b/src/foundry/client/data/collections/journal.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial } from "../../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/data/collections/macros.d.mts
+++ b/src/foundry/client/data/collections/macros.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial } from "../../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/data/collections/playlists.d.mts
+++ b/src/foundry/client/data/collections/playlists.d.mts
@@ -1,4 +1,4 @@
-import type { DeepPartial } from "../../../../utils/index.d.mts";
+import type { DeepPartial } from "fvtt-types/utils";
 import type Document from "../../../common/abstract/document.d.mts";
 
 declare global {

--- a/src/foundry/client/data/collections/scenes.d.mts
+++ b/src/foundry/client/data/collections/scenes.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial } from "../../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 import type Document from "../../../common/abstract/document.d.mts";
 
 declare global {

--- a/src/foundry/client/data/collections/users.d.mts
+++ b/src/foundry/client/data/collections/users.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial } from "../../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 import type Document from "../../../common/abstract/document.d.mts";
 
 declare global {

--- a/src/foundry/client/data/documents/active-effect.d.mts
+++ b/src/foundry/client/data/documents/active-effect.d.mts
@@ -1,4 +1,4 @@
-import type { AnyObject } from "../../../../utils/index.d.mts";
+import type { AnyObject } from "fvtt-types/utils";
 import type { DataModel } from "../../../common/abstract/data.d.mts";
 import type Document from "../../../common/abstract/document.d.mts";
 import type { DataField } from "../../../common/data/fields.d.mts";

--- a/src/foundry/client/data/documents/actor.d.mts
+++ b/src/foundry/client/data/documents/actor.d.mts
@@ -1,4 +1,4 @@
-import type { DeepPartial, InexactPartial } from "../../../../utils/index.d.mts";
+import type { DeepPartial, InexactPartial } from "fvtt-types/utils";
 import type Document from "../../../common/abstract/document.d.mts";
 import type BaseActor from "../../../common/documents/actor.d.mts";
 

--- a/src/foundry/client/data/documents/adventure.d.mts
+++ b/src/foundry/client/data/documents/adventure.d.mts
@@ -1,4 +1,4 @@
-import type { FolderDocumentTypes, InexactPartial, FixedInstanceType } from "../../../../utils/index.d.mts";
+import type { FolderDocumentTypes, InexactPartial, FixedInstanceType } from "fvtt-types/utils";
 // eslint-disable-next-line import/no-named-as-default
 import type DataModel from "../../../common/abstract/data.d.mts";
 import type { fields } from "../../../common/data/module.d.mts";

--- a/src/foundry/client/data/documents/card.d.mts
+++ b/src/foundry/client/data/documents/card.d.mts
@@ -1,4 +1,4 @@
-import type { DeepPartial, InexactPartial } from "../../../../utils/index.d.mts";
+import type { DeepPartial, InexactPartial } from "fvtt-types/utils";
 import type Document from "../../../common/abstract/document.d.mts";
 import type { CardFaceData } from "../../../common/documents/_types.d.mts";
 import type BaseCard from "../../../common/documents/card.d.mts";

--- a/src/foundry/client/data/documents/cards.d.mts
+++ b/src/foundry/client/data/documents/cards.d.mts
@@ -1,4 +1,4 @@
-import type { DeepPartial, InexactPartial, FixedInstanceType } from "../../../../utils/index.d.mts";
+import type { DeepPartial, InexactPartial, FixedInstanceType } from "fvtt-types/utils";
 import type { fields } from "../../../common/data/module.d.mts";
 import type Document from "../../../common/abstract/document.d.mts";
 import type BaseCards from "../../../common/documents/cards.d.mts";

--- a/src/foundry/client/data/documents/chat-message.d.mts
+++ b/src/foundry/client/data/documents/chat-message.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial } from "../../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 import type Document from "../../../common/abstract/document.d.mts";
 import type BaseChatMessage from "../../../common/documents/chat-message.d.mts";
 

--- a/src/foundry/client/data/documents/combat.d.mts
+++ b/src/foundry/client/data/documents/combat.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial } from "../../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 import type Document from "../../../common/abstract/document.d.mts";
 import type BaseCombat from "../../../common/documents/combat.d.mts";
 

--- a/src/foundry/client/data/documents/combatant.d.mts
+++ b/src/foundry/client/data/documents/combatant.d.mts
@@ -1,4 +1,4 @@
-import type { ValueOf } from "../../../../utils/index.d.mts";
+import type { ValueOf } from "fvtt-types/utils";
 import type Document from "../../../common/abstract/document.d.mts";
 import type BaseCombatant from "../../../common/documents/combatant.d.mts";
 

--- a/src/foundry/client/data/documents/fog-exploration.d.mts
+++ b/src/foundry/client/data/documents/fog-exploration.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial } from "../../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 import type { DatabaseGetOperation } from "../../../common/abstract/_types.d.mts";
 import type Document from "../../../common/abstract/document.d.mts";
 import type BaseFogExploration from "../../../common/documents/fog-exploration.d.mts";

--- a/src/foundry/client/data/documents/folder.d.mts
+++ b/src/foundry/client/data/documents/folder.d.mts
@@ -1,4 +1,4 @@
-import type { DeepPartial, InexactPartial } from "../../../../utils/index.d.mts";
+import type { DeepPartial, InexactPartial } from "fvtt-types/utils";
 import type Document from "../../../common/abstract/document.d.mts";
 import type BaseFolder from "../../../common/documents/folder.d.mts";
 

--- a/src/foundry/client/data/documents/journal-entry-page.d.mts
+++ b/src/foundry/client/data/documents/journal-entry-page.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial } from "../../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 import type Document from "../../../common/abstract/document.d.mts";
 import type BaseJournalEntryPage from "../../../common/documents/journal-entry-page.d.mts";
 

--- a/src/foundry/client/data/documents/macro.d.mts
+++ b/src/foundry/client/data/documents/macro.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial } from "../../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 import type Document from "../../../common/abstract/document.d.mts";
 import type BaseMacro from "../../../common/documents/macro.d.mts";
 

--- a/src/foundry/client/data/documents/playlist-sound.d.mts
+++ b/src/foundry/client/data/documents/playlist-sound.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial } from "../../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 import type Sound from "../../../client-esm/audio/sound.d.mts";
 import type Document from "../../../common/abstract/document.d.mts";
 import type BasePlaylistSound from "../../../common/documents/playlist-sound.d.mts";

--- a/src/foundry/client/data/documents/playlist.d.mts
+++ b/src/foundry/client/data/documents/playlist.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial } from "../../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 import type { Document } from "../../../common/abstract/module.d.mts";
 import type BasePlaylist from "../../../common/documents/playlist.d.mts";
 

--- a/src/foundry/client/data/documents/region-behavior.d.mts
+++ b/src/foundry/client/data/documents/region-behavior.d.mts
@@ -1,4 +1,4 @@
-import type { DeepPartial, FixedInstanceType, InexactPartial } from "../../../../utils/index.d.mts";
+import type { DeepPartial, FixedInstanceType, InexactPartial } from "fvtt-types/utils";
 import type { DatabaseCreateOperation } from "../../../common/abstract/_types.d.mts";
 import type Document from "../../../common/abstract/document.d.mts";
 import type { DocumentDatabaseOperations } from "../../../common/abstract/document.d.mts";

--- a/src/foundry/client/data/documents/region.d.mts
+++ b/src/foundry/client/data/documents/region.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial } from "../../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 import type { DocumentDatabaseOperations } from "../../../common/abstract/document.d.mts";
 import type BaseRegion from "../../../common/documents/region.d.mts";
 import type Document from "../../../common/abstract/document.d.mts";

--- a/src/foundry/client/data/documents/scene.d.mts
+++ b/src/foundry/client/data/documents/scene.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial } from "../../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 import type Document from "../../../common/abstract/document.d.mts";
 import type BaseScene from "../../../common/documents/scene.d.mts";
 

--- a/src/foundry/client/data/documents/table.d.mts
+++ b/src/foundry/client/data/documents/table.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial } from "../../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 import type Document from "../../../common/abstract/document.d.mts";
 import type BaseRollTable from "../../../common/documents/roll-table.d.mts";
 

--- a/src/foundry/client/data/documents/token.d.mts
+++ b/src/foundry/client/data/documents/token.d.mts
@@ -1,4 +1,4 @@
-import type { DeepPartial, InexactPartial } from "../../../../utils/index.d.mts";
+import type { DeepPartial, InexactPartial } from "fvtt-types/utils";
 import type Document from "../../../common/abstract/document.d.mts";
 import type { SchemaField } from "../../../common/data/fields.d.mts";
 import type BaseToken from "../../../common/documents/token.d.mts";

--- a/src/foundry/client/data/documents/user.d.mts
+++ b/src/foundry/client/data/documents/user.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial } from "../../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 import type Document from "../../../common/abstract/document.d.mts";
 import type BaseUser from "../../../common/documents/user.d.mts";
 

--- a/src/foundry/client/game.d.mts
+++ b/src/foundry/client/game.d.mts
@@ -1,5 +1,5 @@
 import type { Socket } from "socket.io-client";
-import type { ConfiguredModule, GetKey, EmptyObject, ValueOf, FixedInstanceType } from "../../utils/index.d.mts";
+import type { ConfiguredModule, GetKey, EmptyObject, ValueOf, FixedInstanceType } from "fvtt-types/utils";
 import type BasePackage from "../common/packages/base-package.d.mts";
 import type { Document } from "../common/abstract/module.d.mts";
 

--- a/src/foundry/client/head.d.mts
+++ b/src/foundry/client/head.d.mts
@@ -1,4 +1,4 @@
-import type { FixedInstanceType } from "../../utils/index.d.mts";
+import type { FixedInstanceType } from "fvtt-types/utils";
 import type { EarlierEvents, InitializationEvent } from "./game.d.mts";
 
 type ValidRanHooks = Extract<keyof AssumeHookRan, InitializationEvent>;

--- a/src/foundry/client/hooks.d.mts
+++ b/src/foundry/client/hooks.d.mts
@@ -1,5 +1,5 @@
 import type { EditorState, Plugin } from "prosemirror-state";
-import type { DeepPartial, EmptyObject, FixedInstanceType, ValueOf } from "../../utils/index.d.mts";
+import type { DeepPartial, EmptyObject, FixedInstanceType, ValueOf } from "fvtt-types/utils";
 import type Document from "../common/abstract/document.d.mts";
 import type { EffectChangeData } from "../common/documents/_types.d.mts";
 import type { ProseMirrorDropDown } from "../common/prosemirror/menu.d.mts";

--- a/src/foundry/client/pixi/board.d.mts
+++ b/src/foundry/client/pixi/board.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial, NullishProps, FixedInstanceType } from "../../../utils/index.d.mts";
+import type { InexactPartial, NullishProps, FixedInstanceType } from "fvtt-types/utils";
 import type Document from "../../common/abstract/document.d.mts";
 import type { CANVAS_PERFORMANCE_MODES } from "../../common/constants.d.mts";
 

--- a/src/foundry/client/pixi/core/containers/base-canvas-group.d.mts
+++ b/src/foundry/client/pixi/core/containers/base-canvas-group.d.mts
@@ -1,4 +1,4 @@
-import type { AnyObject, Mixin, PrettifyType, RemoveIndexSignatures } from "../../../../../utils/index.d.mts";
+import type { AnyObject, Mixin, PrettifyType, RemoveIndexSignatures } from "fvtt-types/utils";
 
 declare const DynamicClass: new <_Computed extends object>(arg0: never, ...args: never[]) => _Computed;
 

--- a/src/foundry/client/pixi/core/containers/cached-container.d.mts
+++ b/src/foundry/client/pixi/core/containers/cached-container.d.mts
@@ -1,4 +1,4 @@
-import type { NullishProps } from "../../../../../utils/index.d.mts";
+import type { NullishProps } from "fvtt-types/utils";
 
 export {};
 

--- a/src/foundry/client/pixi/core/containers/full-canvas-container.d.mts
+++ b/src/foundry/client/pixi/core/containers/full-canvas-container.d.mts
@@ -1,4 +1,4 @@
-import type { Mixin } from "../../../../../utils/index.d.mts";
+import type { Mixin } from "fvtt-types/utils";
 
 declare class FullCanvasObject {
   /** @privateRemarks All mixin classses should accept anything for its constructor. */

--- a/src/foundry/client/pixi/core/interaction/canvas-animation.d.mts
+++ b/src/foundry/client/pixi/core/interaction/canvas-animation.d.mts
@@ -1,4 +1,4 @@
-import type { PropertiesOfType, Brand, NullishProps, AnyObject } from "../../../../../utils/index.d.mts";
+import type { PropertiesOfType, Brand, NullishProps, AnyObject } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/pixi/core/interaction/control-icon.d.mts
+++ b/src/foundry/client/pixi/core/interaction/control-icon.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial } from "../../../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/pixi/core/interaction/mouse-handler.d.mts
+++ b/src/foundry/client/pixi/core/interaction/mouse-handler.d.mts
@@ -1,4 +1,4 @@
-import type { Brand, NullishProps } from "../../../../../utils/index.d.mts";
+import type { Brand, NullishProps } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/pixi/core/interaction/ping.d.mts
+++ b/src/foundry/client/pixi/core/interaction/ping.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial } from "../../../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/pixi/core/interaction/pings/pulse.d.mts
+++ b/src/foundry/client/pixi/core/interaction/pings/pulse.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial, NullishProps } from "../../../../../../utils/index.d.mts";
+import type { InexactPartial, NullishProps } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/pixi/core/interaction/render-flags.d.mts
+++ b/src/foundry/client/pixi/core/interaction/render-flags.d.mts
@@ -1,4 +1,4 @@
-import type { AnyConstructor, InexactPartial, Mixin } from "../../../../../utils/index.d.mts";
+import type { AnyConstructor, InexactPartial, Mixin } from "fvtt-types/utils";
 import type { LogCompatibilityWarningOptions } from "../../../../common/utils/logging.d.mts";
 
 declare class RenderFlagObject {

--- a/src/foundry/client/pixi/core/interaction/resize-handle.d.mts
+++ b/src/foundry/client/pixi/core/interaction/resize-handle.d.mts
@@ -1,4 +1,4 @@
-import type { NullishProps } from "../../../../../utils/index.d.mts";
+import type { NullishProps } from "fvtt-types/utils";
 
 declare global {
   class ResizeHandle extends PIXI.Graphics {

--- a/src/foundry/client/pixi/core/loader.d.mts
+++ b/src/foundry/client/pixi/core/loader.d.mts
@@ -1,4 +1,4 @@
-import type { AnyObject } from "../../../../utils/index.d.mts";
+import type { AnyObject } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/pixi/core/shapes/polygon-mesher.d.mts
+++ b/src/foundry/client/pixi/core/shapes/polygon-mesher.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial } from "../../../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/pixi/core/shapes/source-polygon.d.mts
+++ b/src/foundry/client/pixi/core/shapes/source-polygon.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial, FixedInstanceType } from "../../../../../utils/index.d.mts";
+import type { InexactPartial, FixedInstanceType } from "fvtt-types/utils";
 import type PointEffectSourceMixin from "../../../../client-esm/canvas/sources/point-effect-source.d.mts";
 
 declare global {

--- a/src/foundry/client/pixi/extensions/circle.d.mts
+++ b/src/foundry/client/pixi/extensions/circle.d.mts
@@ -1,4 +1,4 @@
-import type { NullishProps } from "../../../../utils/index.d.mts";
+import type { NullishProps } from "fvtt-types/utils";
 import type { LineCircleIntersection } from "../../../common/utils/geometry.d.mts";
 
 declare module "pixi.js" {

--- a/src/foundry/client/pixi/extensions/observable-transform.d.mts
+++ b/src/foundry/client/pixi/extensions/observable-transform.d.mts
@@ -1,4 +1,4 @@
-import type { AnyObject } from "../../../../utils/index.d.mts";
+import type { AnyObject } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/pixi/extensions/polygon.d.mts
+++ b/src/foundry/client/pixi/extensions/polygon.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial, NullishProps } from "../../../../utils/index.d.mts";
+import type { InexactPartial, NullishProps } from "fvtt-types/utils";
 
 declare module "pixi.js" {
   interface Polygon {

--- a/src/foundry/client/pixi/extensions/rectangle.d.mts
+++ b/src/foundry/client/pixi/extensions/rectangle.d.mts
@@ -1,4 +1,4 @@
-import type { UnionToIntersection, Brand, InexactPartial, NullishProps } from "../../../../utils/index.d.mts";
+import type { UnionToIntersection, Brand, InexactPartial, NullishProps } from "fvtt-types/utils";
 
 /**
  * Typically in a mapped type TypeScript associates your type to the original.

--- a/src/foundry/client/pixi/groups/effects.d.mts
+++ b/src/foundry/client/pixi/groups/effects.d.mts
@@ -1,4 +1,4 @@
-import type { ValueOf } from "../../../../utils/index.d.mts";
+import type { ValueOf } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/pixi/groups/environment.d.mts
+++ b/src/foundry/client/pixi/groups/environment.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial } from "../../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 
 // TODO: Remove when this is typed as part of #2674
 type SceneEnvironmentData = unknown;

--- a/src/foundry/client/pixi/groups/interface.d.mts
+++ b/src/foundry/client/pixi/groups/interface.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial } from "../../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/pixi/layers/base/interaction-layer.d.mts
+++ b/src/foundry/client/pixi/layers/base/interaction-layer.d.mts
@@ -1,4 +1,4 @@
-import type { NullishProps } from "../../../../../utils/index.d.mts";
+import type { NullishProps } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/pixi/layers/controls/ruler.d.mts
+++ b/src/foundry/client/pixi/layers/controls/ruler.d.mts
@@ -1,4 +1,4 @@
-import type { NullishProps, ValueOf } from "../../../../../utils/index.d.mts";
+import type { NullishProps, ValueOf } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/pixi/layers/effects/illumination-effects.d.mts
+++ b/src/foundry/client/pixi/layers/effects/illumination-effects.d.mts
@@ -1,4 +1,4 @@
-import type { NullishProps } from "../../../../../utils/index.d.mts";
+import type { NullishProps } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/pixi/layers/effects/visibility.d.mts
+++ b/src/foundry/client/pixi/layers/effects/visibility.d.mts
@@ -1,4 +1,4 @@
-import type { EmptyObject, InexactPartial, ValueOf } from "../../../../../utils/index.d.mts";
+import type { EmptyObject, InexactPartial, ValueOf } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/pixi/layers/effects/weather-effects.d.mts
+++ b/src/foundry/client/pixi/layers/effects/weather-effects.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial } from "../../../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/pixi/layers/grid/layer.d.mts
+++ b/src/foundry/client/pixi/layers/grid/layer.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial, NullishProps } from "../../../../../utils/index.d.mts";
+import type { InexactPartial, NullishProps } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/pixi/layers/grid/mesh.d.mts
+++ b/src/foundry/client/pixi/layers/grid/mesh.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial } from "../../../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/pixi/layers/masks/occlusion.d.mts
+++ b/src/foundry/client/pixi/layers/masks/occlusion.d.mts
@@ -1,4 +1,4 @@
-import type { FixedInstanceType } from "../../../../../utils/index.d.mts";
+import type { FixedInstanceType } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/pixi/layers/placeables/notes.d.mts
+++ b/src/foundry/client/pixi/layers/placeables/notes.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial } from "../../../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/pixi/layers/placeables/region.d.mts
+++ b/src/foundry/client/pixi/layers/placeables/region.d.mts
@@ -1,4 +1,4 @@
-import type { EmptyObject } from "../../../../../utils/index.d.mts";
+import type { EmptyObject } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/pixi/layers/placeables/sounds.d.mts
+++ b/src/foundry/client/pixi/layers/placeables/sounds.d.mts
@@ -1,4 +1,4 @@
-import type { IntentionalPartial, InexactPartial, NullishProps } from "../../../../../utils/index.d.mts";
+import type { IntentionalPartial, InexactPartial, NullishProps } from "fvtt-types/utils";
 import type { AmbientSoundEffect } from "../../../../common/documents/_types.d.mts";
 
 declare global {

--- a/src/foundry/client/pixi/layers/placeables/tokens.d.mts
+++ b/src/foundry/client/pixi/layers/placeables/tokens.d.mts
@@ -1,4 +1,4 @@
-import type { ArrayOverlaps, NullishProps } from "../../../../../utils/index.d.mts";
+import type { ArrayOverlaps, NullishProps } from "fvtt-types/utils";
 import type Document from "../../../../common/abstract/document.d.mts";
 
 declare global {

--- a/src/foundry/client/pixi/layers/placeables/walls.d.mts
+++ b/src/foundry/client/pixi/layers/placeables/walls.d.mts
@@ -1,4 +1,4 @@
-import type { NullishProps } from "../../../../../utils/index.d.mts";
+import type { NullishProps } from "fvtt-types/utils";
 import type Document from "../../../../common/abstract/document.d.mts";
 
 declare global {

--- a/src/foundry/client/pixi/perception/detection-mode.d.mts
+++ b/src/foundry/client/pixi/perception/detection-mode.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial, ValueOf } from "../../../../utils/index.d.mts";
+import type { InexactPartial, ValueOf } from "fvtt-types/utils";
 import type { fields } from "../../../common/data/module.d.mts";
 import type { TokenDetectionMode } from "../../../common/documents/_types.d.mts";
 

--- a/src/foundry/client/pixi/perception/vision-mode.d.mts
+++ b/src/foundry/client/pixi/perception/vision-mode.d.mts
@@ -1,4 +1,4 @@
-import type { AnyObject, InexactPartial, SimpleMerge, ValueOf } from "../../../../utils/index.d.mts";
+import type { AnyObject, InexactPartial, SimpleMerge, ValueOf } from "fvtt-types/utils";
 import type { fields } from "../../../common/data/module.d.mts";
 import DataField = foundry.data.fields.DataField;
 

--- a/src/foundry/client/pixi/perception/weiler-atherton-clipping.d.mts
+++ b/src/foundry/client/pixi/perception/weiler-atherton-clipping.d.mts
@@ -1,4 +1,4 @@
-import type { Brand, NullishProps } from "../../../../utils/index.d.mts";
+import type { Brand, NullishProps } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/pixi/placeable.d.mts
+++ b/src/foundry/client/pixi/placeable.d.mts
@@ -1,4 +1,4 @@
-import type { MakeConform, ValueOf } from "../../../utils/index.d.mts";
+import type { MakeConform, ValueOf } from "fvtt-types/utils";
 import type ApplicationV2 from "../../client-esm/applications/api/application.d.mts";
 import type { Document } from "../../common/abstract/module.d.mts";
 

--- a/src/foundry/client/pixi/placeables/drawing.d.mts
+++ b/src/foundry/client/pixi/placeables/drawing.d.mts
@@ -1,4 +1,4 @@
-import type { ValueOf, FixedInstanceType } from "../../../../utils/index.d.mts";
+import type { ValueOf, FixedInstanceType } from "fvtt-types/utils";
 import type { ConfiguredObjectClassOrDefault } from "../../config.d.mts";
 
 declare global {

--- a/src/foundry/client/pixi/placeables/light.d.mts
+++ b/src/foundry/client/pixi/placeables/light.d.mts
@@ -1,5 +1,5 @@
 import type { ConfiguredObjectClassOrDefault } from "../../config.d.mts";
-import type { FixedInstanceType } from "../../../../utils/index.d.mts";
+import type { FixedInstanceType } from "fvtt-types/utils";
 
 // TODO: Remove when the whole class is updated
 type LightSource = unknown;

--- a/src/foundry/client/pixi/placeables/note.d.mts
+++ b/src/foundry/client/pixi/placeables/note.d.mts
@@ -1,5 +1,5 @@
 import type { ConfiguredObjectClassOrDefault } from "../../config.d.mts";
-import type { FixedInstanceType } from "../../../../utils/index.d.mts";
+import type { FixedInstanceType } from "fvtt-types/utils";
 
 declare global {
   namespace Note {

--- a/src/foundry/client/pixi/placeables/primary-canvas-objects/primary-canvas-object.d.mts
+++ b/src/foundry/client/pixi/placeables/primary-canvas-objects/primary-canvas-object.d.mts
@@ -1,4 +1,4 @@
-import type { Mixin } from "../../../../../utils/index.d.mts";
+import type { Mixin } from "fvtt-types/utils";
 import type Document from "../../../../common/abstract/document.d.mts";
 
 declare class PrimaryCanvasObject {

--- a/src/foundry/client/pixi/placeables/primary-canvas-objects/primary-graphics.d.mts
+++ b/src/foundry/client/pixi/placeables/primary-canvas-objects/primary-graphics.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial } from "../../../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/foundry/client/pixi/placeables/primary-canvas-objects/primary-occludable-object.d.mts
+++ b/src/foundry/client/pixi/placeables/primary-canvas-objects/primary-occludable-object.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial, Mixin } from "../../../../../utils/index.d.mts";
+import type { InexactPartial, Mixin } from "fvtt-types/utils";
 
 declare class PrimaryOccludableObject {
   /** @privateRemarks All mixin classses should accept anything for its constructor. */

--- a/src/foundry/client/pixi/placeables/primary-canvas-objects/primary-sprite-mesh.d.mts
+++ b/src/foundry/client/pixi/placeables/primary-canvas-objects/primary-sprite-mesh.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial } from "../../../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 
 // TODO: Remove when #2570 is completed
 declare const PrimaryBaseSamplerShader: BaseSamplerShader;

--- a/src/foundry/client/pixi/placeables/region.d.mts
+++ b/src/foundry/client/pixi/placeables/region.d.mts
@@ -1,5 +1,5 @@
 import type { ConfiguredObjectClassOrDefault } from "../../config.d.mts";
-import type { Brand, FixedInstanceType } from "../../../../utils/index.d.mts";
+import type { Brand, FixedInstanceType } from "fvtt-types/utils";
 import type RegionShape from "../../../client-esm/canvas/regions/shape.d.mts";
 import type RegionPolygonTree from "../../../client-esm/canvas/regions/polygon-tree.d.mts";
 import type RegionGeometry from "../../../client-esm/canvas/regions/geometry.d.mts";

--- a/src/foundry/client/pixi/placeables/sound.d.mts
+++ b/src/foundry/client/pixi/placeables/sound.d.mts
@@ -1,6 +1,6 @@
 import type Sound from "../../../client-esm/audio/sound.d.mts";
 import type { ConfiguredObjectClassOrDefault } from "../../config.d.mts";
-import type { FixedInstanceType } from "../../../../utils/index.d.mts";
+import type { FixedInstanceType } from "fvtt-types/utils";
 
 declare global {
   namespace AmbientSound {

--- a/src/foundry/client/pixi/placeables/template.d.mts
+++ b/src/foundry/client/pixi/placeables/template.d.mts
@@ -1,4 +1,4 @@
-import type { RequiredProps, FixedInstanceType } from "../../../../utils/index.d.mts";
+import type { RequiredProps, FixedInstanceType } from "fvtt-types/utils";
 import type { ConfiguredObjectClassOrDefault } from "../../config.d.mts";
 
 declare global {

--- a/src/foundry/client/pixi/placeables/tile.d.mts
+++ b/src/foundry/client/pixi/placeables/tile.d.mts
@@ -1,5 +1,5 @@
 import type { ConfiguredObjectClassOrDefault } from "../../config.d.mts";
-import type { FixedInstanceType } from "../../../../utils/index.d.mts";
+import type { FixedInstanceType } from "fvtt-types/utils";
 
 declare global {
   namespace Tile {

--- a/src/foundry/client/pixi/placeables/token.d.mts
+++ b/src/foundry/client/pixi/placeables/token.d.mts
@@ -1,4 +1,4 @@
-import type { NullishProps, RequiredProps, FixedInstanceType } from "../../../../utils/index.d.mts";
+import type { NullishProps, RequiredProps, FixedInstanceType } from "fvtt-types/utils";
 import type BaseToken from "../../../common/documents/token.d.mts";
 import type { ConfiguredObjectClassOrDefault } from "../../config.d.mts";
 

--- a/src/foundry/client/pixi/placeables/wall.d.mts
+++ b/src/foundry/client/pixi/placeables/wall.d.mts
@@ -1,4 +1,4 @@
-import type { FixedInstanceType } from "../../../../utils/index.d.mts";
+import type { FixedInstanceType } from "fvtt-types/utils";
 import type { LineIntersection } from "../../../common/utils/geometry.d.mts";
 import type { ConfiguredObjectClassOrDefault } from "../../config.d.mts";
 

--- a/src/foundry/client/pixi/webgl/extensions/batch-renderer.d.mts
+++ b/src/foundry/client/pixi/webgl/extensions/batch-renderer.d.mts
@@ -1,4 +1,4 @@
-import type { ToMethod, InexactPartial } from "../../../../../utils/index.d.mts";
+import type { ToMethod, InexactPartial } from "fvtt-types/utils";
 
 declare abstract class AnyBatchRenderer extends BatchRenderer {
   constructor(arg0: never, ...args: never[]);

--- a/src/foundry/client/pixi/webgl/helpers/smooth-noise.d.mts
+++ b/src/foundry/client/pixi/webgl/helpers/smooth-noise.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial } from "../../../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 
 declare global {
   namespace SmoothNoise {

--- a/src/foundry/client/pixi/webgl/helpers/texture-extractor.d.mts
+++ b/src/foundry/client/pixi/webgl/helpers/texture-extractor.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial } from "../../../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 
 declare abstract class AnyTextureExtractor extends TextureExtractor {
   constructor(arg0: never, ...args: never[]);

--- a/src/foundry/client/pixi/webgl/shaders/base-shader-mixin.d.mts
+++ b/src/foundry/client/pixi/webgl/shaders/base-shader-mixin.d.mts
@@ -1,4 +1,4 @@
-import type { Mixin } from "../../../../../utils/index.d.mts";
+import type { Mixin } from "fvtt-types/utils";
 
 declare abstract class AnyBaseShader extends BaseShader {
   constructor(arg0: never, ...args: never[]);

--- a/src/foundry/client/pixi/webgl/shaders/base-shader.d.mts
+++ b/src/foundry/client/pixi/webgl/shaders/base-shader.d.mts
@@ -1,4 +1,4 @@
-import type { FixedInstanceType, ToMethod } from "../../../../../utils/index.d.mts";
+import type { FixedInstanceType, ToMethod } from "fvtt-types/utils";
 
 declare abstract class AnyAbstractBaseShader extends AbstractBaseShader {
   constructor(arg0: never, ...args: never[]);

--- a/src/foundry/client/pixi/webgl/shaders/filters/base-filter.d.mts
+++ b/src/foundry/client/pixi/webgl/shaders/filters/base-filter.d.mts
@@ -1,4 +1,4 @@
-import type { FixedInstanceType } from "../../../../../../utils/index.d.mts";
+import type { FixedInstanceType } from "fvtt-types/utils";
 
 declare abstract class AnyAbstractBaseFilter extends AbstractBaseFilter {
   constructor(arg0: never, ...args: never[]);

--- a/src/foundry/client/pixi/webgl/shaders/filters/effects-masking.d.mts
+++ b/src/foundry/client/pixi/webgl/shaders/filters/effects-masking.d.mts
@@ -1,4 +1,4 @@
-import type { AnyObject, FixedInstanceType, ShapeWithIndexSignature } from "../../../../../../utils/index.d.mts";
+import type { AnyObject, FixedInstanceType, ShapeWithIndexSignature } from "fvtt-types/utils";
 
 declare abstract class AnyVisualEffectsMaskingFilter extends VisualEffectsMaskingFilter {
   constructor(arg0: never, ...args: never[]);

--- a/src/foundry/client/pixi/webgl/shaders/filters/glow-overlay.d.mts
+++ b/src/foundry/client/pixi/webgl/shaders/filters/glow-overlay.d.mts
@@ -1,4 +1,4 @@
-import type { FixedInstanceType } from "../../../../../../utils/index.d.mts";
+import type { FixedInstanceType } from "fvtt-types/utils";
 
 declare abstract class AnyGlowOverlayFilter extends GlowOverlayFilter {
   constructor(arg0: never, ...args: never[]);

--- a/src/foundry/client/pixi/webgl/shaders/filters/outline-overlay.d.mts
+++ b/src/foundry/client/pixi/webgl/shaders/filters/outline-overlay.d.mts
@@ -1,4 +1,4 @@
-import type { FixedInstanceType } from "../../../../../../utils/index.d.mts";
+import type { FixedInstanceType } from "fvtt-types/utils";
 
 declare abstract class AnyOutlineOverlayFilter extends OutlineOverlayFilter {
   constructor(arg0: never, ...args: never[]);

--- a/src/foundry/client/pixi/webgl/shaders/filters/transition.d.mts
+++ b/src/foundry/client/pixi/webgl/shaders/filters/transition.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial, ValueOf } from "../../../../../../utils/index.d.mts";
+import type { InexactPartial, ValueOf } from "fvtt-types/utils";
 
 declare abstract class AnyTextureTransitionFilter extends TextureTransitionFilter {
   constructor(arg0: never, ...args: never[]);

--- a/src/foundry/client/pixi/webgl/shaders/filters/visibility.d.mts
+++ b/src/foundry/client/pixi/webgl/shaders/filters/visibility.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial, FixedInstanceType } from "../../../../../../utils/index.d.mts";
+import type { InexactPartial, FixedInstanceType } from "fvtt-types/utils";
 
 declare abstract class AnyVisibilityFilter extends VisibilityFilter {
   constructor(arg0: never, ...args: never[]);

--- a/src/foundry/client/pixi/webgl/shaders/filters/vision-mask-filter.d.mts
+++ b/src/foundry/client/pixi/webgl/shaders/filters/vision-mask-filter.d.mts
@@ -1,4 +1,4 @@
-import type { FixedInstanceType } from "../../../../../../utils/index.d.mts";
+import type { FixedInstanceType } from "fvtt-types/utils";
 
 declare abstract class AnyVisionMaskFilter extends VisionMaskFilter {
   constructor(arg0: never, ...args: never[]);

--- a/src/foundry/client/pixi/webgl/shaders/fragment-channel-mixin.d.mts
+++ b/src/foundry/client/pixi/webgl/shaders/fragment-channel-mixin.d.mts
@@ -1,4 +1,4 @@
-import type { AnyObject, Mixin, ShapeWithIndexSignature } from "../../../../../utils/index.d.mts";
+import type { AnyObject, Mixin, ShapeWithIndexSignature } from "fvtt-types/utils";
 
 declare abstract class AnyAdaptiveFragmentChannel extends AdaptiveFragmentChannel {
   constructor(arg0: never, ...args: never[]);

--- a/src/foundry/client/pixi/webgl/shaders/grid/grid.d.mts
+++ b/src/foundry/client/pixi/webgl/shaders/grid/grid.d.mts
@@ -1,4 +1,4 @@
-import type { IntentionalPartial } from "../../../../../../utils/index.d.mts";
+import type { IntentionalPartial } from "fvtt-types/utils";
 
 declare abstract class AnyGridShader extends GridShader {
   constructor(arg0: never, ...args: never[]);

--- a/src/foundry/client/pixi/webgl/shaders/samplers/base-sampler.d.mts
+++ b/src/foundry/client/pixi/webgl/shaders/samplers/base-sampler.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial, Mixin } from "../../../../../../utils/index.d.mts";
+import type { InexactPartial, Mixin } from "fvtt-types/utils";
 
 declare abstract class AnyBaseSamplerShader extends BaseSamplerShader {
   constructor(arg0: never, ...args: never[]);

--- a/src/foundry/client/pixi/webgl/shaders/weather/effect.d.mts
+++ b/src/foundry/client/pixi/webgl/shaders/weather/effect.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial, FixedInstanceType } from "../../../../../../utils/index.d.mts";
+import type { InexactPartial, FixedInstanceType } from "fvtt-types/utils";
 
 declare abstract class AnyWeatherShaderEffect extends WeatherShaderEffect<any> {
   constructor(arg0: never, ...args: never[]);

--- a/src/foundry/client/pixi/webgl/shaders/weather/fog.d.mts
+++ b/src/foundry/client/pixi/webgl/shaders/weather/fog.d.mts
@@ -1,4 +1,4 @@
-import type { InterfaceToObject } from "../../../../../../utils/index.d.mts";
+import type { InterfaceToObject } from "fvtt-types/utils";
 
 declare abstract class AnyFogShader extends FogShader {
   constructor(arg0: never, ...args: never[]);

--- a/src/foundry/client/pixi/webgl/shaders/weather/rain.d.mts
+++ b/src/foundry/client/pixi/webgl/shaders/weather/rain.d.mts
@@ -1,4 +1,4 @@
-import type { InterfaceToObject } from "../../../../../../utils/index.d.mts";
+import type { InterfaceToObject } from "fvtt-types/utils";
 
 declare abstract class AnyRainShader extends RainShader {
   constructor(arg0: never, ...args: never[]);

--- a/src/foundry/client/pixi/webgl/shaders/weather/snow.d.mts
+++ b/src/foundry/client/pixi/webgl/shaders/weather/snow.d.mts
@@ -1,4 +1,4 @@
-import type { InterfaceToObject } from "../../../../../../utils/index.d.mts";
+import type { InterfaceToObject } from "fvtt-types/utils";
 
 declare abstract class AnySnowShader extends SnowShader {
   constructor(arg0: never, ...args: never[]);

--- a/src/foundry/client/ui/context.d.mts
+++ b/src/foundry/client/ui/context.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial } from "../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 import type ApplicationV2 from "../../client-esm/applications/api/application.d.mts";
 
 export {};

--- a/src/foundry/client/ui/dialog.d.mts
+++ b/src/foundry/client/ui/dialog.d.mts
@@ -1,4 +1,4 @@
-import type { MaybePromise } from "../../../utils/index.d.mts";
+import type { MaybePromise } from "fvtt-types/utils";
 
 declare global {
   interface DialogOptions extends ApplicationOptions {

--- a/src/foundry/client/ui/dragdrop.d.mts
+++ b/src/foundry/client/ui/dragdrop.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial } from "../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 
 export {};
 

--- a/src/foundry/client/ui/editor.d.mts
+++ b/src/foundry/client/ui/editor.d.mts
@@ -1,5 +1,5 @@
 import type { EditorView } from "prosemirror-view";
-import type { AnyObject, InexactPartial, MaybePromise } from "../../../utils/index.d.mts";
+import type { AnyObject, InexactPartial, MaybePromise } from "fvtt-types/utils";
 import type Document from "../../common/abstract/document.d.mts";
 
 declare global {

--- a/src/foundry/client/ui/filepicker.d.mts
+++ b/src/foundry/client/ui/filepicker.d.mts
@@ -1,4 +1,4 @@
-import type { EmptyObject, MaybePromise, ValueOf } from "../../../utils/index.d.mts";
+import type { EmptyObject, MaybePromise, ValueOf } from "fvtt-types/utils";
 
 declare global {
   interface FilePickerOptions extends ApplicationOptions {

--- a/src/foundry/client/ui/filter.d.mts
+++ b/src/foundry/client/ui/filter.d.mts
@@ -1,4 +1,4 @@
-import type { ValueOf } from "../../../utils/index.d.mts";
+import type { ValueOf } from "fvtt-types/utils";
 
 declare global {
   /** Options which customize the behavior of the filter */

--- a/src/foundry/clipper/clipper.d.mts
+++ b/src/foundry/clipper/clipper.d.mts
@@ -1,4 +1,4 @@
-import type { Brand } from "../../utils/index.d.mts";
+import type { Brand } from "fvtt-types/utils";
 
 declare global {
   namespace ClipperLib {

--- a/src/foundry/common/abstract/backend.d.mts
+++ b/src/foundry/common/abstract/backend.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial, FixedInstanceType, LoggingLevels } from "../../../utils/index.d.mts";
+import type { InexactPartial, FixedInstanceType, LoggingLevels } from "fvtt-types/utils";
 import type Document from "./document.d.mts";
 import type {
   DatabaseCreateOperation,

--- a/src/foundry/common/abstract/data.d.mts
+++ b/src/foundry/common/abstract/data.d.mts
@@ -1,4 +1,4 @@
-import type { AnyMutableObject, AnyObject, EmptyObject } from "../../../utils/index.d.mts";
+import type { AnyMutableObject, AnyObject, EmptyObject } from "fvtt-types/utils";
 import type { DataField, SchemaField } from "../data/fields.d.mts";
 import type { fields } from "../data/module.d.mts";
 import type { DataModelValidationFailure } from "../data/validation-failure.d.mts";

--- a/src/foundry/common/abstract/embedded-collection-delta.d.mts
+++ b/src/foundry/common/abstract/embedded-collection-delta.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial } from "../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 import type Document from "./document.d.mts";
 import type EmbeddedCollection from "./embedded-collection.d.mts";
 

--- a/src/foundry/common/abstract/embedded-collection.d.mts
+++ b/src/foundry/common/abstract/embedded-collection.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial } from "../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 import type _Collection from "../utils/collection.d.mts";
 import type { DatabaseAction, DatabaseOperation } from "./_types.d.mts";
 import type Document from "./document.d.mts";

--- a/src/foundry/common/abstract/socket.d.mts
+++ b/src/foundry/common/abstract/socket.d.mts
@@ -1,4 +1,4 @@
-import type { AnyObject } from "../../../utils/index.d.mts";
+import type { AnyObject } from "fvtt-types/utils";
 import type { DatabaseAction, DatabaseOperation, DocumentSocketRequest } from "./_types.d.mts";
 
 /**

--- a/src/foundry/common/config.d.mts
+++ b/src/foundry/common/config.d.mts
@@ -1,7 +1,7 @@
 import type { DataModel } from "./abstract/data.d.mts";
 import type * as fields from "./data/fields.d.mts";
 import type { SOFTWARE_UPDATE_CHANNELS } from "./constants.d.mts";
-import type { AnyObject } from "../../utils/index.d.mts";
+import type { AnyObject } from "fvtt-types/utils";
 
 type DataSchema = foundry.data.fields.DataSchema;
 

--- a/src/foundry/common/constants.d.mts
+++ b/src/foundry/common/constants.d.mts
@@ -1,4 +1,4 @@
-import type { Brand, ValueOf } from "../../utils/index.d.mts";
+import type { Brand, ValueOf } from "fvtt-types/utils";
 
 /**
  * The shortened software name

--- a/src/foundry/common/data/data.d.mts
+++ b/src/foundry/common/data/data.d.mts
@@ -2,7 +2,7 @@ import type { DatabaseBackend } from "../abstract/module.d.mts";
 import type { DataModel } from "../abstract/data.d.mts";
 import type { fields } from "./module.d.mts";
 import type * as documents from "../documents/_module.d.mts";
-import type { AnyMutableObject, EmptyObject, ToMethod, ValueOf } from "../../../utils/index.d.mts";
+import type { AnyMutableObject, EmptyObject, ToMethod, ValueOf } from "fvtt-types/utils";
 import type { FilePathField } from "./fields.d.mts";
 
 type DataSchema = foundry.data.fields.DataSchema;

--- a/src/foundry/common/documents/active-effect.d.mts
+++ b/src/foundry/common/documents/active-effect.d.mts
@@ -1,4 +1,4 @@
-import type { InterfaceToObject, AnyObject, InexactPartial } from "../../../utils/index.d.mts";
+import type { InterfaceToObject, AnyObject, InexactPartial } from "fvtt-types/utils";
 import type Document from "../abstract/document.mts";
 import type * as CONST from "../constants.mts";
 import type * as fields from "../data/fields.d.mts";

--- a/src/foundry/common/documents/actor-delta.d.mts
+++ b/src/foundry/common/documents/actor-delta.d.mts
@@ -1,4 +1,4 @@
-import type { AnyMutableObject, AnyObject, InexactPartial } from "../../../utils/index.d.mts";
+import type { AnyMutableObject, AnyObject, InexactPartial } from "fvtt-types/utils";
 import type Document from "../abstract/document.mts";
 import type { fields } from "../data/module.d.mts";
 import type { CONST, documents } from "../../client-esm/client.d.mts";

--- a/src/foundry/common/documents/actor.d.mts
+++ b/src/foundry/common/documents/actor.d.mts
@@ -1,4 +1,4 @@
-import type { AnyObject } from "../../../utils/index.d.mts";
+import type { AnyObject } from "fvtt-types/utils";
 import type Document from "../abstract/document.mts";
 import type { PrototypeToken } from "../data/data.mts";
 import type * as fields from "../data/fields.d.mts";

--- a/src/foundry/common/documents/ambient-light.d.mts
+++ b/src/foundry/common/documents/ambient-light.d.mts
@@ -1,4 +1,4 @@
-import type { AnyObject } from "../../../utils/index.d.mts";
+import type { AnyObject } from "fvtt-types/utils";
 import type Document from "../abstract/document.mts";
 import type { LightData } from "../data/data.mts";
 import type * as fields from "../data/fields.d.mts";

--- a/src/foundry/common/documents/ambient-sound.d.mts
+++ b/src/foundry/common/documents/ambient-sound.d.mts
@@ -1,4 +1,4 @@
-import type { AnyObject } from "../../../utils/index.d.mts";
+import type { AnyObject } from "fvtt-types/utils";
 import type Document from "../abstract/document.mts";
 import type * as fields from "../data/fields.d.mts";
 

--- a/src/foundry/common/documents/card.d.mts
+++ b/src/foundry/common/documents/card.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial } from "../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 import type Document from "../abstract/document.mts";
 import type * as CONST from "../constants.mts";
 import type * as fields from "../data/fields.d.mts";

--- a/src/foundry/common/documents/cards.d.mts
+++ b/src/foundry/common/documents/cards.d.mts
@@ -1,4 +1,4 @@
-import type { AnyObject } from "../../../utils/index.d.mts";
+import type { AnyObject } from "fvtt-types/utils";
 import type Document from "../abstract/document.mts";
 import type * as fields from "../data/fields.d.mts";
 import type * as documents from "./_module.mts";

--- a/src/foundry/common/documents/chat-message.d.mts
+++ b/src/foundry/common/documents/chat-message.d.mts
@@ -1,4 +1,4 @@
-import type { AnyObject, InexactPartial } from "../../../utils/index.d.mts";
+import type { AnyObject, InexactPartial } from "fvtt-types/utils";
 import type Document from "../abstract/document.mts";
 import type * as CONST from "../constants.mts";
 import type * as fields from "../data/fields.d.mts";

--- a/src/foundry/common/documents/drawing.d.mts
+++ b/src/foundry/common/documents/drawing.d.mts
@@ -1,4 +1,4 @@
-import type { AnyObject, InexactPartial } from "../../../utils/index.d.mts";
+import type { AnyObject, InexactPartial } from "fvtt-types/utils";
 import type Document from "../abstract/document.mts";
 import type * as CONST from "../constants.mts";
 import type * as fields from "../data/fields.d.mts";

--- a/src/foundry/common/documents/item.d.mts
+++ b/src/foundry/common/documents/item.d.mts
@@ -1,4 +1,4 @@
-import type { AnyObject, InexactPartial } from "../../../utils/index.d.mts";
+import type { AnyObject, InexactPartial } from "fvtt-types/utils";
 import type Document from "../abstract/document.mts";
 import type * as fields from "../data/fields.d.mts";
 import type * as documents from "./_module.mts";

--- a/src/foundry/common/documents/journal-entry.d.mts
+++ b/src/foundry/common/documents/journal-entry.d.mts
@@ -1,4 +1,4 @@
-import type { AnyObject } from "../../../utils/index.d.mts";
+import type { AnyObject } from "fvtt-types/utils";
 import type Document from "../abstract/document.mts";
 import type * as fields from "../data/fields.d.mts";
 import type * as documents from "./_module.mts";

--- a/src/foundry/common/documents/macro.d.mts
+++ b/src/foundry/common/documents/macro.d.mts
@@ -1,4 +1,4 @@
-import type { AnyObject, InexactPartial } from "../../../utils/index.d.mts";
+import type { AnyObject, InexactPartial } from "fvtt-types/utils";
 import type Document from "../abstract/document.d.mts";
 import type * as CONST from "../constants.mts";
 import type * as fields from "../data/fields.d.mts";

--- a/src/foundry/common/documents/measured-template.d.mts
+++ b/src/foundry/common/documents/measured-template.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial } from "../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 import type Document from "../abstract/document.mts";
 import type * as fields from "../data/fields.d.mts";
 import type * as documents from "./_module.mts";

--- a/src/foundry/common/documents/note.d.mts
+++ b/src/foundry/common/documents/note.d.mts
@@ -1,4 +1,4 @@
-import type { AnyObject, InexactPartial } from "../../../utils/index.d.mts";
+import type { AnyObject, InexactPartial } from "fvtt-types/utils";
 import type Document from "../abstract/document.mts";
 import type { TextureData } from "../data/data.mts";
 import type * as fields from "../data/fields.d.mts";

--- a/src/foundry/common/documents/playlist-sound.d.mts
+++ b/src/foundry/common/documents/playlist-sound.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial } from "../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 import type Document from "../abstract/document.mts";
 import type * as fields from "../data/fields.d.mts";
 

--- a/src/foundry/common/documents/playlist.d.mts
+++ b/src/foundry/common/documents/playlist.d.mts
@@ -1,4 +1,4 @@
-import type { AnyObject } from "../../../utils/index.d.mts";
+import type { AnyObject } from "fvtt-types/utils";
 import type Document from "../abstract/document.mts";
 import type * as fields from "../data/fields.d.mts";
 import type * as documents from "./_module.mts";

--- a/src/foundry/common/documents/region.d.mts
+++ b/src/foundry/common/documents/region.d.mts
@@ -1,4 +1,4 @@
-import type { ValueOf } from "../../../utils/index.d.mts";
+import type { ValueOf } from "fvtt-types/utils";
 import type Document from "../abstract/document.mts";
 import type { BaseShapeData, fields } from "../data/module.d.mts";
 import type * as documents from "./_module.d.mts";

--- a/src/foundry/common/documents/roll-table.d.mts
+++ b/src/foundry/common/documents/roll-table.d.mts
@@ -1,4 +1,4 @@
-import type { AnyObject } from "../../../utils/index.d.mts";
+import type { AnyObject } from "fvtt-types/utils";
 import type Document from "../abstract/document.mts";
 import type * as fields from "../data/fields.d.mts";
 import type * as documents from "./_module.mts";

--- a/src/foundry/common/documents/scene.d.mts
+++ b/src/foundry/common/documents/scene.d.mts
@@ -1,4 +1,4 @@
-import type { AnyObject } from "../../../utils/index.d.mts";
+import type { AnyObject } from "fvtt-types/utils";
 import type Document from "../abstract/document.mts";
 import type * as CONST from "../constants.mts";
 import type { TextureData } from "../data/data.mts";

--- a/src/foundry/common/documents/table-result.d.mts
+++ b/src/foundry/common/documents/table-result.d.mts
@@ -1,4 +1,4 @@
-import type { AnyObject, InexactPartial } from "../../../utils/index.d.mts";
+import type { AnyObject, InexactPartial } from "fvtt-types/utils";
 import type Document from "../abstract/document.mts";
 import type * as CONST from "../constants.mts";
 import type * as fields from "../data/fields.d.mts";

--- a/src/foundry/common/documents/tile.d.mts
+++ b/src/foundry/common/documents/tile.d.mts
@@ -1,4 +1,4 @@
-import type { AnyObject } from "../../../utils/index.d.mts";
+import type { AnyObject } from "fvtt-types/utils";
 import type Document from "../abstract/document.mts";
 import type * as CONST from "../constants.mts";
 import type { TextureData } from "../data/data.mts";

--- a/src/foundry/common/documents/token.d.mts
+++ b/src/foundry/common/documents/token.d.mts
@@ -1,4 +1,4 @@
-import type { AnyObject, InexactPartial } from "../../../utils/index.d.mts";
+import type { AnyObject, InexactPartial } from "fvtt-types/utils";
 import type { DataModel } from "../abstract/data.d.mts";
 import type Document from "../abstract/document.mts";
 import type * as CONST from "../constants.mts";

--- a/src/foundry/common/documents/user.d.mts
+++ b/src/foundry/common/documents/user.d.mts
@@ -1,4 +1,4 @@
-import type { AnyObject, InexactPartial } from "../../../utils/index.d.mts";
+import type { AnyObject, InexactPartial } from "fvtt-types/utils";
 import type Document from "../abstract/document.mts";
 import type * as CONST from "../constants.mts";
 import type * as fields from "../data/fields.d.mts";

--- a/src/foundry/common/documents/wall.d.mts
+++ b/src/foundry/common/documents/wall.d.mts
@@ -1,4 +1,4 @@
-import type { AnyObject } from "../../../utils/index.d.mts";
+import type { AnyObject } from "fvtt-types/utils";
 import type Document from "../abstract/document.mts";
 import type * as CONST from "../constants.mts";
 import type * as fields from "../data/fields.d.mts";

--- a/src/foundry/common/grid/base.d.mts
+++ b/src/foundry/common/grid/base.d.mts
@@ -1,4 +1,4 @@
-import type { AnyObject, InexactPartial } from "../../../utils/index.d.mts";
+import type { AnyObject, InexactPartial } from "fvtt-types/utils";
 
 /**
  * The base grid class.

--- a/src/foundry/common/grid/gridless.d.mts
+++ b/src/foundry/common/grid/gridless.d.mts
@@ -1,6 +1,6 @@
 import type BaseGrid from "./base.d.mts";
 
-import type { InexactPartial } from "../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 
 declare class Gridless extends BaseGrid {
   override type: CONST.GRID_TYPES;

--- a/src/foundry/common/grid/hexagonal.d.mts
+++ b/src/foundry/common/grid/hexagonal.d.mts
@@ -1,6 +1,6 @@
 import type BaseGrid from "./base.d.mts";
 
-import type { InexactPartial } from "../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 
 declare class HexagonalGrid extends BaseGrid {
   /**

--- a/src/foundry/common/grid/square.d.mts
+++ b/src/foundry/common/grid/square.d.mts
@@ -1,6 +1,6 @@
 import type BaseGrid from "./base.d.mts";
 
-import type { InexactPartial } from "../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 
 declare class SquareGrid extends BaseGrid {
   /**

--- a/src/foundry/common/packages/base-package.d.mts
+++ b/src/foundry/common/packages/base-package.d.mts
@@ -1,4 +1,4 @@
-import type { GetKey, AnyObject, InexactPartial, AnyMutableObject } from "../../../utils/index.d.mts";
+import type { GetKey, AnyObject, InexactPartial, AnyMutableObject } from "fvtt-types/utils";
 // eslint-disable-next-line import/no-named-as-default
 import type DataModel from "../abstract/data.d.mts";
 import type { ReleaseData } from "../config.d.mts";

--- a/src/foundry/common/packages/base-world.d.mts
+++ b/src/foundry/common/packages/base-world.d.mts
@@ -1,6 +1,6 @@
 import type BasePackage from "./base-package.d.mts";
 import type * as fields from "../data/fields.d.mts";
-import type { AnyMutableObject, InexactPartial, Merge } from "../../../utils/index.d.mts";
+import type { AnyMutableObject, InexactPartial, Merge } from "fvtt-types/utils";
 import type { ReleaseData } from "../config.d.mts";
 
 type BaseWorldSchema = Merge<

--- a/src/foundry/common/packages/sub-types.d.mts
+++ b/src/foundry/common/packages/sub-types.d.mts
@@ -1,4 +1,4 @@
-import type { AnyObject, Merge } from "../../../utils/index.d.mts";
+import type { AnyObject, Merge } from "fvtt-types/utils";
 import type Document from "../abstract/document.d.mts";
 import type { DataField, ObjectField } from "../data/fields.d.mts";
 

--- a/src/foundry/common/primitives/array.d.mts
+++ b/src/foundry/common/primitives/array.d.mts
@@ -1,4 +1,4 @@
-import type { OverlapsWith } from "../../../utils/index.d.mts";
+import type { OverlapsWith } from "fvtt-types/utils";
 
 declare global {
   namespace Array {

--- a/src/foundry/common/primitives/string.d.mts
+++ b/src/foundry/common/primitives/string.d.mts
@@ -1,4 +1,4 @@
-import type { Titlecase } from "../../../utils/index.d.mts";
+import type { Titlecase } from "fvtt-types/utils";
 
 declare global {
   interface String {

--- a/src/foundry/common/prosemirror/dirty-plugin.d.mts
+++ b/src/foundry/common/prosemirror/dirty-plugin.d.mts
@@ -1,7 +1,7 @@
 import type { Schema } from "prosemirror-model";
 import type { Plugin } from "prosemirror-state";
 import type ProseMirrorPlugin from "./plugin.d.mts";
-import type { EmptyObject } from "../../../utils/index.d.mts";
+import type { EmptyObject } from "fvtt-types/utils";
 
 export default ProseMirrorDirtyPlugin;
 

--- a/src/foundry/common/prosemirror/dom-parser.d.mts
+++ b/src/foundry/common/prosemirror/dom-parser.d.mts
@@ -1,5 +1,5 @@
 import { DOMParser as BaseDOMParser, Node, ParseOptions, Schema } from "prosemirror-model";
-import type { FixedInstanceType } from "../../../utils/index.d.mts";
+import type { FixedInstanceType } from "fvtt-types/utils";
 
 export default DOMParser;
 

--- a/src/foundry/common/prosemirror/highlight-matches-plugin.d.mts
+++ b/src/foundry/common/prosemirror/highlight-matches-plugin.d.mts
@@ -3,7 +3,7 @@ import type ProseMirrorPlugin from "./plugin.d.mts";
 import type { ProseMirrorMenu } from "./menu.d.mts";
 import { EditorState, Plugin } from "prosemirror-state";
 import { EditorView } from "prosemirror-view";
-import type { EmptyObject, InexactPartial } from "../../../utils/index.d.mts";
+import type { EmptyObject, InexactPartial } from "fvtt-types/utils";
 
 declare namespace ProseMirrorHighlightMatchesPlugin {
   /**

--- a/src/foundry/common/prosemirror/image-plugin.d.mts
+++ b/src/foundry/common/prosemirror/image-plugin.d.mts
@@ -2,7 +2,7 @@ import type { Schema, Slice } from "prosemirror-model";
 import type { Plugin } from "prosemirror-state";
 import type { EditorView } from "prosemirror-view";
 import type ProseMirrorPlugin from "./plugin.d.mts";
-import type { EmptyObject } from "../../../utils/index.d.mts";
+import type { EmptyObject } from "fvtt-types/utils";
 
 export default ProseMirrorImagePlugin;
 /**

--- a/src/foundry/common/prosemirror/paste-transformer.d.mts
+++ b/src/foundry/common/prosemirror/paste-transformer.d.mts
@@ -2,7 +2,7 @@ import type { Schema, Slice } from "prosemirror-model";
 import type ProseMirrorPlugin from "./plugin.d.mts";
 import type { Plugin } from "prosemirror-state";
 import type { EditorView } from "prosemirror-view";
-import type { EmptyObject } from "../../../utils/index.d.mts";
+import type { EmptyObject } from "fvtt-types/utils";
 
 export default ProseMirrorPasteTransformer;
 

--- a/src/foundry/common/prosemirror/plugin.d.mts
+++ b/src/foundry/common/prosemirror/plugin.d.mts
@@ -1,6 +1,6 @@
 import type { Schema } from "prosemirror-model";
 import type { Plugin } from "prosemirror-state";
-import type { AnyObject } from "../../../utils/index.d.mts";
+import type { AnyObject } from "fvtt-types/utils";
 
 export default ProseMirrorPlugin;
 declare abstract class ProseMirrorPlugin {

--- a/src/foundry/common/types.d.mts
+++ b/src/foundry/common/types.d.mts
@@ -1,4 +1,4 @@
-import type { AnyConcreteConstructor, AnyConstructor, AnyFunction } from "../../utils/index.d.mts";
+import type { AnyConcreteConstructor, AnyConstructor, AnyFunction } from "fvtt-types/utils";
 import type { Document } from "./abstract/module.d.mts";
 
 // After seeing that none of these types add anything or are even exported a

--- a/src/foundry/common/utils/event-emitter.d.mts
+++ b/src/foundry/common/utils/event-emitter.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial, Mixin } from "../../../utils/index.d.mts";
+import type { InexactPartial, Mixin } from "fvtt-types/utils";
 
 /**
  * A mixin class which implements the behavior of EventTarget.

--- a/src/foundry/common/utils/helpers.d.mts
+++ b/src/foundry/common/utils/helpers.d.mts
@@ -1,4 +1,4 @@
-import type { AnyConstructor, AnyFunction, DeepPartial, InexactPartial } from "../../../utils/index.d.mts";
+import type { AnyConstructor, AnyFunction, DeepPartial, InexactPartial } from "fvtt-types/utils";
 import type Document from "../abstract/document.d.mts";
 
 /**

--- a/src/foundry/common/utils/string-tree.d.mts
+++ b/src/foundry/common/utils/string-tree.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial } from "../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 
 /**
  * A data structure representing a tree of string nodes with arbitrary object leaves.

--- a/src/foundry/common/utils/word-tree.d.mts
+++ b/src/foundry/common/utils/word-tree.d.mts
@@ -1,4 +1,4 @@
-import type { InexactPartial } from "../../../utils/index.d.mts";
+import type { InexactPartial } from "fvtt-types/utils";
 import type StringTree from "./string-tree.d.mts";
 
 /**

--- a/src/types/augments/particles.d.mts
+++ b/src/types/augments/particles.d.mts
@@ -1,6 +1,6 @@
 /* eslint-disable import/export */
 
-import type { Brand } from "../../utils/index.d.mts";
+import type { Brand } from "fvtt-types/utils";
 
 export namespace behaviors {
   type BehaviorOrder = Brand<number, "PIXI.particles.behaviors.BehaviorOrder">;

--- a/src/types/augments/pixi.d.mts
+++ b/src/types/augments/pixi.d.mts
@@ -1,4 +1,4 @@
-import type { Brand } from "../../utils/index.d.mts";
+import type { Brand } from "fvtt-types/utils";
 import * as _PIXI from "pixi.js";
 
 // Note(LukeAbby): The `smooth.d.mts` and `smooth.d.mts` files exist to make it DRY to selectively tweak PIXI sub-namespaces.

--- a/src/types/augments/smooth.d.mts
+++ b/src/types/augments/smooth.d.mts
@@ -1,4 +1,4 @@
-import type { Brand } from "../../utils/index.d.mts";
+import type { Brand } from "fvtt-types/utils";
 
 type JOINT_TYPE = Brand<number, "PIXI.smooth.JOINT_TYPE">;
 declare const JOINT_TYPE: {

--- a/src/types/augments/tinyMCE.d.mts
+++ b/src/types/augments/tinyMCE.d.mts
@@ -1,6 +1,6 @@
 import _tinymce from "tinymce";
 import type * as _tinymceTypes from "tinymce";
-import type { AnyObject } from "../../utils/index.d.mts";
+import type { AnyObject } from "fvtt-types/utils";
 
 declare global {
   let tinyMCE: typeof _tinymce;

--- a/src/types/config.d.mts
+++ b/src/types/config.d.mts
@@ -1,6 +1,6 @@
 import type Document from "../foundry/common/abstract/document.d.mts";
 import type { fields } from "../foundry/common/data/module.d.mts";
-import type { InterfaceToObject, MaybeEmpty, MustConform, DeepPartial } from "../utils/index.d.mts";
+import type { InterfaceToObject, MaybeEmpty, MustConform, DeepPartial } from "fvtt-types/utils";
 
 declare global {
   /**

--- a/src/types/documentConfiguration.d.mts
+++ b/src/types/documentConfiguration.d.mts
@@ -14,7 +14,7 @@ import type BaseTableResult from "../foundry/common/documents/table-result.d.mts
 import type BaseToken from "../foundry/common/documents/token.d.mts";
 import type BaseUser from "../foundry/common/documents/user.d.mts";
 import type BaseWall from "../foundry/common/documents/wall.d.mts";
-import type { ConformRecord, InterfaceToObject, MakeConform, MustConform, Merge } from "../utils/index.d.mts";
+import type { ConformRecord, InterfaceToObject, MakeConform, MustConform, Merge } from "fvtt-types/utils";
 
 type DocumentConform<T> = MakeConform<T, Document.AnyConstructor>;
 

--- a/tests/foundry/client/data/abstract/canvas-document.test-d.ts
+++ b/tests/foundry/client/data/abstract/canvas-document.test-d.ts
@@ -1,5 +1,5 @@
 import { assertType, expectTypeOf } from "vitest";
-import type { FixedInstanceType } from "../../../../../src/utils/index.d.mts";
+import type { FixedInstanceType } from "fvtt-types/utils";
 
 import Document = foundry.abstract.Document;
 


### PR DESCRIPTION
This was purely cosmetic - to get all the test imports for utils in the same, cleaner format.  I split it out from the other PR I'm about to push to make the substantive one easier to review.