### PR TITLE
Prosemirror tests

### DIFF
--- a/src/foundry/common/prosemirror/_module.d.mts
+++ b/src/foundry/common/prosemirror/_module.d.mts
@@ -5,7 +5,6 @@ import { Schema, DOMSerializer } from "prosemirror-model";
 import { keymap } from "prosemirror-keymap";
 import "./extensions.d.mts";
 import * as collab from "prosemirror-collab";
-import type { Step } from "prosemirror-transform";
 import type { parseHTMLString, serializeHTMLString } from "./util.d.mts";
 
 // A const is being imported here. It can't be `import type`.
@@ -23,6 +22,7 @@ import DOMParser from "./dom-parser.mjs";
 import ProseMirrorInputRules from "./input-rules.mjs";
 import ProseMirrorKeyMaps from "./keymaps.mjs";
 import ProseMirrorMenu from "./menu.mjs";
+import { Step } from "prosemirror-transform";
 /* eslint-enable */
 
 declare const dom: {

--- a/src/foundry/common/prosemirror/_module.d.mts
+++ b/src/foundry/common/prosemirror/_module.d.mts
@@ -11,6 +11,8 @@ import type { parseHTMLString, serializeHTMLString } from "./util.d.mts";
 // A const is being imported here. It can't be `import type`.
 /* eslint-disable import/extensions */
 import { schema as defaultSchema } from "./schema.mjs";
+
+// and these are classes that are available as properties of ProseMirror
 import ProseMirrorPlugin from "./plugin.mjs";
 import ProseMirrorImagePlugin from "./image-plugin.mjs";
 import ProseMirrorDirtyPlugin from "./dirty-plugin.mjs";

--- a/src/foundry/common/prosemirror/_module.d.mts
+++ b/src/foundry/common/prosemirror/_module.d.mts
@@ -2,27 +2,26 @@ import { EditorState, AllSelection, TextSelection, Plugin, PluginKey } from "pro
 import { EditorView } from "prosemirror-view";
 import { Schema, DOMSerializer } from "prosemirror-model";
 // eslint-disable-next-line import/no-named-as-default
-import type ProseMirrorInputRules from "./input-rules.d.mts";
 import { keymap } from "prosemirror-keymap";
-// eslint-disable-next-line import/no-named-as-default
-import type ProseMirrorKeyMaps from "./keymaps.d.mts";
-// eslint-disable-next-line import/no-named-as-default
-import type ProseMirrorMenu from "./menu.d.mts";
 import "./extensions.d.mts";
 import * as collab from "prosemirror-collab";
 import type { Step } from "prosemirror-transform";
 import type { parseHTMLString, serializeHTMLString } from "./util.d.mts";
 
 // A const is being imported here. It can't be `import type`.
-// eslint-disable-next-line import/extensions
+/* eslint-disable import/extensions */
 import { schema as defaultSchema } from "./schema.mjs";
-import type ProseMirrorPlugin from "./plugin.d.mts";
-import type ProseMirrorImagePlugin from "./image-plugin.d.mts";
-import type ProseMirrorDirtyPlugin from "./dirty-plugin.d.mts";
-import type ProseMirrorContentLinkPlugin from "./content-link-plugin.d.mts";
-import type ProseMirrorHighlightMatchesPlugin from "./highlight-matches-plugin.d.mts";
-import type ProseMirrorClickHandler from "./click-handler.d.mts";
-import type DOMParser from "./dom-parser.d.mts";
+import ProseMirrorPlugin from "./plugin.mjs";
+import ProseMirrorImagePlugin from "./image-plugin.mjs";
+import ProseMirrorDirtyPlugin from "./dirty-plugin.mjs";
+import ProseMirrorContentLinkPlugin from "./content-link-plugin.mjs";
+import ProseMirrorHighlightMatchesPlugin from "./highlight-matches-plugin.mjs";
+import ProseMirrorClickHandler from "./click-handler.mjs";
+import DOMParser from "./dom-parser.mjs";
+import ProseMirrorInputRules from "./input-rules.mjs";
+import ProseMirrorKeyMaps from "./keymaps.mjs";
+import ProseMirrorMenu from "./menu.mjs";
+/* eslint-enable */
 
 declare const dom: {
   parser: DOMParser;

--- a/src/foundry/common/prosemirror/schema/lists.d.mts
+++ b/src/foundry/common/prosemirror/schema/lists.d.mts
@@ -1,3 +1,5 @@
+import { Node } from "prosemirror-model";
+
 export declare const ol: {
   content: string;
   managed: Record<string, unknown>;

--- a/tests/foundry/common/prosemirror/_module.test-d.ts
+++ b/tests/foundry/common/prosemirror/_module.test-d.ts
@@ -1,0 +1,77 @@
+import { expectTypeOf } from "vitest";
+import type { Schema, DOMParser, DOMSerializer } from "prosemirror-model";
+import type { Step } from "prosemirror-transform";
+import type { EditorView } from "prosemirror-view";
+import { keymap } from "prosemirror-keymap";
+import type ProseMirrorKeyMaps from "../../../../src/foundry/common/prosemirror/keymaps.d.mts";
+import type ProseMirrorInputRules from "../../../../src/foundry/common/prosemirror/input-rules.d.mts";
+import type ProseMirrorImagePlugin from "../../../../src/foundry/common/prosemirror/image-plugin.d.mts";
+import type ProseMirrorHighlightMatchesPlugin from "../../../../src/foundry/common/prosemirror/highlight-matches-plugin.d.mts";
+import type ProseMirrorClickHandler from "../../../../src/foundry/common/prosemirror/click-handler.d.mts";
+import type ProseMirrorContentLinkPlugin from "../../../../src/foundry/common/prosemirror/content-link-plugin.d.mts";
+import type ProseMirrorDirtyPlugin from "../../../../src/foundry/common/prosemirror/dirty-plugin.d.mts";
+import type { parseHTMLString, serializeHTMLString } from "../../../../src/foundry/common/prosemirror/util.d.mts";
+import * as collab from "prosemirror-collab";
+import * as commands from "prosemirror-commands";
+import * as input from "prosemirror-inputrules";
+import * as tables from "prosemirror-tables";
+import * as state from "prosemirror-state";
+import * as transform from "prosemirror-transform";
+import * as list from "prosemirror-schema-list";
+import type ProseMirrorMenu from "../../../../src/foundry/common/prosemirror/menu.d.mts";
+import type ProseMirrorPlugin from "../../../../src/foundry/common/prosemirror/plugin.d.mts";
+
+expectTypeOf(foundry.prosemirror).toEqualTypeOf<typeof ProseMirror>();
+
+expectTypeOf(ProseMirror.commands).toEqualTypeOf<typeof commands>();
+expectTypeOf(ProseMirror.transform).toEqualTypeOf<typeof transform>();
+expectTypeOf(ProseMirror.list).toEqualTypeOf<typeof list>();
+expectTypeOf(ProseMirror.tables).toEqualTypeOf<typeof tables>();
+expectTypeOf(ProseMirror.input).toEqualTypeOf<typeof input>();
+expectTypeOf(ProseMirror.state).toEqualTypeOf<typeof state>();
+
+expectTypeOf(ProseMirror.AllSelection).toEqualTypeOf<typeof state.AllSelection>();
+expectTypeOf(ProseMirror.TextSelection).toEqualTypeOf<typeof state.TextSelection>();
+expectTypeOf(ProseMirror.DOMParser).toEqualTypeOf<DOMParser>();
+expectTypeOf(ProseMirror.DOMSerializer).toEqualTypeOf<typeof DOMSerializer>();
+expectTypeOf(ProseMirror.EditorState).toEqualTypeOf<typeof state.EditorState>();
+expectTypeOf(ProseMirror.EditorView).toEqualTypeOf<typeof EditorView>();
+expectTypeOf(ProseMirror.Schema).toEqualTypeOf<typeof Schema>();
+expectTypeOf(ProseMirror.Step).toEqualTypeOf<typeof Step>();
+expectTypeOf(ProseMirror.Plugin).toEqualTypeOf<typeof state.Plugin>();
+expectTypeOf(ProseMirror.PluginKey).toEqualTypeOf<typeof state.PluginKey>();
+expectTypeOf(ProseMirror.ProseMirrorPlugin).toEqualTypeOf<typeof ProseMirrorPlugin>();
+expectTypeOf(ProseMirror.ProseMirrorContentLinkPlugin).toEqualTypeOf<typeof ProseMirrorContentLinkPlugin>();
+expectTypeOf(ProseMirror.ProseMirrorHighlightMatchesPlugin).toEqualTypeOf<typeof ProseMirrorHighlightMatchesPlugin>();
+expectTypeOf(ProseMirror.ProseMirrorDirtyPlugin).toEqualTypeOf<typeof ProseMirrorDirtyPlugin>();
+expectTypeOf(ProseMirror.ProseMirrorImagePlugin).toEqualTypeOf<typeof ProseMirrorImagePlugin>();
+expectTypeOf(ProseMirror.ProseMirrorClickHandler).toEqualTypeOf<typeof ProseMirrorClickHandler>();
+expectTypeOf(ProseMirror.ProseMirrorInputRules).toEqualTypeOf<typeof ProseMirrorInputRules>();
+expectTypeOf(ProseMirror.ProseMirrorKeyMaps).toEqualTypeOf<typeof ProseMirrorKeyMaps>();
+expectTypeOf(ProseMirror.ProseMirrorMenu).toEqualTypeOf<typeof ProseMirrorMenu>();
+expectTypeOf(ProseMirror.collab).toEqualTypeOf<typeof collab>();
+expectTypeOf(ProseMirror.defaultPlugins).toEqualTypeOf<
+  Record<
+    | "inputRules"
+    | "keyMaps"
+    | "menu"
+    | "isDirty"
+    | "clickHandler"
+    | "pasteTransformer"
+    | "baseKeyMap"
+    | "dropCursor"
+    | "gapCursor"
+    | "history"
+    | "columnResizing"
+    | "tables",
+    state.Plugin
+  >
+>();
+expectTypeOf(ProseMirror.defaultSchema).toEqualTypeOf<Schema>();
+expectTypeOf(ProseMirror.dom).toEqualTypeOf<{
+  parser: DOMParser;
+  serializer: DOMSerializer;
+  parseString: typeof parseHTMLString;
+  serializeString: typeof serializeHTMLString;
+}>();
+expectTypeOf(ProseMirror.keymap).toEqualTypeOf<typeof keymap>();

--- a/tests/foundry/common/prosemirror/_module.test-d.ts
+++ b/tests/foundry/common/prosemirror/_module.test-d.ts
@@ -32,7 +32,7 @@ expectTypeOf(ProseMirror.state).toEqualTypeOf<typeof state>();
 
 expectTypeOf(ProseMirror.AllSelection).toEqualTypeOf<typeof state.AllSelection>();
 expectTypeOf(ProseMirror.TextSelection).toEqualTypeOf<typeof state.TextSelection>();
-expectTypeOf(ProseMirror.DOMParser).toEqualTypeOf<DOMParser>();
+expectTypeOf(ProseMirror.DOMParser).toEqualTypeOf<typeof DOMParser>();
 expectTypeOf(ProseMirror.DOMSerializer).toEqualTypeOf<typeof DOMSerializer>();
 expectTypeOf(ProseMirror.EditorState).toEqualTypeOf<typeof state.EditorState>();
 expectTypeOf(ProseMirror.EditorView).toEqualTypeOf<typeof EditorView>();

--- a/tests/foundry/common/prosemirror/click-handler.test-d.ts
+++ b/tests/foundry/common/prosemirror/click-handler.test-d.ts
@@ -1,0 +1,4 @@
+import { expectTypeOf } from "vitest";
+
+declare const schema: foundry.prosemirror.Schema;
+expectTypeOf(foundry.prosemirror.ProseMirrorClickHandler.build(schema, {})).toEqualTypeOf<foundry.prosemirror.Plugin>();

--- a/tests/foundry/common/prosemirror/content-link-plugin.test-d.ts
+++ b/tests/foundry/common/prosemirror/content-link-plugin.test-d.ts
@@ -1,0 +1,12 @@
+import { expectTypeOf } from "vitest";
+import type { AnyDocument } from "../../../../src/foundry/client/data/abstract/client-document.d.mts";
+
+declare const schema: foundry.prosemirror.Schema;
+
+const proseMirrorContentLinkPlugin = new foundry.prosemirror.ProseMirrorContentLinkPlugin(schema, {});
+expectTypeOf(proseMirrorContentLinkPlugin.document).toEqualTypeOf<Readonly<AnyDocument>>();
+expectTypeOf(proseMirrorContentLinkPlugin.relativeLinks).toEqualTypeOf<Readonly<boolean>>();
+
+expectTypeOf(
+  foundry.prosemirror.ProseMirrorContentLinkPlugin.build(schema, {}),
+).toEqualTypeOf<foundry.prosemirror.Plugin>();

--- a/tests/foundry/common/prosemirror/content-link-plugin.test-d.ts
+++ b/tests/foundry/common/prosemirror/content-link-plugin.test-d.ts
@@ -1,10 +1,9 @@
 import { expectTypeOf } from "vitest";
-import type { AnyDocument } from "../../../../src/foundry/client/data/abstract/client-document.d.mts";
 
 declare const schema: foundry.prosemirror.Schema;
 
 const proseMirrorContentLinkPlugin = new foundry.prosemirror.ProseMirrorContentLinkPlugin(schema, {});
-expectTypeOf(proseMirrorContentLinkPlugin.document).toEqualTypeOf<Readonly<AnyDocument>>();
+expectTypeOf(proseMirrorContentLinkPlugin.document).toEqualTypeOf<foundry.abstract.Document.Any>();
 expectTypeOf(proseMirrorContentLinkPlugin.relativeLinks).toEqualTypeOf<Readonly<boolean>>();
 
 expectTypeOf(

--- a/tests/foundry/common/prosemirror/dirty-plugin.test-d.ts
+++ b/tests/foundry/common/prosemirror/dirty-plugin.test-d.ts
@@ -1,0 +1,5 @@
+import { expectTypeOf } from "vitest";
+
+declare const schema: foundry.prosemirror.Schema;
+
+expectTypeOf(foundry.prosemirror.ProseMirrorDirtyPlugin.build(schema, {})).toEqualTypeOf<foundry.prosemirror.Plugin>();

--- a/tests/foundry/common/prosemirror/dom-parser.test-d.ts
+++ b/tests/foundry/common/prosemirror/dom-parser.test-d.ts
@@ -1,0 +1,11 @@
+import { expectTypeOf } from "vitest";
+import type { DOMParser as BaseDOMParser, Node } from "prosemirror-model";
+import type { FixedInstanceType } from "../../../../src/utils/index.d.mts";
+
+declare const schema: foundry.prosemirror.Schema;
+
+declare const domParser: foundry.prosemirror.DOMParser;
+declare const dom: FixedInstanceType<typeof window.Node>;
+expectTypeOf(domParser.parse(dom, {})).toEqualTypeOf<Node>();
+
+expectTypeOf(foundry.prosemirror.DOMParser.fromSchema(schema)).toEqualTypeOf<BaseDOMParser>();

--- a/tests/foundry/common/prosemirror/dropdown.test-d.ts
+++ b/tests/foundry/common/prosemirror/dropdown.test-d.ts
@@ -1,0 +1,11 @@
+/* eslint-disable import/extensions */
+import { expectTypeOf } from "vitest";
+import ProseMirrorDropDown from "../../../../src/foundry/common/prosemirror/dropdown.mjs";
+
+const proseMirrorDropDown = new ProseMirrorDropDown("", [], {});
+
+declare const html: HTMLMenuElement;
+
+expectTypeOf(proseMirrorDropDown.activateListeners(html)).toEqualTypeOf<void>();
+expectTypeOf(proseMirrorDropDown.render()).toEqualTypeOf<string>();
+expectTypeOf(proseMirrorDropDown.forEachItem(() => true)).toEqualTypeOf<void>();

--- a/tests/foundry/common/prosemirror/extensions.test-d.ts
+++ b/tests/foundry/common/prosemirror/extensions.test-d.ts
@@ -1,0 +1,8 @@
+/* eslint-disable import/extensions */
+import { expectTypeOf } from "vitest";
+import type { NodeType, ResolvedPos } from "prosemirror-model";
+
+declare const pos: ResolvedPos;
+
+declare const other: NodeType;
+expectTypeOf(pos.hasAncestor(other)).toEqualTypeOf<boolean>();

--- a/tests/foundry/common/prosemirror/highlight-matches-plugin.test-d.ts
+++ b/tests/foundry/common/prosemirror/highlight-matches-plugin.test-d.ts
@@ -1,0 +1,13 @@
+import { expectTypeOf } from "vitest";
+
+declare const schema: foundry.prosemirror.Schema;
+
+new foundry.prosemirror.ProseMirrorHighlightMatchesPlugin(schema, {});
+
+expectTypeOf(
+  foundry.prosemirror.ProseMirrorHighlightMatchesPlugin.build(schema, {}),
+).toEqualTypeOf<foundry.prosemirror.Plugin>();
+
+// TODO: build() should actually returns not just any plugin, but a plugin where spec.view is a function:
+//   view(e: editorView) => PossibleMatchesTooltip
+// that returns a PossibleMatchesTooltip that we can then test the properties of

--- a/tests/foundry/common/prosemirror/image-plugin.test-d.ts
+++ b/tests/foundry/common/prosemirror/image-plugin.test-d.ts
@@ -1,0 +1,8 @@
+import { expectTypeOf } from "vitest";
+
+declare const schema: foundry.prosemirror.Schema;
+
+new foundry.prosemirror.ProseMirrorImagePlugin(schema, {});
+
+expectTypeOf(foundry.prosemirror.ProseMirrorImagePlugin.build(schema, {})).toEqualTypeOf<foundry.prosemirror.Plugin>();
+expectTypeOf(foundry.prosemirror.ProseMirrorImagePlugin.base64ToFile("", "", "")).toEqualTypeOf<File>();

--- a/tests/foundry/common/prosemirror/input-rules.test-d.ts
+++ b/tests/foundry/common/prosemirror/input-rules.test-d.ts
@@ -1,0 +1,10 @@
+import type { InputRule } from "prosemirror-inputrules";
+import { expectTypeOf } from "vitest";
+
+declare const schema: foundry.prosemirror.Schema;
+
+const inputRules = new foundry.prosemirror.ProseMirrorInputRules(schema);
+
+expectTypeOf(inputRules.buildRules()).toEqualTypeOf<InputRule[]>();
+
+expectTypeOf(foundry.prosemirror.ProseMirrorInputRules.build(schema, {})).toEqualTypeOf<foundry.prosemirror.Plugin>();

--- a/tests/foundry/common/prosemirror/keymaps.test-d.ts
+++ b/tests/foundry/common/prosemirror/keymaps.test-d.ts
@@ -1,0 +1,11 @@
+import { expectTypeOf } from "vitest";
+import type { ProseMirrorCommand } from "../../../../src/foundry/common/prosemirror/keymaps.d.mts";
+
+declare const schema: foundry.prosemirror.Schema;
+
+const keymaps = new foundry.prosemirror.ProseMirrorKeyMaps(schema, {});
+
+expectTypeOf(keymaps.onSave()).toEqualTypeOf<void>();
+expectTypeOf(keymaps.buildMapping()).toEqualTypeOf<Record<string, ProseMirrorCommand>>();
+
+expectTypeOf(foundry.prosemirror.ProseMirrorKeyMaps.build(schema, {})).toEqualTypeOf<foundry.prosemirror.Plugin>();

--- a/tests/foundry/common/prosemirror/menu.test-d.ts
+++ b/tests/foundry/common/prosemirror/menu.test-d.ts
@@ -1,0 +1,24 @@
+/* eslint-disable import/extensions */
+import { expectTypeOf } from "vitest";
+import type { EditorView } from "prosemirror-view";
+import type * as PMMNamespace from "../../../../src/foundry/common/prosemirror/menu.d.mts";
+import { Plugin } from "prosemirror-state";
+
+declare const schema: foundry.prosemirror.Schema;
+declare const view: EditorView;
+
+const proseMirrorMenu = new foundry.prosemirror.ProseMirrorMenu(schema, view);
+
+expectTypeOf(proseMirrorMenu.view).toEqualTypeOf<EditorView>();
+expectTypeOf(proseMirrorMenu.items).toEqualTypeOf<PMMNamespace.ProseMirrorMenu.Item[]>();
+expectTypeOf(proseMirrorMenu.id).toEqualTypeOf<Readonly<`prosemirror-menu-${string}`>>();
+expectTypeOf(proseMirrorMenu.options).toEqualTypeOf<PMMNamespace.ProseMirrorMenu.ProseMirrorMenuOptions>();
+expectTypeOf(proseMirrorMenu.dropdowns).toEqualTypeOf<PMMNamespace.ProseMirrorDropDown.Entry[]>();
+expectTypeOf(proseMirrorMenu.render()).toEqualTypeOf<foundry.prosemirror.ProseMirrorMenu>();
+
+declare const html: HTMLMenuElement;
+expectTypeOf(proseMirrorMenu.activateListeners(html)).toEqualTypeOf<void>();
+expectTypeOf(proseMirrorMenu.update(view, view)).toEqualTypeOf<void>();
+expectTypeOf(proseMirrorMenu.destroy()).toEqualTypeOf<void>();
+
+expectTypeOf(foundry.prosemirror.ProseMirrorMenu.build(schema)).toEqualTypeOf<Plugin>();

--- a/tests/foundry/common/prosemirror/paste-transformer.test-d.ts
+++ b/tests/foundry/common/prosemirror/paste-transformer.test-d.ts
@@ -1,0 +1,15 @@
+/* eslint-disable import/extensions */
+import { expectTypeOf } from "vitest";
+import ProseMirrorPasteTransformer from "../../../../src/foundry/common/prosemirror/paste-transformer.mjs";
+import { Slice } from "prosemirror-model";
+import type { EditorView } from "prosemirror-view";
+
+declare const schema: foundry.prosemirror.Schema;
+
+const pasteTransformer = new ProseMirrorPasteTransformer(schema);
+
+declare const slice: Slice;
+declare const view: EditorView;
+expectTypeOf(pasteTransformer._onPaste(slice, view)).toEqualTypeOf<Slice>();
+
+expectTypeOf(ProseMirrorPasteTransformer.build(schema, {})).toEqualTypeOf<foundry.prosemirror.Plugin>();

--- a/tests/foundry/common/prosemirror/plugin.test-d..ts
+++ b/tests/foundry/common/prosemirror/plugin.test-d..ts
@@ -1,0 +1,12 @@
+/* eslint-disable import/extensions */
+import { expectTypeOf } from "vitest";
+import { Schema } from "prosemirror-model";
+import ProseMirrorPlugin from "../../../../src/foundry/common/prosemirror/plugin.mjs";
+
+declare const schema: foundry.prosemirror.Schema;
+
+declare const plugin: ProseMirrorPlugin;
+
+expectTypeOf(plugin.schema).toEqualTypeOf<Schema>();
+
+expectTypeOf(ProseMirrorPlugin.build(schema, {})).toEqualTypeOf<foundry.prosemirror.Plugin>();

--- a/tests/foundry/common/prosemirror/prosemirror.test-d.ts
+++ b/tests/foundry/common/prosemirror/prosemirror.test-d.ts
@@ -1,7 +1,0 @@
-import type { Schema } from "prosemirror-model";
-import type { EditorState } from "prosemirror-state";
-import { expectTypeOf } from "vitest";
-
-expectTypeOf(ProseMirror.EditorState).toEqualTypeOf<typeof EditorState>();
-expectTypeOf(ProseMirror.Schema).toEqualTypeOf<typeof Schema>();
-expectTypeOf(ProseMirror.defaultSchema).toEqualTypeOf<Schema>();

--- a/tests/foundry/common/prosemirror/schema/attribute-capture.test-d.ts
+++ b/tests/foundry/common/prosemirror/schema/attribute-capture.test-d.ts
@@ -1,0 +1,10 @@
+/* eslint-disable import/extensions */
+import type { DOMOutputSpec, MarkSpec, NodeSpec } from "prosemirror-model";
+import { expectTypeOf } from "vitest";
+import AttributeCapture from "../../../../../src/foundry/common/prosemirror/schema/attribute-capture.mjs";
+
+const attributeCapture = new AttributeCapture();
+declare const nodeSpec: NodeSpec;
+declare const markSpec: MarkSpec;
+expectTypeOf(attributeCapture.attributeCapture(nodeSpec)).toEqualTypeOf<DOMOutputSpec>();
+expectTypeOf(attributeCapture.attributeCapture(markSpec)).toEqualTypeOf<DOMOutputSpec>();

--- a/tests/foundry/common/prosemirror/schema/core.test-d.ts
+++ b/tests/foundry/common/prosemirror/schema/core.test-d.ts
@@ -1,0 +1,61 @@
+/* eslint-disable import/extensions */
+import type { Node } from "prosemirror-model";
+import { expectTypeOf } from "vitest";
+import {
+  paragraph,
+  blockquote,
+  hr,
+  heading,
+  pre,
+  br,
+} from "../../../../../src/foundry/common/prosemirror/schema/core.mjs";
+
+expectTypeOf(paragraph).toEqualTypeOf<{
+  attrs: Record<string, unknown>;
+  managed: Record<string, unknown>;
+  content: string;
+  group: string;
+  parseDOM: Record<string, unknown>[];
+  toDOM: (node: Node) => [string, Record<string, string>, number] | [string, number];
+}>();
+
+expectTypeOf(blockquote).toEqualTypeOf<{
+  content: string;
+  group: string;
+  defining: boolean;
+  parseDOM: Record<string, unknown>[];
+  toDOM: () => [string, number];
+}>();
+
+expectTypeOf(hr).toEqualTypeOf<{
+  group: string;
+  parseDOM: Record<string, unknown>[];
+  toDOM: () => [string];
+}>();
+
+expectTypeOf(heading).toEqualTypeOf<{
+  attrs: Record<string, unknown>;
+  content: string;
+  group: string;
+  defining: boolean;
+  parseDOM: Record<string, unknown>[];
+  toDOM: (node: Node) => [string, number];
+}>();
+
+expectTypeOf(pre).toEqualTypeOf<{
+  content: string;
+  marks: string;
+  group: string;
+  code: boolean;
+  defining: boolean;
+  parseDOM: Record<string, unknown>[];
+  toDOM: () => [string, [string, number]];
+}>();
+
+expectTypeOf(br).toEqualTypeOf<{
+  inline: boolean;
+  group: string;
+  selectable: boolean;
+  parseDOM: Record<string, unknown>[];
+  toDOM: () => [string];
+}>();

--- a/tests/foundry/common/prosemirror/schema/image-link-node.test-d.ts
+++ b/tests/foundry/common/prosemirror/schema/image-link-node.test-d.ts
@@ -1,0 +1,21 @@
+/* eslint-disable import/extensions */
+import { expectTypeOf } from "vitest";
+import ImageLinkNode from "../../../../../src/foundry/common/prosemirror/schema/image-link-node.mjs";
+import type { MarkSpec, Node, NodeSpec } from "prosemirror-model";
+import type { EditorView } from "prosemirror-view";
+
+new ImageLinkNode();
+
+expectTypeOf(ImageLinkNode.tag).toEqualTypeOf<"a">();
+expectTypeOf(ImageLinkNode.attrs).toEqualTypeOf<Record<string, unknown>>();
+
+declare const el: HTMLLinkElement;
+expectTypeOf(ImageLinkNode.getAttrs(el)).toEqualTypeOf<boolean | Record<string, unknown>>();
+
+declare const node: Node;
+expectTypeOf(ImageLinkNode.toDOM(node)).toEqualTypeOf<[string, unknown]>();
+expectTypeOf(ImageLinkNode.make()).toEqualTypeOf<NodeSpec | MarkSpec>();
+
+declare const view: EditorView;
+declare const event: JQuery.ClickEvent;
+expectTypeOf(ImageLinkNode.onClick(view, 3, event, node)).toEqualTypeOf<boolean>();

--- a/tests/foundry/common/prosemirror/schema/image-node.test-d.ts
+++ b/tests/foundry/common/prosemirror/schema/image-node.test-d.ts
@@ -1,0 +1,16 @@
+/* eslint-disable import/extensions */
+import { expectTypeOf } from "vitest";
+import ImageNode from "../../../../../src/foundry/common/prosemirror/schema/image-node.mjs";
+import type { MarkSpec, Node, NodeSpec } from "prosemirror-model";
+
+new ImageNode();
+
+expectTypeOf(ImageNode.tag).toEqualTypeOf<"img[src]">();
+expectTypeOf(ImageNode.attrs).toEqualTypeOf<Record<string, unknown>>();
+
+declare const el: HTMLImageElement;
+expectTypeOf(ImageNode.getAttrs(el)).toEqualTypeOf<boolean | Record<string, unknown>>();
+
+declare const node: Node;
+expectTypeOf(ImageNode.toDOM(node)).toEqualTypeOf<[string, unknown]>();
+expectTypeOf(ImageNode.make()).toEqualTypeOf<NodeSpec | MarkSpec>();

--- a/tests/foundry/common/prosemirror/schema/link-mark.test-d.ts
+++ b/tests/foundry/common/prosemirror/schema/link-mark.test-d.ts
@@ -1,0 +1,22 @@
+/* eslint-disable import/extensions */
+import { expectTypeOf } from "vitest";
+import LinkMark from "../../../../../src/foundry/common/prosemirror/schema/link-mark.mjs";
+import type { Mark, MarkSpec, Node, NodeSpec } from "prosemirror-model";
+import type { EditorView } from "prosemirror-view";
+
+new LinkMark();
+
+expectTypeOf(LinkMark.tag).toEqualTypeOf<"a">();
+expectTypeOf(LinkMark.attrs).toEqualTypeOf<Record<string, unknown>>();
+
+declare const el: HTMLLinkElement;
+expectTypeOf(LinkMark.getAttrs(el)).toEqualTypeOf<boolean | Record<string, unknown>>();
+
+declare const node: Node;
+expectTypeOf(LinkMark.toDOM(node)).toEqualTypeOf<[string, unknown]>();
+expectTypeOf(LinkMark.make()).toEqualTypeOf<NodeSpec | MarkSpec>();
+
+declare const view: EditorView;
+declare const event: JQuery.ClickEvent;
+declare const mark: Mark;
+expectTypeOf(LinkMark.onClick(view, 3, event, mark)).toEqualTypeOf<boolean | void>();

--- a/tests/foundry/common/prosemirror/schema/lists.test-d.ts
+++ b/tests/foundry/common/prosemirror/schema/lists.test-d.ts
@@ -1,0 +1,34 @@
+/* eslint-disable import/extensions */
+import type { Node } from "prosemirror-model";
+import { expectTypeOf } from "vitest";
+import { ol, ul, li, liText } from "../../../../../src/foundry/common/prosemirror/schema/lists.mjs";
+
+expectTypeOf(ol).toEqualTypeOf<{
+  content: string;
+  managed: Record<string, unknown>;
+  group: string;
+  attrs: Record<string, unknown>;
+  parseDOM: Record<string, unknown>[];
+  toDOM: (node: Node) => [string, number] | [string, Record<string, unknown>, number];
+}>();
+
+expectTypeOf(ul).toEqualTypeOf<{
+  content: string;
+  group: string;
+  parseDOM: Record<string, unknown>[];
+  toDOM: () => [string, number];
+}>();
+
+expectTypeOf(li).toEqualTypeOf<{
+  content: string;
+  defining: boolean;
+  parseDOM: Record<string, unknown>[];
+  toDOM: () => [string, number];
+}>();
+
+expectTypeOf(liText).toEqualTypeOf<{
+  content: string;
+  defining: boolean;
+  parseDOM: Record<string, unknown>[];
+  toDOM: () => [string, number];
+}>();

--- a/tests/foundry/common/prosemirror/schema/other.test-d.ts
+++ b/tests/foundry/common/prosemirror/schema/other.test-d.ts
@@ -1,0 +1,175 @@
+/* eslint-disable import/extensions */
+import { expectTypeOf } from "vitest";
+import {
+  details,
+  summary,
+  summaryBlock,
+  dl,
+  dt,
+  dd,
+  fieldset,
+  legend,
+  picture,
+  audio,
+  video,
+  track,
+  source,
+  object,
+  figure,
+  figcaption,
+  small,
+  ruby,
+  rp,
+  rt,
+  iframe,
+} from "../../../../../src/foundry/common/prosemirror/schema/other.mjs";
+
+expectTypeOf(details).toEqualTypeOf<{
+  content: string;
+  group: string;
+  defining: boolean;
+  parseDOM: Record<string, unknown>[];
+  toDOM: () => [string, number];
+}>();
+
+expectTypeOf(summary).toEqualTypeOf<{
+  content: string;
+  defining: boolean;
+  parseDOM: Record<string, unknown>[];
+  toDOM: () => [string, number];
+}>();
+
+expectTypeOf(summaryBlock).toEqualTypeOf<{
+  content: string;
+  defining: boolean;
+  parseDOM: Record<string, unknown>[];
+  toDOM: () => [string, number];
+}>();
+
+expectTypeOf(dl).toEqualTypeOf<{
+  content: string;
+  group: string;
+  defining: boolean;
+  parseDOM: Record<string, unknown>[];
+  toDOM: () => [string, number];
+}>();
+
+expectTypeOf(dt).toEqualTypeOf<{
+  content: string;
+  defining: boolean;
+  parseDOM: Record<string, unknown>[];
+  toDOM: () => [string, number];
+}>();
+
+expectTypeOf(dd).toEqualTypeOf<{
+  content: string;
+  defining: boolean;
+  parseDOM: Record<string, unknown>[];
+  toDOM: () => [string, number];
+}>();
+
+expectTypeOf(fieldset).toEqualTypeOf<{
+  content: string;
+  group: string;
+  defining: boolean;
+  parseDOM: Record<string, unknown>[];
+  toDOM: () => [string, number];
+}>();
+
+expectTypeOf(legend).toEqualTypeOf<{
+  content: string;
+  defining: boolean;
+  parseDOM: Record<string, unknown>[];
+  toDOM: () => [string, number];
+}>();
+
+expectTypeOf(picture).toEqualTypeOf<{
+  content: string;
+  group: string;
+  defining: boolean;
+  parseDOM: Record<string, unknown>[];
+  toDOM: () => [string, number];
+}>();
+
+expectTypeOf(audio).toEqualTypeOf<{
+  content: string;
+  group: string;
+  parseDOM: Record<string, unknown>[];
+  toDOM: () => [string, number];
+}>();
+
+expectTypeOf(video).toEqualTypeOf<{
+  content: string;
+  group: string;
+  parseDOM: Record<string, unknown>[];
+  toDOM: () => [string, number];
+}>();
+
+expectTypeOf(track).toEqualTypeOf<{
+  parseDOM: Record<string, unknown>[];
+  toDOM: () => [string];
+}>();
+
+expectTypeOf(source).toEqualTypeOf<{
+  parseDOM: Record<string, unknown>[];
+  toDOM: () => [string];
+}>();
+
+expectTypeOf(object).toEqualTypeOf<{
+  inline: boolean;
+  group: string;
+  parseDOM: Record<string, unknown>[];
+  toDOM: () => [string];
+}>();
+
+expectTypeOf(figure).toEqualTypeOf<{
+  content: string;
+  group: string;
+  defining: boolean;
+  parseDOM: Record<string, unknown>[];
+  toDOM: () => [string, number];
+}>();
+
+expectTypeOf(figcaption).toEqualTypeOf<{
+  content: string;
+  defining: boolean;
+  parseDOM: Record<string, unknown>[];
+  toDOM: () => [string, number];
+}>();
+
+expectTypeOf(small).toEqualTypeOf<{
+  content: string;
+  group: string;
+  defining: boolean;
+  parseDOM: Record<string, unknown>[];
+  toDOM: () => [string, number];
+}>();
+
+expectTypeOf(ruby).toEqualTypeOf<{
+  content: string;
+  group: string;
+  defining: boolean;
+  parseDOM: Record<string, unknown>[];
+  toDOM: () => [string, number];
+}>();
+
+expectTypeOf(rp).toEqualTypeOf<{
+  content: string;
+  parseDOM: Record<string, unknown>[];
+  toDOM: () => [string, number];
+}>();
+
+expectTypeOf(rt).toEqualTypeOf<{
+  content: string;
+  parseDOM: Record<string, unknown>[];
+  toDOM: () => [string, number];
+}>();
+
+expectTypeOf(iframe).toEqualTypeOf<{
+  attrs: Record<string, unknown>;
+  managed: Record<string, unknown>;
+  group: string;
+  defining: boolean;
+  parseDOM: Record<string, unknown>[];
+  toDOM: () => [string, unknown];
+}>();

--- a/tests/foundry/common/prosemirror/schema/schema-definition.test-d.ts
+++ b/tests/foundry/common/prosemirror/schema/schema-definition.test-d.ts
@@ -1,0 +1,14 @@
+/* eslint-disable import/extensions */
+import { expectTypeOf } from "vitest";
+import SchemaDefinition from "../../../../../src/foundry/common/prosemirror/schema/schema-definition.mjs";
+import type { MarkSpec, Node, NodeSpec } from "prosemirror-model";
+
+expectTypeOf(SchemaDefinition.tag).toEqualTypeOf<string>();
+expectTypeOf(SchemaDefinition.attrs).toEqualTypeOf<Record<string, unknown>>();
+
+declare const el: HTMLElement;
+expectTypeOf(SchemaDefinition.getAttrs(el)).toEqualTypeOf<Record<string, unknown> | boolean>();
+
+declare const node: Node;
+expectTypeOf(SchemaDefinition.toDOM(node)).toEqualTypeOf<unknown[]>();
+expectTypeOf(SchemaDefinition.make()).toEqualTypeOf<NodeSpec | MarkSpec>();

--- a/tests/foundry/common/prosemirror/schema/secret-node.test-d.ts
+++ b/tests/foundry/common/prosemirror/schema/secret-node.test-d.ts
@@ -1,0 +1,20 @@
+/* eslint-disable import/extensions */
+import { expectTypeOf } from "vitest";
+import SecretNode from "../../../../../src/foundry/common/prosemirror/schema/secret-node.mjs";
+import type { MarkSpec, Node, NodeSpec } from "prosemirror-model";
+import type { EditorState } from "../../../../../src/foundry/common/prosemirror/_module.d.mts";
+import type { Transaction } from "prosemirror-state";
+
+expectTypeOf(SecretNode.tag).toEqualTypeOf<"section">();
+expectTypeOf(SecretNode.attrs).toEqualTypeOf<Record<string, unknown>>();
+
+declare const el: HTMLElement;
+expectTypeOf(SecretNode.getAttrs(el)).toEqualTypeOf<Record<string, unknown> | boolean>();
+
+declare const node: Node;
+expectTypeOf(SecretNode.toDOM(node)).toEqualTypeOf<[string, Record<string, unknown>, number]>();
+expectTypeOf(SecretNode.make()).toEqualTypeOf<NodeSpec | MarkSpec>();
+
+declare const state: EditorState;
+declare const dispatch: (tr: Transaction) => void;
+expectTypeOf(SecretNode.split(state, dispatch)).toEqualTypeOf<boolean>();

--- a/tests/foundry/common/prosemirror/schema/tables.test-d.ts
+++ b/tests/foundry/common/prosemirror/schema/tables.test-d.ts
@@ -1,0 +1,124 @@
+/* eslint-disable import/extensions */
+import type { Node } from "prosemirror-model";
+import { expectTypeOf } from "vitest";
+import {
+  builtInTableNodes,
+  tableComplex,
+  colgroup,
+  col,
+  thead,
+  tbody,
+  tfoot,
+  caption,
+  captionBlock,
+  tableRowComplex,
+  tableCellComplex,
+  tableCellComplexBlock,
+  tableHeaderComplex,
+  tableHeaderComplexBlock,
+} from "../../../../../src/foundry/common/prosemirror/schema/tables.mjs";
+
+expectTypeOf(builtInTableNodes).toEqualTypeOf<{
+  table: Record<string, unknown>;
+  table_cell: Record<string, unknown>;
+  table_header: Record<string, unknown>;
+  table_row: Record<string, unknown>;
+}>();
+
+expectTypeOf(tableComplex).toEqualTypeOf<{
+  content: string;
+  isolating: boolean;
+  group: string;
+  parseDOM: Record<string, unknown>[];
+  toDOM: () => [string, number];
+}>();
+
+expectTypeOf(colgroup).toEqualTypeOf<{
+  content: string;
+  isolating: boolean;
+  parseDOM: Record<string, unknown>[];
+  toDOM: () => [string, number];
+}>();
+
+expectTypeOf(col).toEqualTypeOf<{
+  tableRole: string;
+  parseDOM: Record<string, unknown>[];
+  toDOM: () => [string];
+}>();
+
+expectTypeOf(thead).toEqualTypeOf<{
+  content: string;
+  isolating: boolean;
+  parseDOM: Record<string, unknown>[];
+  toDOM: () => [string, number];
+}>();
+
+expectTypeOf(tbody).toEqualTypeOf<{
+  content: string;
+  isolating: boolean;
+  parseDOM: Record<string, unknown>[];
+  toDOM: () => [string, number];
+}>();
+
+expectTypeOf(tfoot).toEqualTypeOf<{
+  content: string;
+  isolating: boolean;
+  parseDOM: Record<string, unknown>[];
+  toDOM: () => [string, number];
+}>();
+
+expectTypeOf(caption).toEqualTypeOf<{
+  content: string;
+  isolating: boolean;
+  parseDOM: Record<string, unknown>[];
+  toDOM: () => [string, number];
+}>();
+
+expectTypeOf(captionBlock).toEqualTypeOf<{
+  content: string;
+  isolating: boolean;
+  parseDOM: Record<string, unknown>[];
+  toDOM: () => [string, number];
+}>();
+
+expectTypeOf(tableRowComplex).toEqualTypeOf<{
+  content: string;
+  parseDOM: Record<string, unknown>[];
+  toDOM: () => [string, number];
+}>();
+
+expectTypeOf(tableCellComplex).toEqualTypeOf<{
+  content: string;
+  attrs: Record<string, unknown>;
+  managed: Record<string, string[]>;
+  isolating: boolean;
+  parseDOM: Record<string, unknown>;
+  toDOM: (node: Node) => [string, unknown, number];
+}>();
+
+expectTypeOf(tableCellComplexBlock).toEqualTypeOf<{
+  content: string;
+  attrs: Record<string, unknown>;
+  managed: Record<string, string[]>;
+  isolating: boolean;
+  parseDOM: Record<string, unknown>;
+  toDOM: (node: Node) => [string, unknown, number];
+}>();
+
+expectTypeOf(tableHeaderComplex).toEqualTypeOf<{
+  content: string;
+  attrs: Record<string, unknown>;
+  managed: Record<string, string[]>;
+  isolating: boolean;
+  parseDOM: Record<string, unknown>;
+  toDOM: (node: Node) => [string, unknown, number];
+}>();
+
+expectTypeOf(tableHeaderComplexBlock).toEqualTypeOf<{
+  content: string;
+  attrs: Record<string, unknown>;
+  managed: Record<string, string[]>;
+  isolating: boolean;
+  parseDOM: Record<string, unknown>;
+  toDOM: (node: Node) => [string, unknown, number];
+}>();

--- a/tests/foundry/common/prosemirror/schema/utils.test-d.ts
+++ b/tests/foundry/common/prosemirror/schema/utils.test-d.ts
@@ -1,0 +1,18 @@
+/* eslint-disable import/extensions */
+import { expectTypeOf } from "vitest";
+import {
+  onlyInlineContent,
+  isElementEmpty,
+  stylesFromString,
+  mergeStyle,
+  classesFromString,
+  mergeClass,
+} from "../../../../../src/foundry/common/prosemirror/schema/utils.mjs";
+
+declare const el: HTMLElement;
+expectTypeOf(onlyInlineContent(el)).toEqualTypeOf<boolean>();
+expectTypeOf(isElementEmpty(el)).toEqualTypeOf<boolean>();
+expectTypeOf(stylesFromString("")).toEqualTypeOf<Record<string, unknown>>();
+expectTypeOf(mergeStyle("", "")).toEqualTypeOf<string>();
+expectTypeOf(classesFromString("")).toEqualTypeOf<string[]>();
+expectTypeOf(mergeClass("", "")).toEqualTypeOf<string>();

--- a/tests/foundry/common/prosemirror/string-serializer.test-d.ts
+++ b/tests/foundry/common/prosemirror/string-serializer.test-d.ts
@@ -1,0 +1,27 @@
+/* eslint-disable import/extensions */
+import { expectTypeOf } from "vitest";
+import StringSerializer, { StringNode } from "../../../../src/foundry/common/prosemirror/string-serializer.mjs";
+import type {
+  ProseMirrorMarkOutput,
+  ProseMirrorNodeOutput,
+} from "../../../../src/foundry/common/prosemirror/string-serializer.mjs";
+import type { Fragment } from "prosemirror-model";
+
+declare const schema: foundry.prosemirror.Schema;
+
+declare const nodes: Record<string, ProseMirrorNodeOutput>;
+declare const marks: Record<string, ProseMirrorMarkOutput>;
+
+const stringSerializer = new StringSerializer(nodes, marks);
+
+declare const fragment: Fragment;
+expectTypeOf(stringSerializer.serializeFragment(fragment)).toEqualTypeOf<StringNode>();
+
+expectTypeOf(StringSerializer.fromSchema(schema)).toEqualTypeOf<StringSerializer>();
+
+const stringNode = new StringNode();
+expectTypeOf(stringNode.tag).toEqualTypeOf<Readonly<string | undefined>>();
+expectTypeOf(stringNode.attrs).toEqualTypeOf<Record<string, string> | undefined>();
+expectTypeOf(stringNode.inline).toEqualTypeOf<boolean>();
+expectTypeOf(stringNode.appendChild(stringNode)).toEqualTypeOf<void>();
+expectTypeOf(stringNode.toString()).toEqualTypeOf<string>();

--- a/tests/foundry/common/prosemirror/util.test-d.ts
+++ b/tests/foundry/common/prosemirror/util.test-d.ts
@@ -1,0 +1,18 @@
+/* eslint-disable import/extensions */
+import { expectTypeOf } from "vitest";
+import {
+  parseHTMLString,
+  serializeHTMLString,
+  transformSlice,
+} from "../../../../src/foundry/common/prosemirror/util.mjs";
+import type { ProseMirrorSliceTransformer } from "../../../../src/foundry/common/prosemirror/util.d.mts";
+import type { Node, Slice } from "prosemirror-model";
+
+declare const node: Node;
+
+expectTypeOf(parseHTMLString("")).toEqualTypeOf<Node>();
+expectTypeOf(serializeHTMLString(node)).toEqualTypeOf<string>();
+
+declare const slice: Slice;
+declare const transformer: ProseMirrorSliceTransformer;
+expectTypeOf(transformSlice(slice, transformer)).toEqualTypeOf<Slice>();


### PR DESCRIPTION
Please pay particular attention to the imports that I changed in /common/prosemirror/_module.d.mts

Those should be classes that are available as properties of both `fo;undry.prosemirror` and `ProseMirror`.  I think I did it correctly (and the tests pass), but just wanted to make sure it wasn't going to break something else.