### PR TITLE
Types and tests for `client/pixi/layers/masks/**`

### DIFF
--- a/src/foundry/client/pixi/layers/masks/depth.d.mts
+++ b/src/foundry/client/pixi/layers/masks/depth.d.mts
@@ -23,16 +23,12 @@ declare global {
      * }
      * ```
      */
-    static override textureConfiguration: {
-      scaleMode: PIXI.SCALE_MODES;
-      format: PIXI.FORMATS;
-      multisample: PIXI.MSAA_QUALITY;
-    };
+    static override textureConfiguration: CachedContainer.TextureConfiguration;
 
     /**
      * @defaultValue `[0, 0, 0, 0]`
      */
-    override clearColor: [r: number, g: number, b: number, a: number];
+    override clearColor: Color.RGBAColorVector;
 
     /**
      * Update the elevation-to-depth mapping?
@@ -59,4 +55,13 @@ declare global {
      */
     clear(): void;
   }
+
+  namespace CanvasDepthMask {
+    interface Any extends AnyCanvasDepthMask {}
+    type AnyConstructor = typeof AnyCanvasDepthMask;
+  }
+}
+
+declare abstract class AnyCanvasDepthMask extends CanvasDepthMask {
+  constructor(arg0: never, ...args: never[]);
 }

--- a/src/foundry/client/pixi/layers/masks/occlusion.d.mts
+++ b/src/foundry/client/pixi/layers/masks/occlusion.d.mts
@@ -1,4 +1,4 @@
-import type { FixedInstanceType } from "fvtt-types/utils";
+export {};
 
 declare global {
   /**
@@ -18,21 +18,18 @@ declare global {
      * }
      * ```
      */
-    static override textureConfiguration: {
-      scaleMode: PIXI.SCALE_MODES;
-      format: PIXI.FORMATS;
-      multisample: PIXI.MSAA_QUALITY;
-    };
+    static override textureConfiguration: CachedContainer.TextureConfiguration;
 
     /**
      * Graphics in which token radial and vision occlusion shapes are drawn.
+     * @remarks The `blendMode` of this `LegacyGraphics` is set to `PIXI>BLEND_MODES.MIN_ALL`
      */
     tokens: PIXI.LegacyGraphics;
 
     /**
      * @defaultValue `[0, 1, 1, 1]`
      */
-    override clearColor: [r: number, g: number, b: number, a: number];
+    override clearColor: Color.RGBAColorVector;
 
     override autoRender: boolean;
 
@@ -40,6 +37,9 @@ declare global {
      * Is vision occlusion active?
      */
     get vision(): boolean;
+
+    /** @remarks No setter is provided */
+    set vision(value: never);
 
     /**
      * Clear the occlusion mask.
@@ -78,14 +78,21 @@ declare global {
      * @param tokens - The set of currently controlled Token objects
      * @returns The PCO objects which should be currently occluded
      */
-    protected _identifyOccludedObjects(
-      tokens: Token.ConfiguredInstance[],
-    ): Set<FixedInstanceType<ReturnType<typeof PrimaryCanvasObjectMixin>>>;
+    protected _identifyOccludedObjects(tokens: Token.ConfiguredInstance[]): Set<PrimaryCanvasObjectMixin.AnyMixed>;
 
     /**
      * @deprecated since v11, will be removed in v13
-     * @remarks `"CanvasOcclusionMask#_identifyOccludedTiles has been deprecated in favor of CanvasOcclusionMask#_identifyOccludedObjects."`
+     * @remarks "CanvasOcclusionMask#_identifyOccludedTiles has been deprecated in favor of CanvasOcclusionMask#_identifyOccludedObjects."
      */
-    _identifyOccludedTiles(): Set<typeof PrimaryCanvasObjectMixin>;
+    _identifyOccludedTiles(): Set<PrimaryCanvasObjectMixin.AnyMixed>;
   }
+
+  namespace CanvasOcclusionMask {
+    interface Any extends AnyCanvasOcclusionMask {}
+    type AnyConstructor = typeof AnyCanvasOcclusionMask;
+  }
+}
+
+declare abstract class AnyCanvasOcclusionMask extends CanvasOcclusionMask {
+  constructor(arg0: never, ...args: never[]);
 }

--- a/src/foundry/client/pixi/layers/masks/vision.d.mts
+++ b/src/foundry/client/pixi/layers/masks/vision.d.mts
@@ -15,16 +15,12 @@ declare global {
      * }
      * ```
      */
-    static override textureConfiguration: {
-      scaleMode: PIXI.SCALE_MODES;
-      format: PIXI.FORMATS;
-      multisample: PIXI.MSAA_QUALITY;
-    };
+    static override textureConfiguration: CachedContainer.TextureConfiguration;
 
     /**
      * @defaultValue `[0, 0, 0, 0]`
      */
-    override clearColor: [r: number, g: number, b: number, a: number];
+    override clearColor: Color.RGBAColorVector;
 
     /**
      * @defaultValue `false`
@@ -41,6 +37,9 @@ declare global {
      * The BlurFilter which applies to the vision mask texture.
      * This filter applies a NORMAL blend mode to the container.
      * @defaultValue `undefined`
+     * @remarks Only `undefined` prior to first draw
+     *
+     * Could be overridden if anything ever set `canvas.blurOptions.blurClass`, but nothing in core does
      */
     blurFilter: AlphaBlurFilter | undefined;
 
@@ -50,7 +49,7 @@ declare global {
      * Initialize the vision mask with the los and the fov graphics objects.
      * @param vision - The vision container to attach
      */
-    attachVision(vision: PIXI.Container): CanvasVisionMask.CanvasVisionContainer;
+    attachVision(vision: CanvasVisionMask.CanvasVisionContainer): CanvasVisionMask.CanvasVisionContainer;
 
     /**
      * Detach the vision mask from the cached container.
@@ -60,7 +59,7 @@ declare global {
 
     /**
      * @deprecated since v11, will be removed in v13
-     * @remarks `"CanvasVisionMask#filter has been renamed to blurFilter."`
+     * @remarks "CanvasVisionMask#filter has been renamed to blurFilter."
      */
     get filter(): this["blurFilter"];
 
@@ -68,12 +67,18 @@ declare global {
   }
 
   namespace CanvasVisionMask {
+    interface Any extends AnyCanvasVisionMask {}
+    type AnyConstructor = typeof AnyCanvasVisionMask;
+
     /**
      * The sight part of {@link CanvasVisionContainer}.
      * The blend mode is MAX_COLOR.
      */
     interface CanvasVisionContainerSight extends PIXI.LegacyGraphics {
-      /** FOV that should not be committed to fog exploration. */
+      /**
+       * FOV that should not be committed to fog exploration.
+       * @remarks `blendMode` set to `PIXI.BLEND_MODES.MAX_COLOR`
+       */
       preview: PIXI.LegacyGraphics;
     }
 
@@ -82,14 +87,56 @@ declare global {
      * The blend mode is MAX_COLOR.
      */
     interface CanvasVisionContainerLight extends PIXI.LegacyGraphics {
-      /** FOV that should not be committed to fog exploration. */
+      /**
+       * FOV that should not be committed to fog exploration.
+       * @remarks `blendMode` set to `PIXI.BLEND_MODES.MAX_COLOR`
+       */
       preview: PIXI.LegacyGraphics;
 
-      /** The sprite with the texture of FOV of cached light sources. */
+      /**
+       * The sprite with the texture of FOV of cached light sources.
+       * @remarks `blendMode` set to `PIXI.BLEND_MODES.MAX_COLOR`
+       */
       cached: SpriteMesh;
 
       /** The light perception polygons of vision sources and the FOV of vision sources that provide vision. */
       mask: PIXI.LegacyGraphics & { preview: PIXI.LegacyGraphics };
+
+      /**
+       * The global light container, which hold darkness level meshes for dynamic illumination
+       */
+      global: PIXI.Container & {
+        /** @remarks `blendMode` set to `PIXI.BLEND_MODES.MAX_COLOR` */
+        source: PIXI.LegacyGraphics;
+
+        meshes: PIXI.Container;
+      };
+
+      /**
+       * The light sources
+       * @remarks `blendMode` set to `PIXI.BLEND_MODES.MAX_COLOR`
+       */
+      sources: PIXI.LegacyGraphics;
+
+      /**
+       * @deprecated since v12, until 14
+       * @remarks "CanvasVisibility#vision#fov#lights is deprecated without replacement."
+       */
+      readonly lights: PIXI.LegacyGraphics;
+
+      /**
+       * @deprecated since v12, until 14
+       * @remarks "CanvasVisibility#vision#fov#lightsSprite is deprecated in favor of CanvasVisibility#vision#light#cached."
+       */
+      readonly lightsSprite: SpriteMesh;
+
+      /**
+       * @deprecated since v12, until 14
+       * @remarks "CanvasVisibility#vision#tokens is deprecated in favor of CanvasVisibility#vision#light."
+       *
+       * The above is [sic], but probably meant to refer to `CanvasVisibility#vision#fov#tokens` as deprecated
+       */
+      readonly tokens: this;
     }
 
     /**
@@ -103,14 +150,49 @@ declare global {
 
     /** The currently visible areas. */
     interface CanvasVisionContainer extends PIXI.Container {
+      /**
+       * @remarks A void filter necessary when commiting fog on a texture for dynamic illumination; disabled by default
+       *
+       * `blendMode` set to `PIXI.BLEND_MODES.MAX_COLOR`
+       */
+      containmentFilter: VoidFilter;
+
       /** Areas visible because of light sources and light perception. */
       light: CanvasVisionContainerLight;
 
-      /** Areas visible because of FOV of vision sources. */
+      /**
+       * Areas visible because of FOV of vision sources.
+       * @remarks `blendMode` set to `PIXI.BLEND_MODES.MAX_COLOR`
+       */
       sight: CanvasVisionContainerSight;
 
-      /** Areas erased by darkness sources. */
+      /**
+       * Areas erased by darkness sources.
+       * @remarks `blendMode` set to `PIXI.BLEND_MODES.ERASE`
+       */
       darkness: CanvasVisionContainerDarkness;
+
+      /**
+       * @deprecated since v12, until 14
+       * @remarks "CanvasVisibility#vision#base is deprecated in favor of CanvasVisibility#vision#light#preview."
+       */
+      readonly base: CanvasVisionContainerLight["preview"];
+
+      /**
+       * @deprecated since v12, until 14
+       * @remarks "CanvasVisibility#vision#fov is deprecated in favor of CanvasVisibility#vision#light."
+       */
+      readonly fov: CanvasVisionContainerLight;
+
+      /**
+       * @deprecated since v12, until 14
+       * @remarks "CanvasVisibility#vision#los is deprecated in favor of CanvasVisibility#vision#light#mask."
+       */
+      readonly los: CanvasVisionContainerLight["mask"];
     }
   }
+}
+
+declare abstract class AnyCanvasVisionMask extends CanvasVisionMask {
+  constructor(arg0: never, ...args: never[]);
 }

--- a/tests/foundry/client/pixi/layers/masks/depth.test-d.ts
+++ b/tests/foundry/client/pixi/layers/masks/depth.test-d.ts
@@ -1,9 +1,13 @@
 import { expectTypeOf } from "vitest";
 
-const mySprite = new SpriteMesh();
+expectTypeOf(CanvasDepthMask.textureConfiguration).toEqualTypeOf<CachedContainer.TextureConfiguration>();
 
+const mySprite = new SpriteMesh();
 const myDepthMask = new CanvasDepthMask(mySprite);
 
-expectTypeOf(myDepthMask.createRenderTexture()).toEqualTypeOf<PIXI.RenderTexture>();
-
-expectTypeOf(myDepthMask.clearColor[3]).toEqualTypeOf<number>();
+expectTypeOf(myDepthMask.roofs).toEqualTypeOf<PIXI.Container>();
+expectTypeOf(myDepthMask.clearColor).toEqualTypeOf<Color.RGBAColorVector>();
+expectTypeOf(myDepthMask["_elevationDirty"]).toBeBoolean();
+expectTypeOf(myDepthMask.mapElevation(5)).toBeNumber();
+expectTypeOf(myDepthMask["_update"]()).toBeVoid();
+expectTypeOf(myDepthMask.clear()).toBeVoid();

--- a/tests/foundry/client/pixi/layers/masks/occlusion.test-d.ts
+++ b/tests/foundry/client/pixi/layers/masks/occlusion.test-d.ts
@@ -1,9 +1,23 @@
 import { expectTypeOf } from "vitest";
 
-const mySprite = new SpriteMesh();
+expectTypeOf(CanvasOcclusionMask.textureConfiguration).toEqualTypeOf<CachedContainer.TextureConfiguration>();
 
+const mySprite = new SpriteMesh();
 const myOcclusionMask = new CanvasOcclusionMask(mySprite);
 
-expectTypeOf(myOcclusionMask.createRenderTexture()).toEqualTypeOf<PIXI.RenderTexture>();
+expectTypeOf(myOcclusionMask.tokens).toEqualTypeOf<PIXI.LegacyGraphics>();
+expectTypeOf(myOcclusionMask.clearColor).toEqualTypeOf<Color.RGBAColorVector>();
+expectTypeOf(myOcclusionMask.autoRender).toBeBoolean();
+expectTypeOf(myOcclusionMask.vision).toBeBoolean();
+//@ts-expect-error No setter is provided for `vision`
+myOcclusionMask.vision = false;
+expectTypeOf(myOcclusionMask.clear()).toBeVoid();
+expectTypeOf(myOcclusionMask.mapElevation(20)).toBeNumber();
+expectTypeOf(myOcclusionMask.updateOcclusion()).toBeVoid();
+expectTypeOf(myOcclusionMask["_updateOcclusionMask"]()).toBeVoid();
+expectTypeOf(myOcclusionMask["_updateOcclusionStates"]()).toBeVoid();
+declare const someTokens: Token.ConfiguredInstance[];
+expectTypeOf(myOcclusionMask["_identifyOccludedObjects"](someTokens));
 
-expectTypeOf(myOcclusionMask.clearColor[3]).toEqualTypeOf<number>();
+//deprecated since v11 until v13
+expectTypeOf(myOcclusionMask._identifyOccludedTiles()).toEqualTypeOf<Set<PrimaryCanvasObjectMixin.AnyMixed>>();

--- a/tests/foundry/client/pixi/layers/masks/vision.test-d.ts
+++ b/tests/foundry/client/pixi/layers/masks/vision.test-d.ts
@@ -1,13 +1,35 @@
 import { expectTypeOf } from "vitest";
 
-const mySprite = new SpriteMesh();
+expectTypeOf(CanvasVisionMask.textureConfiguration).toEqualTypeOf<CachedContainer.TextureConfiguration>();
 
+const mySprite = new SpriteMesh();
 const myVisionMask = new CanvasVisionMask(mySprite);
 
-const myVisionContainer = new PIXI.Container();
+expectTypeOf(myVisionMask.clearColor).toEqualTypeOf<Color.RGBAColorVector>();
+expectTypeOf(myVisionMask.autoRender).toBeBoolean();
+expectTypeOf(myVisionMask.vision).toEqualTypeOf<CanvasVisionMask.CanvasVisionContainer | undefined>();
+const vis = myVisionMask.vision;
+if (vis) {
+  expectTypeOf(vis.containmentFilter).toEqualTypeOf<VoidFilter>();
+  expectTypeOf(vis.sight.preview).toEqualTypeOf<PIXI.LegacyGraphics>();
+  expectTypeOf(vis.darkness.darkness).toEqualTypeOf<PIXI.LegacyGraphics>();
+  expectTypeOf(vis.light.global.meshes).toEqualTypeOf<PIXI.Container>();
+  //deprecated since v12 until v14
+  expectTypeOf(vis.light.tokens.tokens.tokens.tokens).toEqualTypeOf<typeof vis.light>();
+  expectTypeOf(vis.base).toEqualTypeOf<typeof vis.light.preview>();
+  expectTypeOf(vis.fov).toEqualTypeOf<typeof vis.light>();
+  expectTypeOf(vis.los).toEqualTypeOf<typeof vis.light.mask>();
+}
 
-expectTypeOf(myVisionMask.createRenderTexture()).toEqualTypeOf<PIXI.RenderTexture>();
+expectTypeOf(myVisionMask.blurFilter).toEqualTypeOf<AlphaBlurFilter | undefined>();
 
-expectTypeOf(myVisionMask.clearColor[3]).toEqualTypeOf<number>();
+expectTypeOf(myVisionMask.draw()).toEqualTypeOf<Promise<void>>();
 
-expectTypeOf(myVisionMask.attachVision(myVisionContainer)).toEqualTypeOf<CanvasVisionContainer>();
+declare const someVisionContainer: CanvasVisionMask.CanvasVisionContainer;
+expectTypeOf(myVisionMask.attachVision(someVisionContainer)).toEqualTypeOf<CanvasVisionMask.CanvasVisionContainer>();
+expectTypeOf(myVisionMask.detachVision()).toEqualTypeOf<CanvasVisionMask.CanvasVisionContainer>();
+
+//deprecated since v11, until v13
+expectTypeOf(myVisionMask.filter).toEqualTypeOf<AlphaBlurFilter | undefined>();
+declare const someBlurFilter: AlphaBlurFilter;
+myVisionMask.filter = someBlurFilter;


### PR DESCRIPTION
cut out of larger PR