### PR TITLE
Rename or remove a couple canvas/pixi types

### DIFF
--- a/src/foundry/client-esm/canvas/regions/mesh.d.mts
+++ b/src/foundry/client-esm/canvas/regions/mesh.d.mts
@@ -55,7 +55,7 @@ declare class RegionMesh extends PIXI.Container {
   /** Tests if a point is indie this RegionMesh */
   containsPoint(point: PIXI.IPointData): boolean;
 
-  override destroy(options?: PIXI.DisplayObject.DestroyOptions): void;
+  override destroy(options?: PIXI.IDestroyOptions | boolean): void;
 }
 
 export default RegionMesh;

--- a/src/foundry/client/pixi/board.d.mts
+++ b/src/foundry/client/pixi/board.d.mts
@@ -781,7 +781,13 @@ declare global {
      */
     type PointArray = [x: number, y: number];
 
-    type PairOfPointsArray = [x0: number, y0: number, x1: number, y1: number];
+    /**
+     * @privateRemarks Alias of `Canvas.PointArray`, as that name, while accurate to Foundry's types,
+     * could easily be inferred to mean incorrect things (`[{x,y}, {x,y}]` for example)
+     * */
+    type PointTuple = PointArray;
+
+    type PairOfPointsTuple = [x0: number, y0: number, x1: number, y1: number];
 
     /**
      * A standard rectangle interface.

--- a/src/foundry/client/pixi/core/shapes/ray.d.mts
+++ b/src/foundry/client/pixi/core/shapes/ray.d.mts
@@ -119,7 +119,7 @@ declare global {
      * @param B - The destination point [x,y]
      * @returns The constructed Ray instance
      */
-    static fromArrays(A: Canvas.PointArray, B: Canvas.PointArray): Ray;
+    static fromArrays(A: Canvas.PointTuple, B: Canvas.PointTuple): Ray;
 
     /**
      * Project the Array by some proportion of it's initial distance.
@@ -169,7 +169,7 @@ declare global {
      * Find the point I[x,y] and distance t* on ray R(t) which intersects another ray
      * @see foundry.utils.lineLineIntersection
      */
-    intersectSegment(coords: Canvas.PairOfPointsArray): LineIntersection | null;
+    intersectSegment(coords: Canvas.PairOfPointsTuple): LineIntersection | null;
   }
 
   namespace Ray {

--- a/src/foundry/client/pixi/layers/controls/cursor.d.mts
+++ b/src/foundry/client/pixi/layers/controls/cursor.d.mts
@@ -28,6 +28,6 @@ declare global {
      */
     protected _animate(): void;
 
-    override destroy(options?: PIXI.DisplayObject.DestroyOptions): void;
+    override destroy(options?: PIXI.IDestroyOptions | boolean): void;
   }
 }

--- a/src/foundry/client/pixi/layers/effects/weather/particles/effect.d.mts
+++ b/src/foundry/client/pixi/layers/effects/weather/particles/effect.d.mts
@@ -32,7 +32,7 @@ declare global {
      */
     getParticleEmitters(options: PIXI.particles.EmitterConfigV3): PIXI.particles.Emitter[];
 
-    override destroy(options?: PIXI.DisplayObject.DestroyOptions): void;
+    override destroy(options?: PIXI.IDestroyOptions | boolean): void;
 
     /**
      * Begin animation for the configured emitters.

--- a/src/foundry/client/pixi/layers/grid/highlight.d.mts
+++ b/src/foundry/client/pixi/layers/grid/highlight.d.mts
@@ -28,6 +28,6 @@ declare global {
     override clear(): this;
 
     /** @privateRemarks Foundry handles this by passing `(...args)` directly to super, but it only takes the one */
-    override destroy(options?: PIXI.DisplayObject.DestroyOptions): void;
+    override destroy(options?: PIXI.IDestroyOptions | boolean): void;
   }
 }

--- a/src/foundry/client/pixi/layers/grid/layer.d.mts
+++ b/src/foundry/client/pixi/layers/grid/layer.d.mts
@@ -153,13 +153,13 @@ declare global {
      * @deprecated since v12, will be removed in v14
      * @remarks `"GridLayer#getTopLeft is deprecated. Use canvas.grid.getTopLeftPoint instead."`
      */
-    getTopLeft(x: number, y: number): Canvas.PointArray;
+    getTopLeft(x: number, y: number): Canvas.PointTuple;
 
     /**
      * @deprecated since v12, will be removed in v14
      * @remarks `"GridLayer#getCenter is deprecated. Use canvas.grid.getCenterPoint instead."`
      */
-    getCenter(x: number, y: number): Canvas.PointArray;
+    getCenter(x: number, y: number): Canvas.PointTuple;
 
     /**
      * @deprecated since v12, will be removed in v14

--- a/src/foundry/client/pixi/layers/placeables/walls.d.mts
+++ b/src/foundry/client/pixi/layers/placeables/walls.d.mts
@@ -38,7 +38,7 @@ declare global {
      * ```
      */
     protected last: {
-      point: Canvas.PointArray | null;
+      point: Canvas.PointTuple | null;
     };
 
     /**
@@ -84,7 +84,7 @@ declare global {
      * @param wall  - The existing Wall object being chained to
      * @returns The [x,y] coordinates of the starting endpoint
      */
-    static getClosestEndpoint(point: Canvas.Point, wall: Wall.ConfiguredInstance): Canvas.PointArray;
+    static getClosestEndpoint(point: Canvas.Point, wall: Wall.ConfiguredInstance): Canvas.PointTuple;
 
     override releaseAll(options?: PlaceableObject.ReleaseOptions): number;
 
@@ -116,7 +116,7 @@ declare global {
          */
         snap: boolean;
       }>,
-    ): Canvas.PointArray;
+    ): Canvas.PointTuple;
 
     /**
      * The Scene Controls tools provide several different types of prototypical Walls to choose from

--- a/src/foundry/client/pixi/placeables/wall.d.mts
+++ b/src/foundry/client/pixi/placeables/wall.d.mts
@@ -126,7 +126,7 @@ declare global {
     /**
      * Return the coordinates [x,y] at the midpoint of the wall segment
      */
-    get midpoint(): Canvas.PointArray;
+    get midpoint(): Canvas.PointTuple;
 
     override get center(): PIXI.Point;
 

--- a/src/foundry/common/grid/base.d.mts
+++ b/src/foundry/common/grid/base.d.mts
@@ -290,7 +290,7 @@ declare abstract class BaseGrid {
    * @returns An Array [x, y] of the top-left coordinate of the square which contains (x, y)
    * @deprecated Since v12 until v14. Use {@link BaseGrid#getTopLeftPoint} instead.
    */
-  getTopLeft(x: number, y: number): Canvas.PointArray;
+  getTopLeft(x: number, y: number): Canvas.PointTuple;
 
   /**
    * Given a pair of coordinates (x, y), return the center of the grid square which contains that point
@@ -299,7 +299,7 @@ declare abstract class BaseGrid {
    * @returns An array [cx, cy] of the central point of the grid space which contains (x, y)
    * @deprecated Since v12 until v14. Use {@link BaseGrid#getCenterPoint} instead.
    */
-  getCenter(x: number, y: number): Canvas.PointArray;
+  getCenter(x: number, y: number): Canvas.PointTuple;
 
   /**
    * Get the grid row and column positions which are neighbors of a certain position
@@ -308,7 +308,7 @@ declare abstract class BaseGrid {
    * @returns An array of grid positions which are neighbors of the row and column
    * @deprecated Since v12 until v14. Use {@link BaseGrid#getAdjacentOffsets} instead.
    */
-  getNeighbors(row: number, col: number): Canvas.PointArray[];
+  getNeighbors(row: number, col: number): Canvas.PointTuple[];
 
   /**
    * Given a pair of pixel coordinates, return the grid position as an Array.
@@ -318,7 +318,7 @@ declare abstract class BaseGrid {
    * @returns An array representing the position in grid units
    * @deprecated Since v12 until v14. Use {@link BaseGrid#getOffset} instead.
    */
-  getGridPositionFromPixels(x: number, y: number): Canvas.PointArray;
+  getGridPositionFromPixels(x: number, y: number): Canvas.PointTuple;
 
   /* -------------------------------------------- */
 
@@ -330,7 +330,7 @@ declare abstract class BaseGrid {
    * @returns An array representing the position in pixels
    * @deprecated Since v12 until v14. Use {@link BaseGrid#getTopLeftPoint} instead.
    */
-  getPixelsFromGridPosition(x: number, y: number): Canvas.PointArray;
+  getPixelsFromGridPosition(x: number, y: number): Canvas.PointTuple;
 
   /* -------------------------------------------- */
 
@@ -354,7 +354,7 @@ declare abstract class BaseGrid {
        */
       token: Token;
     }>,
-  ): Canvas.PointArray;
+  ): Canvas.PointTuple;
 
   /* -------------------------------------------- */
 

--- a/src/foundry/common/grid/hexagonal.d.mts
+++ b/src/foundry/common/grid/hexagonal.d.mts
@@ -170,7 +170,7 @@ declare class HexagonalGrid extends BaseGrid {
    * Special border polygons for different token sizes.
    * @deprecated Since v12 until v14. No Replacement
    */
-  static get POINTY_HEX_BORDERS(): Record<number, Canvas.PointArray[]>;
+  static get POINTY_HEX_BORDERS(): Record<number, Canvas.PointTuple[]>;
 
   /**
    * @deprecated Since v12 until v14. No Replacement
@@ -181,25 +181,25 @@ declare class HexagonalGrid extends BaseGrid {
    * Special border polygons for different token sizes.
    * @deprecated Since v12 until v14. No Replacement
    */
-  static get FLAT_HEX_BORDERS(): Record<number, Canvas.PointArray[]>;
+  static get FLAT_HEX_BORDERS(): Record<number, Canvas.PointTuple[]>;
 
   /**
    * A matrix of x and y offsets which is multiplied by the width/height vector to get pointy-top polygon coordinates
    * @deprecated Since v12 until v14. No Replacement
    */
-  static get pointyHexPoints(): Canvas.PointArray[];
+  static get pointyHexPoints(): Canvas.PointTuple[];
 
   /**
    * A matrix of x and y offsets which is multiplied by the width/height vector to get flat-top polygon coordinates
    * @deprecated Since v12 until v14. No Replacement
    */
-  static get flatHexPoints(): Canvas.PointArray[];
+  static get flatHexPoints(): Canvas.PointTuple[];
 
   /**
    * An array of the points which define a hexagon for this grid shape
    * @deprecated Since v12 until v14. No Replacement
    */
-  get hexPoints(): Canvas.PointArray[];
+  get hexPoints(): Canvas.PointTuple[];
 
   /**
    * A convenience method for getting all the polygon points relative to a top-left [x,y] coordinate pair
@@ -211,12 +211,12 @@ declare class HexagonalGrid extends BaseGrid {
    * @deprecated Since v12 until v14. You can get the shape of the hex with {@link HexagonalGrid#getShape}
    *             and the polygon with {@link HexagonalGrid#getVertices}.
    */
-  getPolygon(x: number, y: number, w?: number, h?: number, points?: Canvas.PointArray[]): Canvas.PointArray[];
+  getPolygon(x: number, y: number, w?: number, h?: number, points?: Canvas.PointTuple[]): Canvas.PointTuple[];
 
   /**
    * @deprecated Since v12 until v14. If you need the shape of a Token, use {@link Token#getShape} instead.
    */
-  getBorderPolygon(w: number, h: number, p: number): Canvas.PointArray[];
+  getBorderPolygon(w: number, h: number, p: number): Canvas.PointTuple[];
 
   /**
    * @deprecated Since v12 until v14. If you need the size of a Token, use {@link Token#getSize} instead.

--- a/src/types/augments/pixi.d.mts
+++ b/src/types/augments/pixi.d.mts
@@ -995,8 +995,6 @@ declare global {
     namespace DisplayObject {
       interface Any extends AnyPIXIDisplayObject {}
       type AnyConstructor = typeof AnyPIXIDisplayObject;
-
-      type DestroyOptions = _PIXI.IDestroyOptions | boolean;
     }
 
     export import Filter = _PIXI.Filter;


### PR DESCRIPTION
`PIXI.DisplayObject.DestroyOptions` is unnecessary

My issues with `PointArray` are covered in the associated comment.