### PR TITLE
Implemented CategoryBrowser for v13.342

### DIFF
--- a/src/foundry/client-esm/applications/settings/config.d.mts
+++ b/src/foundry/client-esm/applications/settings/config.d.mts
@@ -1,4 +1,3 @@
-import type ApplicationV2 from "../api/application.d.mts";
 import type CategoryBrowser from "../api/category-browser.d.mts";
 import type HandlebarsApplicationMixin from "../api/handlebars-application.d.mts";
 
@@ -8,14 +7,29 @@ import type HandlebarsApplicationMixin from "../api/handlebars-application.d.mts
  * @privateRemarks TODO: Stub
  */
 declare class SettingsConfig<
-  RenderContext extends SettingsConfig.RenderContext = SettingsConfig.RenderContext,
+  Entry extends SettingsConfig.Entry = SettingsConfig.Entry,
+  RenderContext extends SettingsConfig.RenderContext<Entry> = SettingsConfig.RenderContext<Entry>,
   Configuration extends CategoryBrowser.Configuration = CategoryBrowser.Configuration,
   RenderOptions extends
     HandlebarsApplicationMixin.ApplicationV2RenderOptions = HandlebarsApplicationMixin.ApplicationV2RenderOptions,
-> extends CategoryBrowser<RenderContext, Configuration, RenderOptions> {}
+> extends CategoryBrowser<Entry, RenderContext, Configuration, RenderOptions> {
+  protected _prepareCategoryData(): Promise<Record<string, CategoryBrowser.CategoryData<Entry>>>;
+}
 
 declare namespace SettingsConfig {
-  interface RenderContext extends ApplicationV2.RenderContext {}
+  // There's a split here between field and menu entries that could/should probably be resolved by a union
+  interface Entry {
+    key?: string;
+    icon?: string;
+    label: string;
+    hint?: string;
+    menu: boolean;
+    buttonText?: string;
+    value?: unknown;
+    field?: foundry.data.fields.DataField.Any;
+  }
+
+  interface RenderContext<Entry> extends CategoryBrowser.RenderContext<Entry> {}
 }
 
 export default SettingsConfig;

--- a/src/foundry/client-esm/applications/settings/menus/default-sheets-config.d.mts
+++ b/src/foundry/client-esm/applications/settings/menus/default-sheets-config.d.mts
@@ -1,19 +1,28 @@
+import type { StringField } from "#common/data/fields.mjs";
 import type CategoryBrowser from "../../api/category-browser.d.mts";
-import type ApplicationV2 from "../../api/application.d.mts";
 import type HandlebarsApplicationMixin from "../../api/handlebars-application.d.mts";
 
 /**
  * @remarks TODO: Stub
  */
 declare class DefaultSheetsConfig<
-  RenderContext extends DefaultSheetsConfig.RenderContext = DefaultSheetsConfig.RenderContext,
+  Entry extends DefaultSheetsConfig.Entry = DefaultSheetsConfig.Entry,
+  RenderContext extends DefaultSheetsConfig.RenderContext<Entry> = DefaultSheetsConfig.RenderContext<Entry>,
   Configuration extends CategoryBrowser.Configuration = CategoryBrowser.Configuration,
   RenderOptions extends
     HandlebarsApplicationMixin.ApplicationV2RenderOptions = HandlebarsApplicationMixin.ApplicationV2RenderOptions,
-> extends CategoryBrowser<RenderContext, Configuration, RenderOptions> {}
+> extends CategoryBrowser<Entry, RenderContext, Configuration, RenderOptions> {
+  protected override _prepareCategoryData(): Promise<Record<string, CategoryBrowser.CategoryData<Entry>>>;
+}
 
 declare namespace DefaultSheetsConfig {
-  interface RenderContext extends ApplicationV2.RenderContext {}
+  interface Entry {
+    field: StringField;
+    choices: Record<string, string>;
+    value: string;
+  }
+
+  interface RenderContext<Entry> extends CategoryBrowser.RenderContext<Entry> {}
 }
 
 export default DefaultSheetsConfig;

--- a/src/foundry/client-esm/applications/sidebar/apps/controls-config.d.mts
+++ b/src/foundry/client-esm/applications/sidebar/apps/controls-config.d.mts
@@ -1,5 +1,4 @@
 import type CategoryBrowser from "../../api/category-browser.d.mts";
-import type ApplicationV2 from "../../api/application.d.mts";
 import type HandlebarsApplicationMixin from "../../api/handlebars-application.d.mts";
 
 /**
@@ -7,14 +6,22 @@ import type HandlebarsApplicationMixin from "../../api/handlebars-application.d.
  * @remarks TODO: Stub
  */
 declare class ControlsConfig<
-  RenderContext extends ControlsConfig.RenderContext = ControlsConfig.RenderContext,
+  Entry extends ControlsConfig.Entry = ControlsConfig.Entry,
+  RenderContext extends ControlsConfig.RenderContext<Entry> = ControlsConfig.RenderContext<Entry>,
   Configuration extends CategoryBrowser.Configuration = CategoryBrowser.Configuration,
   RenderOptions extends
     HandlebarsApplicationMixin.ApplicationV2RenderOptions = HandlebarsApplicationMixin.ApplicationV2RenderOptions,
-> extends CategoryBrowser<RenderContext, Configuration, RenderOptions> {}
+> extends CategoryBrowser<Entry, RenderContext, Configuration, RenderOptions> {
+  protected _prepareCategoryData(): Promise<Record<string, CategoryBrowser.CategoryData<Entry>>>;
+}
 
 declare namespace ControlsConfig {
-  interface RenderContext extends ApplicationV2.RenderContext {}
+  // TODO: Interface is a stub
+  interface Entry {
+    id: string;
+  }
+
+  interface RenderContext<Entry> extends CategoryBrowser.RenderContext<Entry> {}
 }
 
 export default ControlsConfig;

--- a/src/foundry/client-esm/applications/sidebar/apps/tours-management.d.mts
+++ b/src/foundry/client-esm/applications/sidebar/apps/tours-management.d.mts
@@ -1,5 +1,4 @@
 import type CategoryBrowser from "../../api/category-browser.d.mts";
-import type ApplicationV2 from "../../api/application.d.mts";
 import type HandlebarsApplicationMixin from "../../api/handlebars-application.d.mts";
 
 /**
@@ -7,14 +6,21 @@ import type HandlebarsApplicationMixin from "../../api/handlebars-application.d.
  * @remarks TODO: Stub
  */
 declare class ToursManagement<
-  RenderContext extends ToursManagement.RenderContext = ToursManagement.RenderContext,
+  Entry extends ToursManagement.Entry = ToursManagement.Entry,
+  RenderContext extends ToursManagement.RenderContext<Entry> = ToursManagement.RenderContext<Entry>,
   Configuration extends CategoryBrowser.Configuration = CategoryBrowser.Configuration,
   RenderOptions extends
     HandlebarsApplicationMixin.ApplicationV2RenderOptions = HandlebarsApplicationMixin.ApplicationV2RenderOptions,
-> extends CategoryBrowser<RenderContext, Configuration, RenderOptions> {}
+> extends CategoryBrowser<Entry, RenderContext, Configuration, RenderOptions> {
+  protected _prepareCategoryData(): Promise<Record<string, CategoryBrowser.CategoryData<Entry>>>;
+}
 
 declare namespace ToursManagement {
-  interface RenderContext extends ApplicationV2.RenderContext {}
+  interface Entry {
+    id: string;
+  }
+
+  interface RenderContext<Entry> extends CategoryBrowser.RenderContext<Entry> {}
 }
 
 export default ToursManagement;


### PR DESCRIPTION
Implemented CategoryBrowser as an abstract class, with bare minimum for its subclasses. End users are fairly unlikely to use the subclasses but may want to implement/use CategoryBrowser itself.