### PR TITLE
Updated TokenRuler to 13.346

### DIFF
--- a/src/foundry/client/_types.d.mts
+++ b/src/foundry/client/_types.d.mts
@@ -13,8 +13,6 @@ type HotReloadData = Hooks.HotReloadData;
 
 type RulerWaypoint = unknown;
 
-type GridMeasurePathResultWaypoint = unknown;
-
 type TokenFindMovementPathWaypoint = unknown;
 
 type TokenConstrainMovementPathWaypoint = unknown;

--- a/src/foundry/client/_types.d.mts
+++ b/src/foundry/client/_types.d.mts
@@ -9,7 +9,7 @@
 // eslint-disable-next-line import-x/export
 export * from "#common/_types.mjs";
 
-type HotReloadData = unknown;
+type HotReloadData = Hooks.HotReloadData;
 
 type RulerWaypoint = unknown;
 
@@ -29,13 +29,13 @@ type TokenGEtTerrainMovementPathWaypoint = unknown;
 
 type TokenTerrainMovementWaypoint = unknown;
 
-type TokenRulerData = unknown;
+type TokenRulerData = foundry.canvas.placeables.tokens.TokenRuler.Data;
 
 type TokenPlannedMovement = unknown;
 
-type TokenRulerWaypointData = unknown;
+type TokenRulerWaypointData = foundry.canvas.placeables.tokens.TokenRuler.WaypointData;
 
-type TokenRulerWaypoint = unknown;
+type TokenRulerWaypoint = foundry.canvas.placeables.tokens.TokenRuler.Waypoint;
 
 type TokenDragContext = unknown;
 

--- a/src/foundry/client/canvas/placeables/tokens/base-ruler.d.mts
+++ b/src/foundry/client/canvas/placeables/tokens/base-ruler.d.mts
@@ -1,7 +1,68 @@
 import type { Identity } from "#utils";
 
-declare class BaseTokenRuler {
+/**
+ * The ruler of a Token visualizes
+ *   - the movement history of the Token,
+ *   - the movement path the Token currently animating along, and
+ *   - the planned movement path while the Token is being dragged.
+ */
+declare abstract class BaseTokenRuler {
   #BaseTokenRuler: true;
+
+  /**
+   *
+   * @param token - The Token that this ruler belongs to
+   */
+  constructor(token: foundry.canvas.placeables.Token.Implementation);
+
+  /**
+   * The reference to the Token this ruler belongs to.
+   */
+  get token(): foundry.canvas.placeables.Token.Implementation;
+
+  /**
+   * Is the ruler visible?
+   * @defaultValue `false`
+   */
+  get visible(): boolean;
+
+  set visible(value);
+
+  /**
+   * Called when the ruler becomes visible or invisible.
+   */
+  protected abstract _onVisibleChange(): void;
+
+  /**
+   * Is the ruler supposed to be visible?
+   * {@link BaseTokenRuler#visible} is set to {@link BaseTokenRuler#isVisible} in
+   * {@link foundry.canvas.placeables.Token#_refreshState}.
+   */
+  get isVisible(): boolean;
+
+  /**
+   * Draw the ruler.
+   * Called in {@link foundry.canvas.placeables.Token#_draw}.
+   */
+  abstract draw(): Promise<void>;
+
+  /**
+   * Clear the ruler.
+   * Called in {@link foundry.canvas.placeables.Token#clear}.
+   */
+  abstract clear(): void;
+
+  /**
+   * Destroy the ruler.
+   * Called in {@link foundry.canvas.placeables.Token#_destroy}.
+   */
+  abstract destroy(): void;
+
+  /**
+   * Refresh the ruler.
+   * Called in {@link foundry.canvas.placeables.Token#_refreshRuler}.
+   */
+  abstract refresh(rulerData: unknown): void;
 }
 
 declare namespace BaseTokenRuler {

--- a/src/foundry/client/canvas/placeables/tokens/ruler.d.mts
+++ b/src/foundry/client/canvas/placeables/tokens/ruler.d.mts
@@ -132,7 +132,7 @@ declare namespace TokenRuler {
     ray: foundry.canvas.geometry.Ray | null;
 
     /** The measurements at this waypoint. */
-    measurement: unknown; // TODO: GridMeasurePathResultWaypoint
+    measurement: foundry.grid.BaseGrid.MeasurePathResultWaypoint; // TODO: GridMeasurePathResultWaypoint
 
     /** The previous waypoint, if any. */
     previous: Waypoint | null;
@@ -141,7 +141,7 @@ declare namespace TokenRuler {
     next: Waypoint | null;
   }
 
-  type Waypoint = DeepReadonly<Omit<TokenDocument.MovementWaypoint, "movementId"> & WaypointData>;
+  type Waypoint = DeepReadonly<Omit<TokenDocument.MeasuredMovementWaypoint, "movementId"> & WaypointData>;
 
   /**
    * @remarks Intended to be extended by subclasses that need to track additional info between waypoints

--- a/src/foundry/client/canvas/placeables/tokens/ruler.d.mts
+++ b/src/foundry/client/canvas/placeables/tokens/ruler.d.mts
@@ -1,13 +1,211 @@
-import type { Identity } from "#utils";
+import type { DeepReadonly, Identity } from "#utils";
 import type { BaseTokenRuler } from "./_module.d.mts";
 
 declare class TokenRuler extends BaseTokenRuler {
   #TokenRuler: true;
+
+  /**
+   * A handlebars template used to render each waypoint label.
+   */
+  static WAYPOINT_LABEL_TEMPLATE: string;
+
+  protected override _onVisibleChange(): void;
+
+  /**
+   * Configure the properties of the outline.
+   * Called in {@link TokenRuler#draw}.
+   * @returns The thickness in pixels and the color
+   */
+  protected _configureOutline(): TokenRuler.Outline;
+
+  /**
+   * Configure the properties of the dash line.
+   * Called in {@link TokenRuler#draw}.
+   * @returns The dash in pixels, the gap in pixels, and the speed in pixels per second
+   */
+  protected _configureDashLine(): TokenRuler.DashLine;
+
+  draw(): Promise<void>;
+
+  clear(): void;
+
+  destroy(): void;
+
+  refresh(rulerData: TokenRuler.Data): void;
+
+  /**
+   * Get the context used to render a ruler waypoint label.
+   */
+  protected _getWaypointLabelContext(
+    waypoint: TokenRuler.Waypoint,
+    state: TokenRuler.State,
+  ): TokenRuler.WaypointContext | void;
+
+  /**
+   * Get the style of the waypoint at the given waypoint.
+   * @param waypoint - The waypoint
+   * @returns  The radius, color, and alpha of the waypoint. If the radius is 0, no waypoint marker is drawn.
+   */
+  protected _getWaypointStyle(waypoint: TokenRuler.Waypoint): TokenRuler.WaypointStyle;
+
+  /**
+   * Get the style of the segment from the previous to the given waypoint.
+   * @param waypoint - The waypoint
+   * @returns The line width, color, and alpha of the segment.  If the width is 0, no segment is drawn.
+   */
+  protected _getSegmentStyle(waypoint: TokenRuler.Waypoint): TokenRuler.SegmentStyle;
+
+  /**
+   * Get the style to be used to highlight the grid offset.
+   * @param waypoint - The waypoint
+   * @param offset - An occupied grid offset at the given waypoint that is to be highlighted
+   * @returns The color, alpha, texture, and texture matrix to be used to draw the grid space.
+   *          If the alpha is 0, the grid space is not highlighted.
+   */
+  protected _getGridHighlightStyle(
+    waypoint: TokenRuler.Waypoint,
+    offset: DeepReadonly<foundry.grid.BaseGrid.Offset3D>,
+  ): TokenRuler.GridHighlightStyle;
 }
 
 declare namespace TokenRuler {
   interface Any extends AnyTokenRuler {}
   interface AnyConstructor extends Identity<typeof AnyTokenRuler> {}
+
+  interface Outline {
+    thickness: number;
+    color: PIXI.ColorSource;
+  }
+
+  interface DashLine {
+    dash: number;
+    gap: number;
+    speed: number;
+  }
+
+  interface Data {
+    /**
+     * The waypoints that were already passed by the Token
+     */
+    passedWaypoints: unknown[]; // TODO: Token.MeasuredMovementWaypoint
+
+    /**
+     * The waypoints that the Token will try move to next
+     */
+    pendingWaypoints: unknown[]; // TODO: Token.MeasuredMovementWaypoint
+
+    /**
+     * Movement planned by Users
+     */
+    plannedMovement: Record<string, unknown>; // TODO: Token.PlannedMovement
+  }
+
+  interface WaypointData {
+    /** The config of the movement action */
+    actionConfig: CONFIG.Token.MovementActionConfig;
+
+    /** The ID of movement, or null if planned movement. */
+    movementId: string | null;
+
+    /** The index of the waypoint, which is equal to the number of explicit waypoints from the first to this waypoint. */
+    index: number;
+
+    /** The stage this waypoint belongs to */
+    stage: "passed" | "pending" | "planned";
+
+    /** Is this waypoint hidden? */
+    hidden: boolean;
+
+    /** Is this waypoint unreachable? */
+    unreachable: boolean;
+
+    /** The center point of the Token at this waypoint. */
+    center: PIXI.Point;
+
+    /** The size of the Token in pixels at this waypoint. */
+    size: {
+      width: number;
+      height: number;
+    };
+
+    /** The ray from the center point of previous to the center point of this waypoint, or null if there is no previous waypoint. */
+    ray: foundry.canvas.geometry.Ray | null;
+
+    /** The measurements at this waypoint. */
+    measurement: unknown; // TODO: GridMeasurePathResultWaypoint
+
+    /** The previous waypoint, if any. */
+    previous: Waypoint | null;
+
+    /** The next waypoint, if any. */
+    next: Waypoint | null;
+  }
+
+  type Waypoint = DeepReadonly<Omit<TokenDocument.MovementWaypoint, "movementId"> & WaypointData>;
+
+  /**
+   * @remarks Intended to be extended by subclasses that need to track additional info between waypoints
+   * Importantly, this is *not* saved to the token's movement data, instead it is merely mutated locally.
+   */
+  interface State {
+    hasElevation: boolean;
+    previousElevation: number;
+  }
+
+  /**
+   * @remarks Fed into the template
+   */
+  interface WaypointContext {
+    action: string;
+    cssClass: string;
+    secret: boolean;
+    units: string;
+    uiScale: number;
+    position: {
+      x: number;
+      y: number;
+    };
+    distance: SegmentDistance;
+    cost: SegmentCost;
+    elevation: ElevationContext;
+  }
+
+  interface SegmentDistance {
+    total: string;
+    delta?: string;
+  }
+
+  interface SegmentCost {
+    total: string;
+    units: string;
+    delta?: string;
+  }
+
+  interface ElevationContext {
+    total: number;
+    icon: string;
+    hidden: boolean;
+    delta?: string;
+  }
+
+  interface WaypointStyle {
+    radius: number;
+    color?: PIXI.ColorSource;
+    alpha?: number;
+  }
+
+  interface SegmentStyle {
+    width: number;
+    color?: PIXI.ColorSource;
+    alpha?: number;
+  }
+
+  interface GridHighlightStyle {
+    color?: PIXI.ColorSource;
+    alpha?: number;
+    texture?: PIXI.Texture;
+    matrix?: PIXI.Matrix | null;
+  }
 }
 
 export default TokenRuler;

--- a/src/foundry/client/config.d.mts
+++ b/src/foundry/client/config.d.mts
@@ -3560,6 +3560,16 @@ declare global {
 
       interface _MovementActionConfig {
         /**
+         * The FontAwesome icon class.
+         */
+        icon: string;
+
+        /**
+         * An image filename. Takes precedence over the icon if both are supplied.
+         */
+        img: string;
+
+        /**
          * The number that is used to sort the movement actions / movement action configs.
          * Determines the order in the Token Config/HUD and of cycling.
          * @defaultValue `0`
@@ -3630,11 +3640,6 @@ declare global {
          * The label of the movement action.
          */
         label: string;
-
-        /**
-         * The icon of the movement action.
-         */
-        icon: string;
       }
     }
 

--- a/src/foundry/common/grid/_types.d.mts
+++ b/src/foundry/common/grid/_types.d.mts
@@ -31,15 +31,15 @@ type HexagonalGridCoordinates3D = HexagonalGrid.Coordinates3D;
 
 type GridSnappingBehavior = BaseGrid.SnappingBehavior;
 
-type GridMeasurePathWaypointData2D = unknown;
+type GridMeasurePathWaypointData2D = foundry.grid.BaseGrid.MeasurePathWaypoint2D;
 
-type GridMeasurePathWaypointData3D = unknown;
+type GridMeasurePathWaypointData3D = foundry.grid.BaseGrid.MeasurePathWaypoint3D;
 
-type GridMeasurePathResultWaypoint = unknown;
+type GridMeasurePathResultWaypoint = foundry.grid.BaseGrid.MeasurePathResultWaypoint;
 
-type GridMeasurePathResultSegment = unknown;
+type GridMeasurePathResultSegment = foundry.grid.BaseGrid.MeasurePathResultSegment;
 
-type GridMeasurePathResult = unknown;
+type GridMeasurePathResult = foundry.grid.BaseGrid.MeasurePathResult;
 
 type GridMeasurePathCostFunction2D = BaseGrid.MeasurePathCostFunction2D;
 

--- a/src/foundry/public/scripts/ktx2/basis_transcoder.d.mts
+++ b/src/foundry/public/scripts/ktx2/basis_transcoder.d.mts
@@ -1,6 +1,5 @@
 import type { BASIS as _BASIS } from "pixi-basis-ktx2";
 
 declare global {
-  // eslint-disable-next-line no-var
   var BASIS: _BASIS;
 }

--- a/src/foundry/public/scripts/ktx2/pixi-ktx2.min.d.mts
+++ b/src/foundry/public/scripts/ktx2/pixi-ktx2.min.d.mts
@@ -1,6 +1,5 @@
 import type * as _PixiBasisKTX2 from "pixi-basis-ktx2";
 
 declare global {
-  // eslint-disable-next-line no-var
   var PixiBasisKTX2: typeof _PixiBasisKTX2;
 }

--- a/src/types/augments/socket.io-client.d.mts
+++ b/src/types/augments/socket.io-client.d.mts
@@ -1,7 +1,6 @@
 import type * as _io from "socket.io-client";
 
 declare global {
-  // eslint-disable-next-line no-var
   var io: typeof _io & typeof _io.io & { connect: typeof _io.io };
   namespace io {
     type Socket = _io.Socket;

--- a/tests/foundry/client/canvas/placeables/tokens/ruler.test-d.ts
+++ b/tests/foundry/client/canvas/placeables/tokens/ruler.test-d.ts
@@ -1,4 +1,170 @@
 // import { expectTypeOf } from "vitest";
-// import { TokenRuler } from "#client/canvas/placeables/tokens/_module.mjs";
+import type { TokenRuler } from "#client/canvas/placeables/tokens/_module.mjs";
+import type { DeepReadonly } from "#utils";
 
-// TODO: new in v13
+/**
+ * Draw Steel implementation of the core token ruler
+ */
+class DrawSteelTokenRuler extends foundry.canvas.placeables.tokens.TokenRuler {
+  static override WAYPOINT_LABEL_TEMPLATE = "templates/hud/waypoint-label.hbs";
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Helper function called in `init` hook
+   * @internal
+   */
+  static applyDSMovementConfig() {
+    // Adjusting `Blink (Teleport)` to just be Teleport and maintain its use elsewhere
+    const teleport = { ...CONFIG.Token.movement.actions.blink, label: "TOKEN.MOVEMENT.ACTIONS.teleport.label" };
+    foundry.utils.mergeObject(
+      CONFIG.Token.movement.actions,
+      {
+        "-=blink": null,
+        teleport,
+        burrow: {
+          getCostFunction: (
+            _token: TokenDocument.Implementation,
+            _options: foundry.canvas.placeables.Token.MeasureMovementPathOptions,
+          ) => {
+            return (cost: number) => cost * 3;
+          },
+        },
+        climb: {
+          canSelect: (token: TokenDocument.Implementation | foundry.data.PrototypeToken) =>
+            // eslint-disable-next-line no-restricted-syntax
+            !(token instanceof TokenDocument) || !token.hasStatusEffect("prone"),
+          getCostFunction: (
+            _token: TokenDocument.Implementation,
+            _options: foundry.canvas.placeables.Token.MeasureMovementPathOptions,
+          ) => {
+            return (cost: number) => cost * 2;
+          },
+        },
+        crawl: {
+          canSelect: (token: TokenDocument.Implementation | foundry.data.PrototypeToken) =>
+            // eslint-disable-next-line no-restricted-syntax
+            token instanceof TokenDocument && token.hasStatusEffect("prone"),
+        },
+        fly: {
+          canSelect: (token: TokenDocument.Implementation | foundry.data.PrototypeToken) =>
+            // eslint-disable-next-line no-restricted-syntax
+            !(token instanceof TokenDocument) || !token.hasStatusEffect("prone"),
+        },
+        jump: {
+          canSelect: (token: TokenDocument.Implementation | foundry.data.PrototypeToken) =>
+            // eslint-disable-next-line no-restricted-syntax
+            !(token instanceof TokenDocument) || !token.hasStatusEffect("prone"),
+          // default for jump is cost * 2
+          getCostFunction: () => (cost: number) => cost,
+        },
+        swim: {
+          canSelect: (token: TokenDocument.Implementation | foundry.data.PrototypeToken) =>
+            // eslint-disable-next-line no-restricted-syntax
+            !(token instanceof TokenDocument) || !token.hasStatusEffect("prone"),
+          getCostFunction: (
+            _token: TokenDocument.Implementation,
+            _options: foundry.canvas.placeables.Token.MeasureMovementPathOptions,
+          ) => {
+            return (cost: number) => cost * 2;
+          },
+        },
+        walk: {
+          canSelect: (token: TokenDocument.Implementation | foundry.data.PrototypeToken) =>
+            // eslint-disable-next-line no-restricted-syntax
+            !(token instanceof TokenDocument) || !token.hasStatusEffect("prone"),
+        },
+      },
+      { performDeletions: true },
+    );
+  }
+
+  override _getWaypointLabelContext(
+    waypoint: TokenRuler.Waypoint,
+    state: DrawSteelTokenRuler.State,
+  ): DrawSteelTokenRuler.WaypointContext | void {
+    const context = super._getWaypointLabelContext(waypoint, state) as DrawSteelTokenRuler.WaypointContext | void;
+
+    if (!this.token.inCombat) return context;
+
+    state.segmentWaypoints ??= [];
+    state.segmentWaypoints.push(waypoint);
+
+    if (!context) return;
+
+    const _points = this.token.document.getCompleteMovementPath(state.segmentWaypoints);
+
+    const startedNear = state.endPointEnemies ?? new Set();
+    // Actual code has some Token Document methods to fetch relevant info
+    const endPointEnemies = new Set([]);
+    const passedBy = new Set([]).union(startedNear);
+    const delta = waypoint.actionConfig.teleport ? 0 : passedBy.difference(endPointEnemies).size;
+    const strikes = {
+      delta,
+      total: delta + (state.strikes?.total ?? 0),
+    };
+
+    state.endPointEnemies = endPointEnemies;
+    state.strikes = strikes;
+    state.segmentWaypoints = [waypoint];
+    context.strikes = strikes;
+
+    return context;
+  }
+
+  override _getSegmentStyle(waypoint: TokenRuler.Waypoint) {
+    const style = super._getSegmentStyle(waypoint);
+    this.#speedValueStyle(style, waypoint);
+    return style;
+  }
+
+  override _getGridHighlightStyle(waypoint: TokenRuler.Waypoint, offset: DeepReadonly<foundry.grid.BaseGrid.Offset3D>) {
+    const style = super._getGridHighlightStyle(waypoint, offset);
+    this.#speedValueStyle(style, waypoint);
+    return style;
+  }
+
+  /**
+   * Adjusts the grid or segment style based on the token's movement characteristics
+   * @param style    - The calculated style properties from the parent class
+   * @param waypoint - The waypoint being adjusted
+   */
+  #speedValueStyle(style: TokenRuler.SegmentStyle | TokenRuler.GridHighlightStyle, waypoint: TokenRuler.Waypoint) {
+    // color order
+    const colors = [0x33bc4e, 0xf1d836, 0xe72124] as const;
+
+    if (waypoint.actionConfig.teleport) {
+      // actual code calls a token document getter
+      const movementTypes = new Set(["strings"]);
+      if (!movementTypes.has("teleport")) return style;
+      const value = (foundry.utils.getProperty(this, "token.document.actor.system.movement.teleport") as number) ?? 0;
+      const index = waypoint.cost > value ? 2 : 0;
+      style.color = colors[index];
+    } else {
+      const value =
+        (foundry.utils.getProperty(this, "token.document.actor.system.movement.value") as number) ?? Infinity;
+      // Total cost, up to 1x is green, up to 2x is yellow, over that is red
+      const index = Math.clamp(Math.floor((waypoint.measurement.cost - 1) / value), 0, 2) as 0 | 2;
+      style.color = colors[index];
+    }
+  }
+}
+
+declare namespace DrawSteelTokenRuler {
+  interface Strikes {
+    delta: number;
+    total: number;
+  }
+
+  interface State extends TokenRuler.State {
+    segmentWaypoints: TokenRuler.Waypoint[];
+    endPointEnemies: Set<TokenDocument.Implementation>;
+    strikes: Strikes;
+  }
+
+  interface WaypointContext extends TokenRuler.WaypointContext {
+    strikes?: Strikes;
+  }
+}
+
+declare const _testRuler: DrawSteelTokenRuler;


### PR DESCRIPTION
Need attention on line 95 of the tests. I used the functioning Draw Steel Token Ruler to validate our types and was quite happy with how it worked out with fairly minimal casts (most annoying of them all of course is the `as const` cast).