### PR TITLE
Narrow argument types on select `Set` methods

### DIFF
--- a/src/foundry/common/primitives/set.d.mts
+++ b/src/foundry/common/primitives/set.d.mts
@@ -1,3 +1,5 @@
+import type { OverlapsWith } from "#utils";
+
 export {};
 
 declare global {
@@ -8,7 +10,7 @@ declare global {
      * @param other - Some other set to compare against
      * @returns Are the sets equal?
      */
-    equals(other: ReadonlySetLike<unknown>): boolean;
+    equals<const O>(other: Set<OverlapsWith<O, T>>): boolean;
 
     /**
      * Return the first value from the set.
@@ -22,7 +24,7 @@ declare global {
      * @returns Do the sets intersect?
      * @remarks Just returns {@linkcode Set.isDisjointFrom | !this.isDisjointFrom(other)}
      */
-    intersects(other: ReadonlySetLike<unknown>): boolean;
+    intersects<const O>(other: ReadonlySetLike<OverlapsWith<O, T>>): boolean;
 
     /**
      * Test whether this set is a subset of some other set.
@@ -31,7 +33,7 @@ declare global {
      * @returns Is the other set a subset of this one?
      * @deprecated "`Set#isSubset` is deprecated in favor of the native {@linkcode Set.isSubsetOf | Set#isSubsetOf}." (since v13, until v15)
      */
-    isSubset(other: ReadonlySetLike<unknown>): boolean;
+    isSubset<const O>(other: ReadonlySetLike<OverlapsWith<O, T>>): boolean;
 
     /**
      * Convert a set to a JSON object by mapping its contents to an array

--- a/tests/foundry/common/primitives/set.test-d.ts
+++ b/tests/foundry/common/primitives/set.test-d.ts
@@ -23,15 +23,13 @@ describe("Set Tests", () => {
     expectTypeOf(stringSet.equals(stringSet2)).toBeBoolean();
     expectTypeOf(stringUnionSet.equals(stringSet)).toBeBoolean();
     expectTypeOf(stringSet.equals(stringUnionSet)).toBeBoolean();
-    // This should be an error because a set cannot equal a set with an element type its does not overlap with, but
-    // due to OverlapsWith-based types breaking things, it is currently allowed
+    // @ts-expect-error A set cannot equal a set with an element type its does not overlap with
     stringSet.equals(numberSet);
 
     expectTypeOf(stringSet.intersects(stringSet2)).toBeBoolean();
     expectTypeOf(stringUnionSet.intersects(stringSet)).toBeBoolean();
     expectTypeOf(stringSet.intersects(stringUnionSet)).toBeBoolean();
-    // This should be an error because a set cannot intersect a set with an element type its does not overlap with, but
-    // due to OverlapsWith-based types breaking things, it is currently allowed
+    // @ts-expect-error A set cannot intersect a set with an element type its does not overlap with
     stringSet.intersects(numberSet);
   });
 
@@ -68,8 +66,7 @@ describe("Set Tests", () => {
     // Deprecated since v13, until v15
     // eslint-disable-next-line @typescript-eslint/no-deprecated
     expectTypeOf(stringSet.isSubset(stringSet2)).toBeBoolean();
-    // This should be an error because a set cannot be a subset of a set with an element type its does not overlap with, but
-    // due to OverlapsWith-based types breaking things, it is currently allowed
+    // @ts-expect-error A set cannot be a subset of a set with an element type its does not overlap with
     // eslint-disable-next-line @typescript-eslint/no-deprecated
     stringSet.isSubset(numberSet);
   });


### PR DESCRIPTION
Currently breaking variance, not sure how to restrict further without errors